### PR TITLE
fix(backend): 修正 GitHub App 客户端获取令牌的方式

### DIFF
--- a/backend/core/github_app.py
+++ b/backend/core/github_app.py
@@ -94,8 +94,8 @@ class GitHubAppClient:
     def get_app_client(self) -> Github:
         """获取App级别的GitHub客户端"""
         if self._app_client is None:
-            # 获取App的访问令牌
-            token = self.integration.get_access_token(settings.github_app_id)
+            # 使用 JWT token 访问 App 级别 API
+            token = self.integration.create_jwt()
             self._app_client = Github(login_or_token=token)
         return self._app_client
 


### PR DESCRIPTION
- 将获取 App 级别访问令牌的方式从 `get_access_token` 调整为 `create_jwt`
- 更新注释以准确反映使用 JWT token 访问 App 级别 API 的逻辑