### PR TITLE
fix(backend): 修复 ChromaDB 多条件过滤逻辑

### DIFF
--- a/backend/services/code_index_service.py
+++ b/backend/services/code_index_service.py
@@ -347,14 +347,21 @@ class CodeIndexService:
         if not query_embedding:
             return []
 
-        # 构建过滤条件
-        where_filters = {}
+        # 构建过滤条件（ChromaDB 多条件需使用 $and 运算符）
+        filters = []
         if language:
-            where_filters["language"] = language
+            filters.append({"language": language})
         if file_path:
-            where_filters["file_path"] = file_path
+            filters.append({"file_path": file_path})
         if pr_number is not None:
-            where_filters["pr_number"] = str(pr_number)
+            filters.append({"pr_number": str(pr_number)})
+
+        if len(filters) == 0:
+            where_filters = None
+        elif len(filters) == 1:
+            where_filters = filters[0]
+        else:
+            where_filters = {"$and": filters}
 
         # 执行检索
         results = await self.vector_store.search_code(


### PR DESCRIPTION
- 将过滤条件从字典拼接改为列表构建，适配 ChromaDB 的 $and 运算符要求
- 根据条件数量动态生成 where_filters：0 个条件设为 None，1 个条件直接使用，多个条件使用 $and 组合
- 确保语言、文件路径和 PR 编号的过滤功能正确执行