### PR TITLE
fix(config): 修复配置锁字典更新时的线程安全问题

### DIFF
--- a/backend/webui/routes/config.py
+++ b/backend/webui/routes/config.py
@@ -62,7 +62,8 @@ def _get_config_lock(path: str) -> asyncio.Lock:
         cleaned = {k: v for k, v in _config_locks.items() if v.locked()}
         if path not in cleaned:
             cleaned[path] = lock
-        _config_locks = cleaned
+        _config_locks.clear()
+        _config_locks.update(cleaned)
     return lock
 
 


### PR DESCRIPTION
- 修复 `_get_config_lock` 函数中更新 `_config_locks` 字典时的线程安全问题
- 使用 `clear()` 和 `update()` 替代直接赋值，避免并发场景下的数据竞争
- 确保在清理未锁定的锁时，字典更新操作的原子性