### PR TITLE
fix(backend): 修复行内评论跨hunk和路径解析失败问题

### DIFF
--- a/backend/core/github_app.py
+++ b/backend/core/github_app.py
@@ -601,32 +601,57 @@ class GitHubAppClient:
             if hasattr(e, "status") and hasattr(e, "data"):
                 logger.error(f"提交Review失败: GitHub API返回错误 (status={e.status})")
                 logger.error(f"响应数据: {e.data}")
+
+                is_resolvable_error = False
+
                 if isinstance(e.data, dict):
                     msg = e.data.get("message") or e.data.get("error", "未知错误")
                     logger.error(f"错误信息: {msg}")
 
-                    # 特别处理 422 错误（Path could not be resolved）
                     if e.status == 422:
                         errors = e.data.get("errors", [])
-                        if errors and "Path could not be resolved" in str(errors):
-                            logger.error("⚠️ 文件路径无法解析错误详情:")
-                            # 记录所有评论的路径，帮助定位问题
-                            if inline_comments:
-                                logger.error(
-                                    f"  尝试提交的 {len(inline_comments)} 条评论的路径:"
-                                )
-                                for i, comment in enumerate(inline_comments, 1):
-                                    file_path = comment.get("file_path")
-                                    line_number = comment.get("line_number")
-                                    start_line = comment.get("start_line")
-                                    if start_line:
-                                        logger.error(
-                                            f"    [{i}] {file_path}:{start_line}-{line_number}"
-                                        )
-                                    else:
-                                        logger.error(
-                                            f"    [{i}] {file_path}:{line_number}"
-                                        )
+                        errors_str = str(errors) if errors else ""
+
+                        if "Line could not be resolved" in errors_str or (
+                            "line" in errors_str.lower()
+                            and "could not" in errors_str.lower()
+                        ):
+                            is_resolvable_error = True
+                        if "Path could not be resolved" in errors_str:
+                            is_resolvable_error = True
+
+                        # 记录所有评论的路径，帮助定位问题
+                        if inline_comments:
+                            logger.error(
+                                f"  尝试提交的 {len(inline_comments)} 条评论的详情:"
+                            )
+                            for i, comment in enumerate(inline_comments, 1):
+                                file_path = comment.get("file_path")
+                                line_number = comment.get("line_number")
+                                start_line = comment.get("start_line")
+                                if start_line:
+                                    logger.error(
+                                        f"    [{i}] {file_path}:{start_line}-{line_number}"
+                                    )
+                                else:
+                                    logger.error(
+                                        f"    [{i}] {file_path}:{line_number}"
+                                    )
+
+                # 422 行号/路径无法解析时，降级为无行内评论的 Review
+                if is_resolvable_error and body and inline_comments:
+                    logger.warning(
+                        "422 行号/路径无法解析，尝试降级为无行内评论的 Review..."
+                    )
+                    try:
+                        pr.create_review(event=event, body=body, comments=[])
+                        logger.info(
+                            f"✅ 降级成功: 已提交无行内评论的 Review "
+                            f"({repo_owner}/{repo_name}#{pr_number})"
+                        )
+                        return True
+                    except Exception as fallback_error:
+                        logger.error(f"降级提交也失败: {fallback_error}")
             else:
                 logger.error(f"提交Review失败: {error_type}: {str(e)}")
 

--- a/backend/services/comment_service.py
+++ b/backend/services/comment_service.py
@@ -452,9 +452,50 @@ class CommentService:
                 )
                 continue
 
-            # 3. 更新文件路径为匹配后的路径
-            comment["file_path"] = matched_path
-            validated.append(comment)
+            # 3. 验证 start_line（多行评论的起始行）
+            start_line = comment.get("start_line")
+            if start_line is not None:
+                if start_line == line_number:
+                    # 单行评论不需要 start_line，移除避免 API 问题
+                    start_line = None
+                elif start_line not in allowed_lines:
+                    logger.warning(
+                        f"start_line {start_line} 不在 Diff 安全区内 "
+                        f"(文件: {matched_path})，降级为单行评论 (行号 {line_number})"
+                    )
+                    start_line = None
+                # start_line 和 line_number 必须在同一 hunk 内
+                elif (
+                    analysis.hunk_boundaries
+                    and matched_path in analysis.hunk_boundaries
+                ):
+                    same_hunk = False
+                    for hunk_start, hunk_end in analysis.hunk_boundaries[
+                        matched_path
+                    ]:
+                        if (
+                            hunk_start <= start_line <= hunk_end
+                            and hunk_start <= line_number <= hunk_end
+                        ):
+                            same_hunk = True
+                            break
+                    if not same_hunk:
+                        logger.warning(
+                            f"跨 hunk 多行评论: {matched_path}:{start_line}-{line_number}，"
+                            f"降级为单行评论 (行号 {line_number})"
+                        )
+                        start_line = None
+
+            # 4. 构建验证通过的评论副本（不修改原始数据）
+            validated_comment = {
+                "file_path": matched_path,
+                "line_number": line_number,
+                "body": comment.get("body", ""),
+                "severity": comment.get("severity", "suggestion"),
+            }
+            if start_line:
+                validated_comment["start_line"] = start_line
+            validated.append(validated_comment)
             logger.debug(f"✓ 验证通过: {matched_path}:{line_number}")
 
         return validated

--- a/backend/services/pr_analyzer.py
+++ b/backend/services/pr_analyzer.py
@@ -64,6 +64,10 @@ class PRAnalysis:
     # 格式：{"file_path.py": {10, 15, 20, 25}, "another.py": {5, 10}}
     changed_lines_map: Dict[str, set] = None
 
+    # Hunk 边界：每个文件的 hunk 行范围列表，用于检测跨 hunk 多行评论
+    # 格式：{"file.py": [(10, 20), (50, 65)], ...}
+    hunk_boundaries: Dict[str, List[Tuple[int, int]]] = None
+
     # 增量审查标记
     is_incremental: bool = False
 
@@ -184,8 +188,8 @@ class PRAnalyzer:
                     len(code_files), code_changes
                 )
 
-            # 提取 diff 安全区白名单
-            changed_lines_map = self._extract_changed_lines(code_files)
+            # 提取 diff 安全区白名单和 hunk 边界
+            changed_lines_map, hunk_boundaries = self._extract_changed_lines(code_files)
 
             analysis = PRAnalysis(
                 pr_id=pr_info["pr_id"],
@@ -202,6 +206,7 @@ class PRAnalyzer:
                 should_skip=should_skip,
                 skip_reason=skip_reason,
                 changed_lines_map=changed_lines_map,
+                hunk_boundaries=hunk_boundaries,
                 is_incremental=is_incremental,
                 new_commits=new_commits,
             )
@@ -218,21 +223,27 @@ class PRAnalyzer:
             logger.error(f"分析PR时出错: {e}", exc_info=True)
             raise
 
-    def _extract_changed_lines(self, code_files: List[PRFileInfo]) -> Dict[str, set]:
-        """从文件 patch 中提取变更的行号（Diff 安全区）
+    def _extract_changed_lines(
+        self, code_files: List[PRFileInfo]
+    ) -> Tuple[Dict[str, set], Dict[str, List[Tuple[int, int]]]]:
+        """从文件 patch 中提取变更的行号（Diff 安全区）和 hunk 边界
 
-        解析 unified diff 格式，提取所有变更行的行号。
-        这个白名单用于验证 AI 给出的行号是否在 diff 范围内。
+        解析 unified diff 格式，提取所有变更行的行号和每个 hunk 的行范围。
+        安全区白名单用于验证 AI 给出的行号是否在 diff 范围内，
+        hunk 边界用于检测跨 hunk 的多行评论（GitHub API 不允许）。
 
         Args:
             code_files: 代码文件列表
 
         Returns:
-            字典，key 为文件路径，value 为变更行号的集合
+            元组：(changed_lines, hunk_boundaries)
+            - changed_lines: 字典，key 为文件路径，value 为变更行号的集合
+            - hunk_boundaries: 字典，key 为文件路径，value 为 hunk (起始行, 结束行) 列表
         """
         import re
 
         changed_lines = {}
+        hunk_boundaries = {}
 
         for file_info in code_files:
             if not file_info.patch:
@@ -273,6 +284,7 @@ class PRAnalyzer:
                     )
 
                     current_line = new_start
+                    hunk_start = new_start
                     lines_in_hunk = 0
                     added_lines = 0
                     removed_lines = 0
@@ -320,6 +332,13 @@ class PRAnalyzer:
                     logger.info(
                         f"  ✓ Hunk #{hunk_count} 解析完成: +{added_lines} -{removed_lines} 行, 包含{context_lines}行上下文, PR后行号范围: {new_start}-{current_line - 1}"
                     )
+
+                    # 记录 hunk 边界
+                    hunk_end = current_line - 1
+                    if file_info.path not in hunk_boundaries:
+                        hunk_boundaries[file_info.path] = []
+                    hunk_boundaries[file_info.path].append((hunk_start, hunk_end))
+
                     continue
 
                 i += 1
@@ -334,7 +353,7 @@ class PRAnalyzer:
                 logger.warning(f"⚠️  文件 {file_info.path} 未提取到任何行号")
 
         logger.info(f"🎯 构建 Diff 安全区完成，覆盖 {len(changed_lines)} 个文件")
-        return changed_lines
+        return changed_lines, hunk_boundaries
 
     def _should_skip_review(
         self, code_file_count: int, code_changes: int, total_files: int

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -564,14 +564,39 @@ class ReviewWorker:
                         f"[{task_id}] 第 {attempt + 1} 次提交Review失败，1秒后重试..."
                     )
                     await asyncio.sleep(1)
+
+            # 最终兜底：带行内评论的 Review 提交失败时，尝试仅提交 Review Body
+            if not success and inline_comments:
+                logger.warning(
+                    f"[{task_id}] 带行内评论的Review提交失败，尝试仅提交Review Body..."
+                )
+                success = self.github_app.submit_review(
+                    repo_owner=pr_info["repo_owner"],
+                    repo_name=pr_info["repo_name"],
+                    pr_number=pr_info["pr_number"],
+                    event=decision.value.upper(),
+                    body=review_body,
+                    bot_username=bot_username,
+                    enable_idempotency_check=enable_idempotency,
+                )
+                if success:
+                    logger.info(
+                        f"[{task_id}] ✅ 降级成功: 已提交无行内评论的Review"
+                    )
                 else:
                     logger.error(f"[{task_id}] 重试 {max_retries} 次后仍然失败")
 
             if success:
-                logger.info(
-                    f"[{task_id}] ✅ 成功提交Review到GitHub: {decision.value} "
-                    f"(含{len(inline_comments)}条行内评论)"
-                )
+                if inline_comments:
+                    logger.info(
+                        f"[{task_id}] ✅ 成功提交Review到GitHub: {decision.value} "
+                        f"(含{len(inline_comments)}条行内评论)"
+                    )
+                else:
+                    logger.info(
+                        f"[{task_id}] ✅ 成功提交Review到GitHub: {decision.value} "
+                        f"(无行内评论)"
+                    )
             else:
                 logger.warning(
                     f"[{task_id}] ⚠️ 提交Review到GitHub失败，但已保存到数据库"


### PR DESCRIPTION
- 新增 hunk 边界检测，避免跨 hunk 多行评论导致 GitHub API 422 错误
- 优化评论验证逻辑，自动降级无效的多行评论为单行评论
- 增强错误处理，当行号/路径无法解析时自动降级为无行内评论的 Review
- 更新 PRAnalysis 数据结构，支持 hunk 边界信息存储