### PR TITLE
fix(backend): 修正配置参数类型转换，确保返回整数类型

### DIFF
--- a/backend/services/ai_reviewer/tools/file_tool.py
+++ b/backend/services/ai_reviewer/tools/file_tool.py
@@ -25,14 +25,16 @@ class FileToolHandler:
     """
 
     def _get_tool_limits(self) -> dict:
-        """从策略配置读取工具限制参数"""
+        """从策略配置读取工具限制参数，确保返回整数类型"""
         ce = get_strategy_config().get_context_enhancement_config()
         return {
-            "max_file_lines": ce.get("max_file_lines", MAX_FILE_LINES),
-            "default_context_lines": ce.get(
-                "default_context_lines", DEFAULT_CONTEXT_LINES
+            "max_file_lines": int(ce.get("max_file_lines", MAX_FILE_LINES)),
+            "default_context_lines": int(
+                ce.get("default_context_lines", DEFAULT_CONTEXT_LINES)
             ),
-            "max_context_lines": ce.get("max_context_lines", MAX_CONTEXT_LINES),
+            "max_context_lines": int(
+                ce.get("max_context_lines", MAX_CONTEXT_LINES)
+            ),
         }
 
     async def read_file(

--- a/backend/webui/routes/config.py
+++ b/backend/webui/routes/config.py
@@ -192,9 +192,9 @@ async def save_strategies_section(
                     "max_tool_iterations": int(form.get("max_tool_iterations", 20)),
                     "max_file_size": int(form.get("max_file_size", 200000)),
                     "enable_ai_tools_in_batch": form.get("enable_ai_tools_in_batch") is not None,
-                    "max_file_lines": int(form.get("max_file_lines", 500)),
-                    "default_context_lines": int(form.get("default_context_lines", 20)),
-                    "max_context_lines": int(form.get("max_context_lines", 200)),
+                    "max_file_lines": int(float(form.get("max_file_lines", 500))),
+                    "default_context_lines": int(float(form.get("default_context_lines", 20))),
+                    "max_context_lines": int(float(form.get("max_context_lines", 200))),
                 }
 
             elif section == "review_policy":


### PR DESCRIPTION
- 在 FileToolHandler._get_tool_limits 方法中，将从策略配置读取的参数显式转换为整数类型，避免潜在类型错误
- 在 WebUI 配置保存逻辑中，对 max_file_lines、default_context_lines 和 max_context_lines 参数增加 float 转换后再转 int，防止表单输入为浮点数时导致类型异常