### PR TITLE
fix(webhook): 优化 /analyze 命令的处理逻辑，仅限 Issue 使用

### DIFF
--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -249,19 +249,16 @@ async def handle_issue_comment_event(payload: Dict[str, Any]) -> JSONResponse:
             # 检查 /revoke 命令
             if re.match(r"^/revoke(\s|$)", comment_body):
                 return await handle_revoke_command(payload)
+            # 检查 /analyze 命令（仅限 Issue）
+            if re.match(r"^/analyze(\s|$)", comment_body):
+                issue = payload.get("issue", {})
+                if not issue.get("pull_request"):
+                    return await handle_issue_analyze_command(payload)
+                return JSONResponse(
+                    content={"status": "ignored", "reason": "/analyze only for issues"}
+                )
             return JSONResponse(
                 content={"status": "ignored", "reason": "not a review command"}
-            )
-
-        # 检查是否为PR评论（排除普通Issue）
-        issue = payload.get("issue", {})
-        if not issue.get("pull_request"):
-            # 非 PR 评论：检测 /analyze 命令
-            comment_body_check = payload.get("comment", {}).get("body", "").strip()
-            if re.match(r"^/analyze(\s|$)", comment_body_check):
-                return await handle_issue_analyze_command(payload)
-            return JSONResponse(
-                content={"status": "ignored", "reason": "not a recognized command"}
             )
 
         # 提取PR信息

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -244,6 +244,9 @@ async def handle_issue_comment_event(payload: Dict[str, Any]) -> JSONResponse:
         # 提取评论内容
         comment_body = payload.get("comment", {}).get("body", "").strip()
 
+        # 提前获取 issue 信息，供命令分发使用
+        issue = payload.get("issue", {})
+
         # 检查是否为 /full-review 指令（精确匹配，避免误匹配 /full-review-extra 等）
         if not re.match(r"^/full-review(\s|$)", comment_body):
             # 检查 /revoke 命令
@@ -251,11 +254,10 @@ async def handle_issue_comment_event(payload: Dict[str, Any]) -> JSONResponse:
                 return await handle_revoke_command(payload)
             # 检查 /analyze 命令（仅限 Issue）
             if re.match(r"^/analyze(\s|$)", comment_body):
-                issue = payload.get("issue", {})
                 if not issue.get("pull_request"):
                     return await handle_issue_analyze_command(payload)
                 return JSONResponse(
-                    content={"status": "ignored", "reason": "/analyze only for issues"}
+                    content={"status": "ignored", "reason": "/analyze 仅适用于 Issue"}
                 )
             return JSONResponse(
                 content={"status": "ignored", "reason": "not a review command"}


### PR DESCRIPTION
- 将 /analyze 命令的检查逻辑移至 /revoke 命令检查之后，统一在 PR 评论处理分支中进行
- 添加条件判断，确保 /analyze 仅对 Issue 生效，对 PR 评论返回忽略状态
- 删除原有的独立非 PR 评论处理分支，简化代码结构
- 提高代码可读性和维护性，避免重复的命令检查逻辑





<!-- sakura-ai-issue-links-start -->

Resolves #148

<!-- sakura-ai-issue-links-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 进一步优化了 webhook 中 `/analyze` 命令的处理逻辑，将其严格限制为仅适用于 Issue 场景，并提前获取 issue 信息以提升处理效率。共修改 1 个文件，代码变更 +4/-2。

### 主要改动列表
- **Bug 修复**：调整 `/analyze` 命令的处理条件，确保仅在 Issue 相关事件中触发，避免在其他场景（如 Pull Request）中误执行。
- **代码优化**：简化 webhook 处理逻辑，提前获取 issue 信息，减少冗余代码，提升可读性和维护性。

### 影响范围
- 仅影响后端 webhook 模块（`backend/api/webhook.py`），涉及 Issue 相关的自动化分析功能。
- 无外部接口或数据库变更，对现有功能无负面影响。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    webhook[webhook.py] --> github_app[github_app]
    webhook --> review_worker[review_worker]
    webhook --> telegram_service[telegram_service]
    webhook --> notifications[notifications]
    webhook --> config[config]
```

<!-- sakura-ai-depgraph-end -->