### PR TITLE
feat(sakura): 支持已有PR分支复用和准备阶段文件收集

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-2.8.4-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.8.5-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-2.8.4-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.8.5-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -116,6 +116,28 @@ async def handle_pull_request_event(payload: Dict[str, Any]) -> JSONResponse:
             logger.info(f"忽略PR动作: {action}")
             return JSONResponse(content={"status": "ignored", "action": action})
 
+        # 过滤 Bot 自身创建的 PR（如 sakura-memory 系统创建的 PR）
+        bot_username = settings.bot_username
+        sender = pr_info.get("sender", "")
+        author = pr_info.get("author", "")
+
+        if bot_username and (sender == bot_username or author == bot_username):
+            logger.info(
+                f"跳过 Bot 自身创建的 PR: {pr_info['repo_full_name']}#{pr_info['pr_number']}"
+            )
+            return JSONResponse(
+                content={"status": "ignored", "reason": "bot self-created PR"}
+            )
+
+        # 过滤 sakura-memory 分支 PR（兜底过滤）
+        if pr_info.get("branch", "").startswith("sakura-memory/"):
+            logger.info(
+                f"跳过 sakura-memory 分支 PR: {pr_info['repo_full_name']}#{pr_info['pr_number']}"
+            )
+            return JSONResponse(
+                content={"status": "ignored", "reason": "sakura-memory branch PR"}
+            )
+
         # 检查PR状态
         if pr_info.get("merged"):
             logger.info(

--- a/backend/core/github_app.py
+++ b/backend/core/github_app.py
@@ -1142,6 +1142,7 @@ def extract_pr_info_from_webhook(payload: Dict[str, Any]) -> Optional[Dict[str, 
             "state": pull_request["state"],
             "draft": pull_request.get("draft", False),
             "merged": pull_request.get("merged", False),
+            "sender": payload.get("sender", {}).get("login", ""),
             "before": payload.get("before"),
             "after": payload.get("after"),
         }

--- a/backend/main.py
+++ b/backend/main.py
@@ -176,7 +176,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Sakura AI Reviewer",
     description="GitHub AI代码审查机器人",
-    version="2.8.4",
+    version="2.8.5",
     lifespan=lifespan,
 )
 
@@ -217,7 +217,7 @@ async def root():
     """根路径"""
     return {
         "service": "Sakura AI Reviewer",
-        "version": "2.8.4",
+        "version": "2.8.5",
         "status": "running",
         "docs": "/docs",
     }

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -125,6 +125,8 @@ class GitHubWriteService:
         self, repo, files: dict, message: str, branch: str, author: InputGitAuthor,
     ) -> str:
         """提交文件到指定分支（不创建 PR）/ Commit files to an existing branch"""
+        if not files:
+            raise ValueError("files must not be empty")
 
         def _sync() -> str:
             last_sha = None

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -23,7 +23,7 @@ class GitHubWriteService:
     """GitHub 文件写入服务 / GitHub file write service"""
 
     DEFAULT_AUTHOR_NAME = "Sakura AI Reviewer"
-    DEFAULT_AUTHOR_EMAIL = "Sakura520222@outlook.com"
+    DEFAULT_AUTHOR_EMAIL = "Sakura520222@163.com"
     SAKURA_BRANCH_PREFIX = "sakura-memory"
 
     def __init__(self):
@@ -121,11 +121,58 @@ class GitHubWriteService:
         logger.info("Committed {} -> {}", path, sha[:8])
         return sha
 
+    async def _commit_to_branch(
+        self, repo, files: dict, message: str, branch: str, author: InputGitAuthor,
+    ) -> str:
+        """提交文件到指定分支（不创建 PR）/ Commit files to an existing branch"""
+
+        def _sync() -> str:
+            last_sha = None
+            for path, content in files.items():
+                try:
+                    existing = repo.get_contents(path, ref=branch)
+                    if isinstance(existing, list):
+                        raise ValueError(f"Path {path} is a directory")
+                    result = repo.update_file(
+                        path=path, message=message, content=content,
+                        sha=existing.sha, branch=branch, author=author,
+                    )
+                except UnknownObjectException:
+                    result = repo.create_file(
+                        path=path, message=message, content=content,
+                        branch=branch, author=author,
+                    )
+                commit_obj = result.get("commit") if isinstance(result, dict) else None
+                if commit_obj:
+                    last_sha = commit_obj.sha
+            return last_sha or ""
+
+        sha = await asyncio.to_thread(_sync)
+        logger.info(
+            "Appended {} file(s) to {}:{} -> {}",
+            len(files), repo.full_name, branch,
+            sha[:8] if sha else "unknown",
+        )
+        return sha
+
     async def _commit_via_pr(
         self, repo, files: dict, message: str, base_branch: str, author: InputGitAuthor,
     ) -> str:
         """通过创建分支 + PR + 尝试合并来提交文件 / Commit via branch + PR + auto-merge"""
 
+        # 查找已有未合并分支 / Check for existing open sakura PR branch
+        existing_branch = await self._find_open_sakura_branch(repo)
+
+        if existing_branch:
+            logger.info(
+                "Found existing open branch {} for {}, appending commits",
+                existing_branch, repo.full_name,
+            )
+            return await self._commit_to_branch(
+                repo, files, message, existing_branch, author,
+            )
+
+        # 无已有分支 → 创建新分支 + PR / No existing branch → create new
         timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
         new_branch = f"{self.SAKURA_BRANCH_PREFIX}/{timestamp}"
 
@@ -262,6 +309,30 @@ class GitHubWriteService:
                 repo.full_name, e,
             )
             return "main"
+
+    async def _find_open_sakura_branch(self, repo) -> Optional[str]:
+        """查找已有的未合并 sakura 分支 / Find existing open sakura PR branch"""
+
+        def _sync() -> Optional[str]:
+            pulls = repo.get_pulls(state="open")
+            for pr in pulls:
+                if pr.head.ref.startswith(f"{self.SAKURA_BRANCH_PREFIX}/"):
+                    return pr.head.ref
+            return None
+
+        try:
+            return await asyncio.to_thread(_sync)
+        except Exception as e:
+            logger.debug("Failed to search open PRs: {}", e)
+            return None
+
+    async def get_sakura_branch(self, repo) -> Optional[str]:
+        """获取当前未合并的 sakura 分支名（供读取用）
+
+        Get the open sakura branch name for reading files before merge.
+        Returns None if no open sakura PR exists (files are on main).
+        """
+        return await self._find_open_sakura_branch(repo)
 
 
 # 模块级单例访问 / Module-level singleton accessor

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -145,6 +145,11 @@ class GitHubWriteService:
                 commit_obj = result.get("commit") if isinstance(result, dict) else None
                 if commit_obj:
                     last_sha = commit_obj.sha
+                else:
+                    logger.warning(
+                        "create_file/update_file returned no commit for {} on {}",
+                        path, branch,
+                    )
             return last_sha or ""
 
         sha = await asyncio.to_thread(_sync)
@@ -161,9 +166,10 @@ class GitHubWriteService:
         """通过创建分支 + PR + 尝试合并来提交文件 / Commit via branch + PR + auto-merge"""
 
         # 查找已有未合并分支 / Check for existing open sakura PR branch
-        existing_branch = await self._find_open_sakura_branch(repo)
+        found = await self._find_open_sakura_branch(repo, base_branch=base_branch)
 
-        if existing_branch:
+        if found:
+            existing_branch, _ = found
             logger.info(
                 "Found existing open branch {} for {}, appending commits",
                 existing_branch, repo.full_name,
@@ -310,14 +316,27 @@ class GitHubWriteService:
             )
             return "main"
 
-    async def _find_open_sakura_branch(self, repo) -> Optional[str]:
-        """查找已有的未合并 sakura 分支 / Find existing open sakura PR branch"""
+    async def _find_open_sakura_branch(
+        self, repo, base_branch: Optional[str] = None,
+    ) -> Optional[tuple]:
+        """查找已有的未合并 sakura 分支 / Find existing open sakura PR branch
 
-        def _sync() -> Optional[str]:
+        Returns:
+            (head_ref, base_ref) 元组，未找到时返回 None
+        """
+
+        def _sync() -> Optional[tuple]:
             pulls = repo.get_pulls(state="open")
             for pr in pulls:
                 if pr.head.ref.startswith(f"{self.SAKURA_BRANCH_PREFIX}/"):
-                    return pr.head.ref
+                    # 校验 base 分支一致性 / Verify base branch matches
+                    if base_branch and pr.base.ref != base_branch:
+                        logger.warning(
+                            "Open sakura PR #{} targets {} but expected {}, skipping",
+                            pr.number, pr.base.ref, base_branch,
+                        )
+                        continue
+                    return (pr.head.ref, pr.base.ref)
             return None
 
         try:
@@ -332,7 +351,8 @@ class GitHubWriteService:
         Get the open sakura branch name for reading files before merge.
         Returns None if no open sakura PR exists (files are on main).
         """
-        return await self._find_open_sakura_branch(repo)
+        found = await self._find_open_sakura_branch(repo)
+        return found[0] if found else None
 
 
 # 模块级单例访问 / Module-level singleton accessor

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -143,13 +143,11 @@ class GitHubWriteService:
                         branch=branch, author=author,
                     )
                 commit_obj = result.get("commit") if isinstance(result, dict) else None
-                if commit_obj:
-                    last_sha = commit_obj.sha
-                else:
-                    logger.warning(
-                        "create_file/update_file returned no commit for {} on {}",
-                        path, branch,
+                if commit_obj is None:
+                    raise RuntimeError(
+                        f"create_file/update_file returned no commit for {path}"
                     )
+                last_sha = commit_obj.sha
             return last_sha or ""
 
         sha = await asyncio.to_thread(_sync)
@@ -326,6 +324,7 @@ class GitHubWriteService:
         """
 
         def _sync() -> Optional[tuple]:
+            # NOTE: get_pulls 默认只返回前 30 条，超 30 个 open PR 时可能遗漏
             pulls = repo.get_pulls(state="open")
             for pr in pulls:
                 if pr.head.ref.startswith(f"{self.SAKURA_BRANCH_PREFIX}/"):

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -23,7 +23,7 @@ class GitHubWriteService:
     """GitHub 文件写入服务 / GitHub file write service"""
 
     DEFAULT_AUTHOR_NAME = "Sakura AI Reviewer"
-    DEFAULT_AUTHOR_EMAIL = "Sakura520222@163.com"
+    DEFAULT_AUTHOR_EMAIL = "sakura@firefly520.top"
     SAKURA_BRANCH_PREFIX = "sakura-memory"
 
     def __init__(self):

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -148,7 +148,7 @@ class GitHubWriteService:
                         f"create_file/update_file returned no commit for {path}"
                     )
                 last_sha = commit_obj.sha
-            return last_sha or ""
+            return last_sha
 
         sha = await asyncio.to_thread(_sync)
         logger.info(

--- a/backend/services/sakura_memory_service.py
+++ b/backend/services/sakura_memory_service.py
@@ -261,7 +261,9 @@ class SakuraMemoryService:
                     setattr(state, key, value)
                 await session.commit()
 
-    async def initialize(self, repo, repo_full_name: str) -> None:
+    async def initialize(
+        self, repo, repo_full_name: str, prepare_only: bool = False,
+    ) -> Optional[dict]:
         """初始化 .sakura/ 目录 / Initialize .sakura/ directory
 
         为新仓库自动创建 .sakura/ 目录，包含 SAKURA.md 和 memory.md。
@@ -270,16 +272,20 @@ class SakuraMemoryService:
         Args:
             repo: PyGithub Repository 对象
             repo_full_name: 仓库完整名称 (owner/repo)
+            prepare_only: 只收集文件不提交，返回文件字典供调用方合并提交
+
+        Returns:
+            prepare_only=True 时返回文件字典，否则返回 None
         """
         # 检查是否已初始化 / Check if already initialized
         state = await self._get_or_create_state(repo_full_name)
         if state.is_initialized:
-            return
+            return {} if prepare_only else None
 
         config = self._get_config()
         init_config = config.get("initialization", {})
         if not init_config.get("auto_init", True):
-            return
+            return {} if prepare_only else None
 
         try:
             # 检查核心文件是否已存在 / Check if core files already exist
@@ -291,7 +297,7 @@ class SakuraMemoryService:
                     ".sakura/ 已初始化 (SAKURA.md={}, memory.md={}), 跳过: {}",
                     has_sakura_md, has_memory_md, repo_full_name,
                 )
-                return
+                return {} if prepare_only else None
 
             # 收集仓库信息 / Collect repo info
             logger.info(f"[sakura] 步骤1: 收集仓库信息 {repo_full_name}")
@@ -323,13 +329,20 @@ class SakuraMemoryService:
 
             if not sakura_md:
                 logger.warning(f"LLM 返回空内容，跳过初始化: {repo_full_name}")
-                return
+                return {} if prepare_only else None
 
             # 创建初始文件 / Create initial files
             files = {
                 ".sakura/SAKURA.md": sakura_md,
                 ".sakura/memory.md": "# 项目记忆\n\n（首次初始化，暂无记忆）\n",
             }
+
+            if prepare_only:
+                logger.info(
+                    "[sakura] prepare_only: {} init files for {}",
+                    len(files), repo_full_name,
+                )
+                return files
 
             commit_msg = init_config.get(
                 "init_commit_message",
@@ -386,12 +399,19 @@ class SakuraMemoryService:
         try:
             # 确保已初始化 / Ensure initialized
             state = await self._get_or_create_state(repo_full_name)
-            if not state.is_initialized:
-                await self.initialize(repo, repo_full_name)
+            init_files = {}
+            needs_init = not state.is_initialized
+            if needs_init:
+                init_files = await self.initialize(
+                    repo, repo_full_name, prepare_only=True,
+                ) or {}
 
-            # 读取当前 memory.md / Read current memory.md
+            # 从 PR 分支或 main 读取 memory.md / Read memory.md from PR branch or main
+            sakura_ref = await self.write_service.get_sakura_branch(repo)
             current_memory = (
-                await self.write_service.read_file(repo, ".sakura/memory.md") or ""
+                await self.write_service.read_file(
+                    repo, ".sakura/memory.md", ref=sakura_ref,
+                ) or ""
             )
 
             # 提取增量审查上下文 / Extract incremental review context
@@ -497,15 +517,28 @@ class SakuraMemoryService:
             # 提交反思文件 / Commit reflection file
             files = {reflection_path: reflection_content}
             commit_msg = f"chore(sakura): add reflection for PR#{pr_number}"
+            if init_files:
+                files.update(init_files)
+                commit_msg = (
+                    f"chore(sakura): initialize .sakura/ and add reflection for PR#{pr_number}"
+                )
+                logger.info(
+                    "[sakura] combining init ({}) + reflection into single commit for {}",
+                    len(init_files), repo_full_name,
+                )
             await self.write_service.commit_files(repo, files, commit_msg)
 
-            # 更新反思计数 / Update reflection count
+            # 更新状态 / Update state
+            state_updates = {"reflection_count": state.reflection_count + 1}
+            if needs_init:
+                state_updates["is_initialized"] = True
+            await self._update_state(repo_full_name, **state_updates)
             new_count = state.reflection_count + 1
-            await self._update_state(repo_full_name, reflection_count=new_count)
 
             logger.info(
-                "已写入反思: {} PR#{} [{}] (第{}次反思)",
+                "已写入反思: {} PR#{} [{}] (第{}次反思{})",
                 repo_full_name, pr_number, review_type, new_count,
+                ", 初始化完成" if needs_init else "",
             )
 
             # 检查是否需要合并 / Check if consolidation is needed
@@ -556,8 +589,9 @@ class SakuraMemoryService:
             )
 
             # 读取最近的反思 / Read recent reflections
+            sakura_ref = await self.write_service.get_sakura_branch(repo)
             reflections = await self._read_recent_reflections(
-                repo, consolidation_config.get("interval", 5)
+                repo, consolidation_config.get("interval", 5), ref=sakura_ref,
             )
             if not reflections:
                 logger.warning("[consolidate] 未找到反思文件: {}", repo_full_name)
@@ -566,10 +600,14 @@ class SakuraMemoryService:
 
             # 读取当前文件 / Read current files
             current_sakura = (
-                await self.write_service.read_file(repo, ".sakura/SAKURA.md") or ""
+                await self.write_service.read_file(
+                    repo, ".sakura/SAKURA.md", ref=sakura_ref,
+                ) or ""
             )
             current_memory = (
-                await self.write_service.read_file(repo, ".sakura/memory.md") or ""
+                await self.write_service.read_file(
+                    repo, ".sakura/memory.md", ref=sakura_ref,
+                ) or ""
             )
             logger.info(
                 "[consolidate] 当前文件: SAKURA.md={}字, memory.md={}字",
@@ -688,11 +726,12 @@ class SakuraMemoryService:
             if not state.is_initialized:
                 return {}
 
+            sakura_ref = await self.write_service.get_sakura_branch(repo)
             sakura_md = await self.write_service.read_file(
-                repo, ".sakura/SAKURA.md"
+                repo, ".sakura/SAKURA.md", ref=sakura_ref,
             )
             memory_md = await self.write_service.read_file(
-                repo, ".sakura/memory.md"
+                repo, ".sakura/memory.md", ref=sakura_ref,
             )
 
             result = {}
@@ -745,7 +784,9 @@ class SakuraMemoryService:
             )
         return "\n".join(lines)
 
-    async def _read_recent_reflections(self, repo, count: int) -> str:
+    async def _read_recent_reflections(
+        self, repo, count: int, ref: Optional[str] = None,
+    ) -> str:
         """读取最近的反思文件 / Read recent reflection files
 
         从 .sakura/memory/ 目录读取最近的反思文件并合并为文本。
@@ -754,13 +795,14 @@ class SakuraMemoryService:
         Args:
             repo: PyGithub Repository 对象
             count: 要读取的文件数量
+            ref: 分支引用，默认 HEAD（main）
 
         Returns:
             合并后的反思内容字符串
         """
         try:
             contents = await asyncio.to_thread(
-                lambda: repo.get_contents(".sakura/memory")
+                lambda: repo.get_contents(".sakura/memory", ref=ref or "HEAD")
             )
             if not contents:
                 return ""

--- a/backend/webui/routes/auth.py
+++ b/backend/webui/routes/auth.py
@@ -35,7 +35,7 @@ def _get_telegram_deep_link() -> str | None:
     return None
 
 
-APP_VERSION = "2.8.4"
+APP_VERSION = "2.8.5"
 
 _OAUTH_STATE_TTL = 600  # state 有效期 10 分钟
 _OAUTH_STATE_KEY_PREFIX = "oauth:state:"

--- a/docker/mysql-init/init.sql
+++ b/docker/mysql-init/init.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS review_queue (
 
 -- 插入默认配置
 INSERT IGNORE INTO app_config (key_name, key_value, description) VALUES
-('app_version', '2.8.4', '应用版本号'),
+('app_version', '2.8.5', '应用版本号'),
 ('max_concurrent_reviews', '5', '最大并发审查数量'),
 ('review_timeout_seconds', '300', '审查超时时间（秒）'),
 ('enable_auto_review', 'true', '是否启用自动审查'),

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -2322,7 +2322,7 @@ Issue 分析详情。
   "success": true,
   "message": "ok",
   "data": {
-    "version": "2.8.4",
+    "version": "2.8.5",
     "build_date": "2026-04-17"
   }
 }


### PR DESCRIPTION
- 修改 github_write_service.py 默认邮箱地址为 Sakura520222@163.com
- 新增 _commit_to_branch 方法，支持向现有分支提交文件
- 重构 _commit_via_pr 逻辑，优先查找已有未合并的 sakura 分支并复用
- 新增 _find_open_sakura_branch 方法，遍历开放PR获取分支名
- 新增 get_sakura_branch 公开方法，供外部读取未合并分支名
- 修改 sakura_memory_service.py initialize 方法，增加 prepare_only 参数控制是否仅返回文件字典
- initialize 方法在 prepare_only 模式下返回文件字典，否则返回 None
- adjust_workflow 方法调用 initialize 的 prepare_only 模式收集初始文件
- 使用 get_sakura_branch 获取分支引用，从 PR 分支读取 memory.md 替代默认读取 main 分支



<!-- sakura-ai-issue-links-start -->

Resolves #189
Resolves #201
Resolves #200

<!-- sakura-ai-issue-links-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

## PR 变更总结（完整版）

**变更概览**  
为 Sakura 服务新增 **PR 分支复用**、**准备阶段文件收集**及 **PR 事件过滤**能力，并修复 GitHub Write 服务的多项缺陷，同时更新版本号至 2.8.5。共修改 10 个文件，代码变更 **+185/-28**。

**主要改动**  
1. **webhook.py**  
   - 新增 PR 事件过滤逻辑，跳过 Bot 自建 PR 和 `sakura-memory` 分支 PR

2. **github_write_service.py**  
   - 支持复用已存在的 PR 分支，避免重复创建  
   - 修复 commit 对象缺失、返回值为空的问题  
   - 增强分支查找逻辑和异常处理

3. **sakura_memory_service.py**  
   - 准备阶段新增文件收集功能  
   - 优化内存数据处理流程

4. **版本与配置更新**  
   - 版本号升级至 2.8.5（`main.py`、`auth.py`、`init.sql`）  
   - `github_app.py` 辅助配置调整

**影响范围**  
- **Webhook 处理**：有效过滤自触发 PR，避免循环调用  
- **PR 创建**：提升分支复用效率，确保返回值完整可靠  
- **准备阶段**：具备文件收集能力，为下游提供完整上下文  
- **建议测试**：分支复用、PR 过滤规则、边界条件及返回值解析

<!-- sakura-ai-summary-end -->