### PR TITLE
Fix #219: SiliconFlow Rerank API 307 redirect from trailing slash

### DIFF
--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -296,9 +296,9 @@ class RerankerService:
             # 提取文档内容
             texts = [doc["content"] for doc in docs]
 
-            # 调用 Rerank API
+            # 调用 Rerank API (路径留空，避免与 base_url 拼接后产生尾部斜杠触发 307 重定向)
             response = await self.client.post(
-                "/",
+                "",
                 json={
                     "model": settings.rerank_model,
                     "query": query,


### PR DESCRIPTION
## Problem
SiliconFlow Rerank API fails due to trailing slash causing 307 redirect.

Base URL `.../v1/rerank` + path `/` = `.../v1/rerank/` which triggers 307.

## Fix
Changed request path from `/` to `""` to prevent trailing slash.

## Changes
- `backend/services/embedding_service.py` line 301

Fixes #219

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**  
修复 SiliconFlow Rerank API 因请求 URL 末尾斜杠导致 307 重定向的问题（#219），移除多余斜杠以使请求直接到达目标端点。

**主要改动列表**  
- **backend/services/embedding_service.py**  
  - 修改 SiliconFlow Rerank API 请求地址，将末端路径从 `.../rerank/` 改为 `.../rerank`（共 2 处），消除 307 重定向。

**影响范围**  
仅影响使用 SiliconFlow 重排序服务的调用逻辑，修正后请求将避免额外的 HTTP 重定向，提升响应速度并减少不必要的网络开销。对核心嵌入功能无影响。

<!-- sakura-ai-summary-end -->