### PR TITLE
fix(embedding_service): fix SiliconFlow Rerank API 307 redirect caused by trailing slash

### DIFF
--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -221,7 +221,7 @@ class RerankerService:
             if self.provider == "siliconflow":
                 # SiliconFlow Rerank API (使用 httpx)
                 self.client = httpx.AsyncClient(
-                    base_url=settings.rerank_base_url,
+                    base_url=settings.rerank_base_url.rstrip("/"),
                     headers={"Authorization": f"Bearer {settings.rerank_api_key}"},
                     timeout=30.0,
                 )
@@ -298,7 +298,7 @@ class RerankerService:
 
             # 调用 Rerank API
             response = await self.client.post(
-                "/",
+                "",
                 json={
                     "model": settings.rerank_model,
                     "query": query,


### PR DESCRIPTION
## Problem

Fixes #219

The SiliconFlow Rerank API request fails with a `307 Temporary Redirect` because the request URL contains a trailing slash:

```
Redirect response '307 Temporary Redirect' for url 'https://api.siliconflow.cn/v1/rerank/'
Redirect location: '/v1/rerank'
```

The issue occurs because:
1. `httpx.AsyncClient` is initialized with `base_url=settings.rerank_base_url`
2. The request is made with `client.post("/")` which resolves against the base URL
3. Depending on configuration or httpx behavior, this can produce either:
   - A request to the wrong endpoint (`https://api.siliconflow.cn/`)
   - Or a request with a trailing slash (`https://api.siliconflow.cn/v1/rerank/`)
4. The API returns a 307 redirect to `/v1/rerank` (without trailing slash)
5. httpx does **not** automatically follow 307 redirects for POST requests (RFC 7231 compliance)

## What I Fixed

Two minimal, defensive changes in `backend/services/embedding_service.py`:

### 1. Strip trailing slashes from `rerank_base_url`

```python
# Before
base_url=settings.rerank_base_url,

# After
base_url=settings.rerank_base_url.rstrip("/"),
```

This ensures the base URL is always clean, even if a user accidentally configures it with a trailing slash.

### 2. Change POST path from `/` to `''`

```python
# Before
response = await self.client.post("/", ...)

# After
response = await self.client.post("", ...)
```

When using httpx with a `base_url` that contains a path (e.g., `/v1/rerank`):
- `post("/")` replaces the entire path with `/`, sending the request to `https://api.siliconflow.cn/`
- `post("")` preserves the base URL path exactly, sending the request to `https://api.siliconflow.cn/v1/rerank`

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| base_url configured correctly | May hit wrong endpoint or trigger 307 | ✅ Hits correct endpoint |
| base_url with trailing slash | 307 redirect → failure | ✅ Trailing slash stripped, correct endpoint |
| httpx URL joining edge cases | Unpredictable path resolution | ✅ Explicit, predictable base URL usage |

## Why This Solution Is Correct

1. **Minimal blast radius**: Only 2 lines changed in a single file, no refactoring or unrelated changes
2. **Defensive against user config**: `.rstrip("/")` handles both correct and misconfigured base URLs
3. **Matches httpx semantics**: Using `post("")` with a base URL is the idiomatic way to request the base URL endpoint itself
4. **No side effects**: Embedding service (`AsyncOpenAI`) is unaffected; only the reranker `httpx.AsyncClient` is changed
5. **Backward compatible**: Users with correct configs will see the same behavior; users with broken configs will now succeed

## How to Test

1. Configure reranking with SiliconFlow:
   ```bash
   export RERANK_PROVIDER=siliconflow
   export RERANK_BASE_URL=https://api.siliconflow.cn/v1/rerank
   export RERANK_API_KEY=your-api-key
   ```
2. Trigger any rerank operation (e.g., process an issue with AI summary)
3. **Before fix**: Warning log about 307 redirect, reranking falls back to original order
4. **After fix**: ✅ `重排序完成` success log with correct reranked results

---

I reproduced this locally by simulating the httpx URL resolution with the current code vs. the patched code. The patched code consistently resolves to `https://api.siliconflow.cn/v1/rerank` without any trailing slash.

I am happy to address any feedback. 🙏

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**  
修复了 SiliconFlow Rerank API 因请求地址末尾多余斜杠导致 307 重定向的问题，通过移除尾部斜杠使请求直达正确端点。

**主要改动列表**  
- `backend/services/embedding_service.py`：调整 SiliconFlow Rerank API 的请求 URL，移除末尾斜杠（+2/-2 行），避免服务端返回 307 重定向。

**影响范围**  
- 仅影响调用 SiliconFlow Rerank 模型的重排序流程，其他嵌入或重排服务不受影响。  
- 变更后请求不再产生多余的重定向，降低延迟并消除因客户端未正确处理重定向导致的潜在失败。

<!-- sakura-ai-summary-end -->