### PR TITLE
fix: add follow_redirects to SiliconFlow rerank httpx client

### DIFF
--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -224,6 +224,7 @@ class RerankerService:
                     base_url=settings.rerank_base_url,
                     headers={"Authorization": f"Bearer {settings.rerank_api_key}"},
                     timeout=30.0,
+                    follow_redirects=True,
                 )
                 logger.info(
                     f"✅ 重排序服务初始化成功: {self.provider} ({settings.rerank_model})"
@@ -296,7 +297,7 @@ class RerankerService:
             # 提取文档内容
             texts = [doc["content"] for doc in docs]
 
-            # 调用 Rerank API (路径留空，避免与 base_url 拼接后产生尾部斜杠触发 307 重定向)
+            # 调用 Rerank API
             response = await self.client.post(
                 "",
                 json={


### PR DESCRIPTION
## Summary
- Add `follow_redirects=True` to the `httpx.AsyncClient` in `RerankerService._init_client()`, fixing the root cause of 307 Temporary Redirect errors from the SiliconFlow Rerank API
- Simplify comment that described the now-unnecessary URL path workaround

## Context
PR #219  changed `post("/")` to `post("")` to avoid a trailing-slash 307, but httpx defaults to `follow_redirects=False`, so any 3xx response would still cause rerank to silently fail (returning unsorted results). This PR fixes the actual root cause.

Closes #222

## Test plan
- [x] Verify rerank requests complete without 307 errors
- [x] Confirm sorted results are returned correctly from rerank