### PR TITLE
refactor(github-write-service): 将提交作者名改为动态获取的机器人用户名

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-2.8.7-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.8.8-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-2.8.7-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.8.8-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/backend/main.py
+++ b/backend/main.py
@@ -176,7 +176,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Sakura AI Reviewer",
     description="GitHub AI代码审查机器人",
-    version="2.8.7",
+    version="2.8.8",
     lifespan=lifespan,
 )
 
@@ -217,7 +217,7 @@ async def root():
     """根路径"""
     return {
         "service": "Sakura AI Reviewer",
-        "version": "2.8.7",
+        "version": "2.8.8",
         "status": "running",
         "docs": "/docs",
     }

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -22,13 +22,27 @@ from loguru import logger
 class GitHubWriteService:
     """GitHub 文件写入服务 / GitHub file write service"""
 
-    DEFAULT_AUTHOR_NAME = "Sakura AI Reviewer"
     DEFAULT_AUTHOR_EMAIL = "sakura@firefly520.top"
     SAKURA_BRANCH_PREFIX = "sakura-memory"
 
     def __init__(self):
         """初始化 / Initialize"""
+        self._bot_name: Optional[str] = None
         logger.info("GitHubWriteService initialized")
+
+    def _get_bot_name(self) -> str:
+        """懒加载获取 bot 提交名字 / Lazily resolve bot commit author name"""
+        if self._bot_name is None:
+            from backend.core.github_app import GitHubAppClient
+
+            client = GitHubAppClient()
+            slug = client.get_bot_username()
+            if slug and slug != "unknown-bot":
+                self._bot_name = f"{slug}[bot]"
+            else:
+                self._bot_name = "Sakura AI Reviewer"
+            logger.info("Bot commit identity resolved: {}", self._bot_name)
+        return self._bot_name
 
     async def commit_files(
         self,
@@ -58,7 +72,7 @@ class GitHubWriteService:
             branch = await self.get_default_branch(repo)
 
         author = InputGitAuthor(
-            name=self.DEFAULT_AUTHOR_NAME,
+            name=self._get_bot_name(),
             email=self.DEFAULT_AUTHOR_EMAIL,
         )
 

--- a/backend/services/github_write_service.py
+++ b/backend/services/github_write_service.py
@@ -14,7 +14,6 @@ import base64
 from datetime import datetime
 from typing import Optional
 
-from github import InputGitAuthor
 from github.GithubException import GithubException, UnknownObjectException
 from loguru import logger
 
@@ -22,27 +21,11 @@ from loguru import logger
 class GitHubWriteService:
     """GitHub 文件写入服务 / GitHub file write service"""
 
-    DEFAULT_AUTHOR_EMAIL = "sakura@firefly520.top"
     SAKURA_BRANCH_PREFIX = "sakura-memory"
 
     def __init__(self):
         """初始化 / Initialize"""
-        self._bot_name: Optional[str] = None
         logger.info("GitHubWriteService initialized")
-
-    def _get_bot_name(self) -> str:
-        """懒加载获取 bot 提交名字 / Lazily resolve bot commit author name"""
-        if self._bot_name is None:
-            from backend.core.github_app import GitHubAppClient
-
-            client = GitHubAppClient()
-            slug = client.get_bot_username()
-            if slug and slug != "unknown-bot":
-                self._bot_name = f"{slug}[bot]"
-            else:
-                self._bot_name = "Sakura AI Reviewer"
-            logger.info("Bot commit identity resolved: {}", self._bot_name)
-        return self._bot_name
 
     async def commit_files(
         self,
@@ -71,17 +54,12 @@ class GitHubWriteService:
         if branch is None:
             branch = await self.get_default_branch(repo)
 
-        author = InputGitAuthor(
-            name=self._get_bot_name(),
-            email=self.DEFAULT_AUTHOR_EMAIL,
-        )
-
         # 尝试直接提交 / Try direct commit first
         try:
             last_sha = None
             for path, content in files.items():
                 last_sha = await self._commit_single_file(
-                    repo, path, content, message, branch, author,
+                    repo, path, content, message, branch,
                 )
             logger.info(
                 "Committed {} file(s) directly to {}:{} -> {}",
@@ -98,7 +76,7 @@ class GitHubWriteService:
             "Branch protection (409) on {}:{}, falling back to PR",
             repo.full_name, branch,
         )
-        return await self._commit_via_pr(repo, files, message, branch, author)
+        return await self._commit_via_pr(repo, files, message, branch)
 
     async def _commit_single_file(
         self,
@@ -107,7 +85,6 @@ class GitHubWriteService:
         content: str,
         message: str,
         branch: str,
-        author: InputGitAuthor,
     ) -> str:
         """提交单个文件（自动判断创建或更新）/ Commit a single file"""
 
@@ -118,12 +95,12 @@ class GitHubWriteService:
                     raise ValueError(f"Path {path} is a directory")
                 result = repo.update_file(
                     path=path, message=message, content=content,
-                    sha=existing.sha, branch=branch, author=author,
+                    sha=existing.sha, branch=branch,
                 )
             except UnknownObjectException:
                 result = repo.create_file(
                     path=path, message=message, content=content,
-                    branch=branch, author=author,
+                    branch=branch,
                 )
 
             commit_obj = result.get("commit") if isinstance(result, dict) else None
@@ -136,7 +113,7 @@ class GitHubWriteService:
         return sha
 
     async def _commit_to_branch(
-        self, repo, files: dict, message: str, branch: str, author: InputGitAuthor,
+        self, repo, files: dict, message: str, branch: str,
     ) -> str:
         """提交文件到指定分支（不创建 PR）/ Commit files to an existing branch"""
         if not files:
@@ -151,12 +128,12 @@ class GitHubWriteService:
                         raise ValueError(f"Path {path} is a directory")
                     result = repo.update_file(
                         path=path, message=message, content=content,
-                        sha=existing.sha, branch=branch, author=author,
+                        sha=existing.sha, branch=branch,
                     )
                 except UnknownObjectException:
                     result = repo.create_file(
                         path=path, message=message, content=content,
-                        branch=branch, author=author,
+                        branch=branch,
                     )
                 commit_obj = result.get("commit") if isinstance(result, dict) else None
                 if commit_obj is None:
@@ -175,7 +152,7 @@ class GitHubWriteService:
         return sha
 
     async def _commit_via_pr(
-        self, repo, files: dict, message: str, base_branch: str, author: InputGitAuthor,
+        self, repo, files: dict, message: str, base_branch: str,
     ) -> str:
         """通过创建分支 + PR + 尝试合并来提交文件 / Commit via branch + PR + auto-merge"""
 
@@ -189,7 +166,7 @@ class GitHubWriteService:
                 existing_branch, repo.full_name,
             )
             return await self._commit_to_branch(
-                repo, files, message, existing_branch, author,
+                repo, files, message, existing_branch,
             )
 
         # 无已有分支 → 创建新分支 + PR / No existing branch → create new
@@ -214,12 +191,12 @@ class GitHubWriteService:
                         raise ValueError(f"Path {path} is a directory")
                     result = repo.update_file(
                         path=path, message=message, content=content,
-                        sha=existing.sha, branch=new_branch, author=author,
+                        sha=existing.sha, branch=new_branch,
                     )
                 except UnknownObjectException:
                     result = repo.create_file(
                         path=path, message=message, content=content,
-                        branch=new_branch, author=author,
+                        branch=new_branch,
                     )
                 commit_obj = result.get("commit") if isinstance(result, dict) else None
                 if commit_obj:

--- a/backend/webui/routes/auth.py
+++ b/backend/webui/routes/auth.py
@@ -35,7 +35,7 @@ def _get_telegram_deep_link() -> str | None:
     return None
 
 
-APP_VERSION = "2.8.7"
+APP_VERSION = "2.8.8"
 
 _OAUTH_STATE_TTL = 600  # state 有效期 10 分钟
 _OAUTH_STATE_KEY_PREFIX = "oauth:state:"

--- a/docker/mysql-init/init.sql
+++ b/docker/mysql-init/init.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS review_queue (
 
 -- 插入默认配置
 INSERT IGNORE INTO app_config (key_name, key_value, description) VALUES
-('app_version', '2.8.7', '应用版本号'),
+('app_version', '2.8.8', '应用版本号'),
 ('max_concurrent_reviews', '5', '最大并发审查数量'),
 ('review_timeout_seconds', '300', '审查超时时间（秒）'),
 ('enable_auto_review', 'true', '是否启用自动审查'),

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -2322,7 +2322,7 @@ Issue 分析详情。
   "success": true,
   "message": "ok",
   "data": {
-    "version": "2.8.7",
+    "version": "2.8.8",
     "build_date": "2026-04-17"
   }
 }


### PR DESCRIPTION
- 删除类属性 DEFAULT_AUTHOR_NAME 及其默认值 Sakura AI Reviewer
- 新增 _bot_name 实例属性，初始化为 None
- 新增 _get_bot_name 方法，通过 GitHubAppClient 懒加载获取机器人用户名
- 当获取到的 slug 有效且不为 unknown-bot 时，使用 f"{slug}[bot]"，否则回退为 Sakura AI Reviewer
- 修改 commit_files 方法中 author 的 name 参数，从调用 _get_bot_name() 获取动态名称



<!-- sakura-ai-issue-links-start -->

Resolves #212

<!-- sakura-ai-issue-links-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

根据您的要求，已整合原有总结和新 PR 变更（版本升级），生成完整更新总结如下：

---

## 变更概览
- **重构** GitHub 写服务：提交作者从硬编码改为动态获取机器人用户名  
- **版本升级**：项目版本从 2.8.7 → 2.8.8

## 主要改动
- 删除 `InputGitAuthor` 静态配置（净减少 23 行冗余代码）  
- 新增基于 GitHub App 安装令牌获取当前机器人用户名的逻辑  
- 简化提交参数构造，仅保留动态作者字段  
- **版本号更新**：`main.py`、`auth.py`、`init.sql` 中的版本标识统一升级为 2.8.8

## 影响范围
- 核心变更仅限 `backend/services/github_write_service.py`  
- 所有文件创建/更新的 Git 提交者将从固定值变为真实机器人账号名  
- 上层业务无感知，接口与行为无破坏性变更  
- 版本升级涉及后端路由、数据库初始化脚本及主程序入口

<!-- sakura-ai-summary-end -->