### PR TITLE
fix(workflow): Add error handling for branch deletion in merged branc...

### DIFF
--- a/.github/workflows/gitflow-cleanup-merged-branches.yml
+++ b/.github/workflows/gitflow-cleanup-merged-branches.yml
@@ -39,10 +39,19 @@ jobs:
               return;
             }
 
-            await github.rest.git.deleteRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `heads/${head}`,
-            });
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${head}`,
+              });
+            } catch (error) {
+              if (error.status === 422 || error.status === 404) {
+                core.info(`分支已不存在，跳过删除：${head}`);
+                return;
+              }
+
+              throw error;
+            }
 
             core.info(`已删除合并到 ${base} 的分支：${head}`);


### PR DESCRIPTION
- Wrap git.deleteRef call in try-catch block to handle HTTP 422 and 404 errors
- Skip deletion and log informational message when branch no longer exists (error status 422 or 404)
- Re-throw other errors to preserve failure behavior for unexpected issues