### PR TITLE
feat(config): Add enable_inline_comments toggle for inline comment co...

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -252,8 +252,10 @@ class Settings(BaseSettings):
     code_chunk_size: int = 500  # 代码块大小（字符数）
     code_chunk_overlap: int = 50  # 代码块重叠大小
 
-    # ========== 增量审查历史上下文配置 ==========
+    # 行内评论配置
     enable_inline_comments: bool = True  # 是否启用行内评论
+
+    # ========== 增量审查历史上下文配置 ==========
     enable_incremental_history_context: bool = True  # 是否启用增量审查历史上下文
     enable_pr_summary: bool = False  # 是否启用 PR 变更自动总结
     incremental_history_max_reviews: int = 5  # 最多查询的历史审查轮数

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -253,6 +253,7 @@ class Settings(BaseSettings):
     code_chunk_overlap: int = 50  # 代码块重叠大小
 
     # ========== 增量审查历史上下文配置 ==========
+    enable_inline_comments: bool = True  # 是否启用行内评论
     enable_incremental_history_context: bool = True  # 是否启用增量审查历史上下文
     enable_pr_summary: bool = False  # 是否启用 PR 变更自动总结
     incremental_history_max_reviews: int = 5  # 最多查询的历史审查轮数
@@ -611,6 +612,7 @@ DYNAMIC_CONFIG_GROUPS: OrderedDict[str, dict] = OrderedDict(
                 "keys": [
                     "max_file_count",
                     "max_line_count",
+                    "enable_inline_comments",
                 ],
             },
         ),
@@ -876,6 +878,7 @@ DYNAMIC_CONFIG_LABELS: dict[str, str] = {
     "max_file_count": "最大文件数",
     "max_line_count": "最大行数",
     "enable_incremental_history_context": "启用增量审查历史上下文",
+    "enable_inline_comments": "启用行内评论",
     "enable_pr_summary": "启用 PR 变更总结",
     "incremental_history_max_reviews": "历史审查轮数上限",
     "incremental_history_summary_max_tokens": "摘要生成最大 Token",

--- a/backend/services/comment_service.py
+++ b/backend/services/comment_service.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Dict, Any, Optional
 from loguru import logger
 
-from backend.core.config import get_strategy_config
+from backend.core.config import get_settings, get_strategy_config
 from backend.services.label_service import label_service
 
 
@@ -93,6 +93,14 @@ class CommentService:
         try:
             # 检查是否有行内评论
             inline_comments = review_result.get("inline_comments", [])
+
+            # 行内评论开关检查（关闭时清空，保留 AI 输出但跳过提交）
+            if not get_settings().enable_inline_comments:
+                if inline_comments:
+                    logger.info(
+                        f"行内评论功能已关闭，跳过 {len(inline_comments)} 条行内评论"
+                    )
+                inline_comments = []
 
             if pr:
                 try:

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -957,6 +957,14 @@ class ReviewWorker:
             # 5. 获取行内评论
             inline_comments = review_result.get("inline_comments", [])
 
+            # 5.0 检查行内评论开关（关闭时清空，保留 AI 输出但跳过提交）
+            if not settings.enable_inline_comments:
+                if inline_comments:
+                    logger.info(
+                        f"[{task_id}] 行内评论功能已关闭，跳过 {len(inline_comments)} 条行内评论"
+                    )
+                inline_comments = []
+
             # 5.1 验证和过滤行内评论（使用 Diff 安全区）
             # 这一步确保文件路径正确匹配 PR 中的实际路径，避免 "Path could not be resolved" 错误
             if inline_comments and analysis and analysis.changed_lines_map:

--- a/docker/mysql-init/init.sql
+++ b/docker/mysql-init/init.sql
@@ -85,7 +85,8 @@ INSERT IGNORE INTO app_config (key_name, key_value, description) VALUES
 ('enable_auto_review', 'true', '是否启用自动审查'),
 ('issue_auto_create_labels', 'true', '自动为 Issue 应用 AI 推荐的标签'),
 ('issue_auto_assign', 'true', '自动为 Issue 指派 AI 推荐的负责人'),
-('issue_max_tool_iterations', '15', 'Issues 分析中 AI 工具调用最大迭代次数');
+('issue_max_tool_iterations', '15', 'Issues 分析中 AI 工具调用最大迭代次数'),
+('enable_inline_comments', 'true', '是否启用行内评论');
 
 -- 创建 Sakura 记忆系统状态表
 CREATE TABLE IF NOT EXISTS sakura_memory_states (


### PR DESCRIPTION
- Add enable_inline_comments config field in Settings with default True
- Include enable_inline_comments in dynamic config group keys
- Add enable_inline_comments label mapping for UI display
- Insert enable_inline_comments row into app_config table with default true
- Skip inline comments in comment_service when toggle is off
- Skip inline comments in review_worker when toggle is off



<!-- sakura-ai-issue-links-start -->

Resolves #236

<!-- sakura-ai-issue-links-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

根据你提供的对话历史，最新的用户请求实际上是在要求**根据 DS2API_HISTORY.txt 中的信息，生成一份完整的更新总结**（结合已有的旧总结与新变更）。

由于该文件中未提供新的 PR 变更内容（Commit 信息不完整，且“以下是该 PR 之前的 AI 总结…”之后的旧总结已经包含了本次 PR 的全部改动点），我将基于已有信息直接输出一份**最终完整总结**，保持结构清晰、不超过 300 字：

---

### 变更概览
本次 PR 新增 `enable_inline_comments` 配置开关，用于动态控制行内评论功能的启用与关闭。

### 主要改动列表
- **config.py**：新增 `enable_inline_comments` 配置项（默认值待定）。
- **comment_service.py**：根据开关决定是否生成行内评论（+9/-1）。
- **review_worker.py**：在后台任务处理中集成开关判断逻辑（+8/-0）。
- **init.sql**：更新数据库初始化脚本以适配配置变更（+2/-1）。

### 影响范围
- 行内评论的生成行为变为可配置，支持动态开启或关闭。
- 涉及评论服务、后台任务及数据库初始化流程。

--- 

如果需要我根据新的代码变更（例如后续的 commit）重新生成总结，请提供新的 diff 或 PR 描述。

<!-- sakura-ai-summary-end -->