### PR TITLE
chore(workflow): Add issues write permission to gitflow-sync workflow

### DIFF
--- a/.github/workflows/gitflow-sync-main-to-develop.yml
+++ b/.github/workflows/gitflow-sync-main-to-develop.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: 计算同步分支


### PR DESCRIPTION
- Grant `issues: write` permission in the gitflow-sync-main-to-develop workflow job