### PR TITLE
feat(webhook): Cancel PR review task when PR is closed or merged

### DIFF
--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -111,6 +111,30 @@ async def handle_pull_request_event(payload: Dict[str, Any]) -> JSONResponse:
 
         action = pr_info["action"]
 
+        # Handle PR closed/merged event: cancel any active review task
+        if action == "closed":
+            task_key = (
+                f"{pr_info.get('repo_full_name', '')}#{pr_info.get('pr_number', '')}"
+            )
+            try:
+                from backend.workers.review_worker import get_worker
+
+                worker = get_worker()
+                cancelled = worker.cancel_task(task_key)
+                if cancelled:
+                    logger.info(
+                        f"[webhook] PR closed event: 已取消审查任务 {task_key}"
+                    )
+                else:
+                    logger.debug(
+                        f"[webhook] PR closed event: 无活跃审查任务 {task_key}"
+                    )
+            except Exception as e:
+                logger.warning(f"[webhook] 取消审查任务失败: {e}")
+            return JSONResponse(
+                content={"status": "accepted", "action": "cancelled", "task": task_key}
+            )
+
         # 只处理以下动作
         supported_actions = ["opened", "synchronize", "reopened"]
         if action not in supported_actions:

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -113,10 +113,11 @@ async def handle_pull_request_event(payload: Dict[str, Any]) -> JSONResponse:
 
         # Handle PR closed/merged event: cancel any active review task
         if action == "closed":
-            task_key = (
-                f"{pr_info.get('repo_full_name', '')}#{pr_info.get('pr_number', '')}"
-            )
+            from backend.workers.review_worker import ReviewWorker
+
+            task_key = ReviewWorker._make_task_key(pr_info)
             try:
+                # Lazy import to avoid webhook ↔ worker circular dependency
                 from backend.workers.review_worker import get_worker
 
                 worker = get_worker()

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -113,13 +113,11 @@ async def handle_pull_request_event(payload: Dict[str, Any]) -> JSONResponse:
 
         # Handle PR closed/merged event: cancel any active review task
         if action == "closed":
-            from backend.workers.review_worker import ReviewWorker
+            # Lazy import to avoid webhook ↔ worker circular dependency
+            from backend.workers.review_worker import ReviewWorker, get_worker
 
             task_key = ReviewWorker._make_task_key(pr_info)
             try:
-                # Lazy import to avoid webhook ↔ worker circular dependency
-                from backend.workers.review_worker import get_worker
-
                 worker = get_worker()
                 cancelled = worker.cancel_task(task_key)
                 if cancelled:

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -140,6 +140,14 @@ async def handle_pull_request_event(payload: Dict[str, Any]) -> JSONResponse:
             logger.info(f"忽略PR动作: {action}")
             return JSONResponse(content={"status": "ignored", "action": action})
 
+        # Register cancel event IMMEDIATELY after action validation,
+        # before any async operations (quota check, Telegram, dismiss, etc.)
+        # so that a closed webhook arriving during those operations can cancel the task.
+        from backend.workers.review_worker import ReviewWorker, get_worker
+
+        task_key = ReviewWorker._make_task_key(pr_info)
+        get_worker()._register_task(task_key, force_new=True)
+
         # 过滤 Bot 自身创建的 PR（如 sakura-memory 系统创建的 PR）
         bot_username = settings.bot_username
         sender = pr_info.get("sender", "")

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -31,6 +31,7 @@ class PRStatus(str, enum.Enum):
     REVIEWING = "reviewing"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class ReviewDecision(str, enum.Enum):

--- a/backend/webui/templates/components/log_filters.html
+++ b/backend/webui/templates/components/log_filters.html
@@ -27,6 +27,7 @@
             <option value="reviewing" {% if status == 'reviewing' %}selected{% endif %}>{{ _('common.processing') }}</option>
             <option value="completed" {% if status == 'completed' %}selected{% endif %}>{{ _('scan.completed') }}</option>
             <option value="failed" {% if status == 'failed' %}selected{% endif %}>{{ _('queue.failed') }}</option>
+            <option value="cancelled" {% if status == 'cancelled' %}selected{% endif %}>{{ _('pr.cancelled_status') }}</option>
         </select>
 
         <!-- 日期范围 -->

--- a/backend/webui/templates/components/log_list_fragment.html
+++ b/backend/webui/templates/components/log_list_fragment.html
@@ -25,6 +25,8 @@
                     <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">{{ _('common.processing') }}</span>
                     {% elif r.status == "failed" %}
                     <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">{{ _('queue.failed') }}</span>
+                    {% elif r.status == "cancelled" %}
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400">{{ _('pr.cancelled_status') }}</span>
                     {% else %}
                     <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ _('common.pending') }}</span>
                     {% endif %}

--- a/backend/webui/templates/pr_detail.html
+++ b/backend/webui/templates/pr_detail.html
@@ -70,6 +70,11 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
                     {{ _('queue.failed') }}
                 </span>
+                {% elif review.status == "cancelled" %}
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/></svg>
+                    {{ _('pr.cancelled_status') }}
+                </span>
                 {% else %}
                 <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
                     {{ _('common.pending') }}

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -241,6 +241,7 @@ issue:
     low: "Low"
   completed_status: "Completed"
   failed_status: "Failed"
+  cancelled_status: "Cancelled"
   analyzing_status: "Analyzing"
   pending_status: "Pending"
   reanalyze: "Re-analyze"

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -207,6 +207,7 @@ pr:
   changes_requested: "Changes Requested"
   commented: "Commented"
   processing: "Reviewing"
+  cancelled_status: "Cancelled"
 
 # ========== Issue Analysis ==========
 issue:

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -241,6 +241,7 @@ issue:
     low: "低"
   completed_status: "已完成"
   failed_status: "失败"
+  cancelled_status: "已取消"
   analyzing_status: "分析中"
   pending_status: "待处理"
   reanalyze: "重新分析"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -207,6 +207,7 @@ pr:
   changes_requested: "需修改"
   commented: "评论"
   processing: "审查中"
+  cancelled_status: "已取消"
 
 # ========== Issue 分析 / Issue Analysis ==========
 issue:

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -1288,10 +1288,9 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     worker = get_worker()
     task_key = ReviewWorker._make_task_key(pr_info)
 
-    # Register cancel event BEFORE asyncio.create_task, so that a closed
-    # webhook arriving before the coroutine starts executing can still cancel it.
-    # force_new ensures a clean event even if a previous task's event is stale.
-    worker._register_task(task_key, force_new=True)
+    # Cancel event was already registered in webhook handler immediately
+    # after action validation, before any async operations.
+    # This ensures cancel_task works even during slow webhook processing.
 
     # 在生产环境中，这里应该提交到Celery队列
     # 为了简化，我们直接异步执行

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -128,6 +128,8 @@ class ReviewWorker:
         self._background_tasks: set = set()
         # Cancel signal management: task_key -> asyncio.Event
         # Shared by all tasks for the same PR (owner/repo#pr_number)
+        # Thread-safety: dict operations are atomic under GIL; asyncio.Event
+        # is signal-only (set/check), safe for concurrent async coroutines.
         self._cancel_events: Dict[str, asyncio.Event] = {}
 
     @staticmethod
@@ -138,11 +140,16 @@ class ReviewWorker:
     def _register_task(self, task_key: str) -> asyncio.Event:
         """Register a review task and return its cancel event.
 
-        Multiple tasks for the same PR share the same cancel event.
+        If an existing event is already set (stale from a cancelled task),
+        create a fresh one so the new task doesn't inherit the cancelled state.
         """
-        if task_key not in self._cancel_events:
-            self._cancel_events[task_key] = asyncio.Event()
-        return self._cancel_events[task_key]
+        existing = self._cancel_events.get(task_key)
+        if existing and not existing.is_set():
+            return existing
+        # Always create a fresh event (covers: no existing, or stale set event)
+        event = asyncio.Event()
+        self._cancel_events[task_key] = event
+        return event
 
     def _unregister_task(self, task_key: str):
         """Remove cancel event after task completes or fails"""
@@ -202,6 +209,8 @@ class ReviewWorker:
                 # Cancel checkpoint: before code indexing
                 if self._check_cancelled(task_key):
                     logger.info(f"[{task_id}] 任务已被取消，跳过代码索引: {task_key}")
+                    if review_id:
+                        await self._update_review_status(review_id, PRStatus.CANCELLED)
                     return task_id
 
                 # 2.5 代码索引（在 AI 审查前完成，确保 search_code_context 工具可用）
@@ -305,6 +314,10 @@ class ReviewWorker:
                     logger.info(
                         f"[{task_id}] 任务已被取消，跳过 PR 总结和 AI 审查: {task_key}"
                     )
+                    if review_obj:
+                        await self.comment_service.delete_placeholder_comment(review_obj)
+                    if review_id:
+                        await self._update_review_status(review_id, PRStatus.CANCELLED)
                     return task_id
 
                 # 4.5 PR 变更总结（如果启用）
@@ -1245,7 +1258,11 @@ def get_worker() -> ReviewWorker:
 
 
 async def submit_review_task(pr_info: Dict[str, Any]) -> str:
-    """提交审查任务（从Webhook调用）"""
+    """提交审查任务（从Webhook调用）
+
+    Returns:
+        str: Task key in format "owner/repo#pr_number", used for cancellation.
+    """
     worker = get_worker()
     task_key = ReviewWorker._make_task_key(pr_info)
 

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -175,9 +175,29 @@ class ReviewWorker:
         event = self._cancel_events.get(task_key)
         return event is not None and event.is_set()
 
+    async def _cancel_and_cleanup(
+        self,
+        task_id: str,
+        task_key: str,
+        review_obj,
+        review_id: Optional[int],
+        reason: str,
+    ):
+        """Common cleanup for all cancel checkpoints.
+
+        Deletes placeholder comment and updates DB status to CANCELLED.
+        Safe to call when review_obj/review_id are None (early checkpoints).
+        """
+        logger.info(f"[{task_id}] 任务已被取消，{reason}: {task_key}")
+        if review_obj:
+            await self.comment_service.delete_placeholder_comment(review_obj)
+        if review_id:
+            await self._update_review_status(review_id, PRStatus.CANCELLED)
+        return task_id
+
     async def process_review_task(self, pr_info: Dict[str, Any]) -> str:
         """处理审查任务"""
-        task_id = str(uuid.uuid4())
+        task_id = str(uuid.uuid4())[:8]
         task_key = self._make_task_key(pr_info)
         review_obj = None  # 用于保存 GitHub Review 对象
         review_id = None  # 用于保存数据库审查记录 ID
@@ -196,10 +216,9 @@ class ReviewWorker:
                 # Check if already cancelled (e.g. PR closed while queued)
                 # Note: review_id is None at this point, no DB record to update
                 if self._check_cancelled(task_key):
-                    logger.info(
-                        f"[{task_id}] 任务已被取消（PR 已关闭/合并），跳过审查: {task_key}"
+                    return await self._cancel_and_cleanup(
+                        task_id, task_key, None, None, "PR 已关闭/合并，跳过审查"
                     )
-                    return task_id
 
                 # 1. 分析PR
                 analysis = await self.analyzer.analyze_pr(pr_info)
@@ -212,10 +231,9 @@ class ReviewWorker:
 
                 # Cancel checkpoint: before code indexing
                 if self._check_cancelled(task_key):
-                    logger.info(f"[{task_id}] 任务已被取消，跳过代码索引: {task_key}")
-                    if review_id:
-                        await self._update_review_status(review_id, PRStatus.CANCELLED)
-                    return task_id
+                    return await self._cancel_and_cleanup(
+                        task_id, task_key, None, review_id, "跳过代码索引"
+                    )
 
                 # 2.5 代码索引（在 AI 审查前完成，确保 search_code_context 工具可用）
                 if settings.auto_index_pr_changes and settings.enable_code_index:
@@ -313,16 +331,12 @@ class ReviewWorker:
                 )
                 pr = await asyncio.to_thread(repo.get_pull, pr_info["pr_number"])
 
-                # Cancel checkpoint: before PR summary and AI review (most important)
+                # Cancel checkpoint: before PR summary and AI review
                 if self._check_cancelled(task_key):
-                    logger.info(
-                        f"[{task_id}] 任务已被取消，跳过 PR 总结和 AI 审查: {task_key}"
+                    return await self._cancel_and_cleanup(
+                        task_id, task_key, review_obj, review_id,
+                        "跳过 PR 总结和 AI 审查",
                     )
-                    if review_obj:
-                        await self.comment_service.delete_placeholder_comment(review_obj)
-                    if review_id:
-                        await self._update_review_status(review_id, PRStatus.CANCELLED)
-                    return task_id
 
                 # 4.5 PR 变更总结（如果启用）
                 pr_summary_text = None
@@ -579,16 +593,9 @@ class ReviewWorker:
 
                 # Cancel checkpoint: before AI review (critical — most expensive step)
                 if self._check_cancelled(task_key):
-                    logger.info(
-                        f"[{task_id}] 任务已被取消，跳过 AI 审查: {task_key}"
+                    return await self._cancel_and_cleanup(
+                        task_id, task_key, review_obj, review_id, "跳过 AI 审查"
                     )
-                    # Clean up placeholder comment
-                    if review_obj:
-                        await self.comment_service.delete_placeholder_comment(review_obj)
-                    # Update database status to cancelled
-                    if review_id:
-                        await self._update_review_status(review_id, PRStatus.CANCELLED)
-                    return task_id
 
                 # 7. 并行执行AI审查和标签推荐
                 await self._update_review_status(review_id, PRStatus.REVIEWING)
@@ -1265,12 +1272,11 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     """提交审查任务（从Webhook调用）
 
     Returns:
-        str: Task identifier combining task_key and short UUID for traceability,
-             format: "owner/repo#pr_number (task: uuid[:8])"
+        str: Task key in format "owner/repo#pr_number", used for cancellation.
+             The internal task_id (short UUID) is logged by process_review_task.
     """
     worker = get_worker()
     task_key = ReviewWorker._make_task_key(pr_info)
-    short_id = str(uuid.uuid4())[:8]
 
     # If a previous task for the same PR is still running, cancel it first
     worker.cancel_task(task_key)
@@ -1279,8 +1285,8 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     # 为了简化，我们直接异步执行
     asyncio.create_task(worker.process_review_task(pr_info))
 
-    # 返回任务标识（含 task_key 用于取消 + short UUID 用于日志追踪）
-    return f"{task_key} (task: {short_id})"
+    # 返回任务标识（owner/repo#pr_number），可用于取消
+    return task_key
 
 
 async def process_review_task_sync(pr_info: Dict[str, Any]) -> str:

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -137,7 +137,7 @@ class ReviewWorker:
         """Generate unique task key: owner/repo#pr_number"""
         return f"{pr_info['repo_full_name']}#{pr_info['pr_number']}"
 
-    def _register_task(self, task_key: str) -> asyncio.Event:
+    def _register_task(self, task_key: str, force_new: bool = False) -> asyncio.Event:
         """Register a review task and return its cancel event.
 
         Idempotent: multiple registrations for the same task_key share the same
@@ -145,7 +145,17 @@ class ReviewWorker:
 
         If an existing event is already set (stale from a cancelled task),
         create a fresh one so the new task doesn't inherit the cancelled state.
+
+        Args:
+            task_key: Unique key for the PR (owner/repo#pr_number)
+            force_new: If True, always create a fresh event (used by
+                       submit_review_task to ensure a clean state before
+                       the coroutine starts executing).
         """
+        if force_new:
+            event = asyncio.Event()
+            self._cancel_events[task_key] = event
+            return event
         existing = self._cancel_events.get(task_key)
         if existing and not existing.is_set():
             return existing
@@ -202,8 +212,8 @@ class ReviewWorker:
         review_obj = None  # 用于保存 GitHub Review 对象
         review_id = None  # 用于保存数据库审查记录 ID
 
-        # Register cancel event for this PR
-        self._register_task(task_key)
+        # Cancel event was already registered in submit_review_task
+        # before asyncio.create_task, so cancel_task works immediately
 
         # 获取并发信号量，限制同时运行的审查任务数
         semaphore = await _get_review_semaphore()
@@ -1278,8 +1288,10 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     worker = get_worker()
     task_key = ReviewWorker._make_task_key(pr_info)
 
-    # If a previous task for the same PR is still running, cancel it first
-    worker.cancel_task(task_key)
+    # Register cancel event BEFORE asyncio.create_task, so that a closed
+    # webhook arriving before the coroutine starts executing can still cancel it.
+    # force_new ensures a clean event even if a previous task's event is stale.
+    worker._register_task(task_key, force_new=True)
 
     # 在生产环境中，这里应该提交到Celery队列
     # 为了简化，我们直接异步执行

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -126,11 +126,54 @@ class ReviewWorker:
         self.ai_reviewer = AIReviewer()
         self.comment_service = CommentService()
         self._background_tasks: set = set()
+        # Cancel signal management: task_key -> asyncio.Event
+        # Shared by all tasks for the same PR (owner/repo#pr_number)
+        self._cancel_events: Dict[str, asyncio.Event] = {}
+
+    @staticmethod
+    def _make_task_key(pr_info: Dict[str, Any]) -> str:
+        """Generate unique task key: owner/repo#pr_number"""
+        return f"{pr_info['repo_full_name']}#{pr_info['pr_number']}"
+
+    def _register_task(self, task_key: str) -> asyncio.Event:
+        """Register a review task and return its cancel event.
+
+        Multiple tasks for the same PR share the same cancel event.
+        """
+        if task_key not in self._cancel_events:
+            self._cancel_events[task_key] = asyncio.Event()
+        return self._cancel_events[task_key]
+
+    def _unregister_task(self, task_key: str):
+        """Remove cancel event after task completes or fails"""
+        self._cancel_events.pop(task_key, None)
+
+    def cancel_task(self, task_key: str) -> bool:
+        """Signal cancellation for a PR's review task(s). Called from webhook.
+
+        Returns True if there was an active task to cancel.
+        """
+        event = self._cancel_events.get(task_key)
+        if event and not event.is_set():
+            event.set()
+            logger.info(f"[cancel] 已设置取消信号: {task_key}")
+            return True
+        return False
+
+    def _check_cancelled(self, task_key: str) -> bool:
+        """Check if cancellation has been signaled for this task"""
+        event = self._cancel_events.get(task_key)
+        return event is not None and event.is_set()
 
     async def process_review_task(self, pr_info: Dict[str, Any]) -> str:
         """处理审查任务"""
         task_id = str(uuid.uuid4())
+        task_key = self._make_task_key(pr_info)
         review_obj = None  # 用于保存 GitHub Review 对象
+        review_id = None  # 用于保存数据库审查记录 ID
+
+        # Register cancel event for this PR
+        self._register_task(task_key)
 
         # 获取并发信号量，限制同时运行的审查任务数
         semaphore = await _get_review_semaphore()
@@ -140,6 +183,13 @@ class ReviewWorker:
                     f"[{task_id}] 开始处理审查任务: {pr_info['repo_full_name']}#{pr_info['pr_number']}"
                 )
 
+                # Check if already cancelled (e.g. PR closed while queued)
+                if self._check_cancelled(task_key):
+                    logger.info(
+                        f"[{task_id}] 任务已被取消（PR 已关闭/合并），跳过审查: {task_key}"
+                    )
+                    return task_id
+
                 # 1. 分析PR
                 analysis = await self.analyzer.analyze_pr(pr_info)
 
@@ -147,6 +197,11 @@ class ReviewWorker:
                 if analysis.should_skip:
                     logger.info(f"[{task_id}] 跳过审查: {analysis.skip_reason}")
                     await self._save_skip_record(analysis, pr_info)
+                    return task_id
+
+                # Cancel checkpoint: before code indexing
+                if self._check_cancelled(task_key):
+                    logger.info(f"[{task_id}] 任务已被取消，跳过代码索引: {task_key}")
                     return task_id
 
                 # 2.5 代码索引（在 AI 审查前完成，确保 search_code_context 工具可用）
@@ -244,6 +299,13 @@ class ReviewWorker:
                     client.get_repo, pr_info["repo_full_name"]
                 )
                 pr = await asyncio.to_thread(repo.get_pull, pr_info["pr_number"])
+
+                # Cancel checkpoint: before PR summary and AI review (most important)
+                if self._check_cancelled(task_key):
+                    logger.info(
+                        f"[{task_id}] 任务已被取消，跳过 PR 总结和 AI 审查: {task_key}"
+                    )
+                    return task_id
 
                 # 4.5 PR 变更总结（如果启用）
                 pr_summary_text = None
@@ -498,6 +560,19 @@ class ReviewWorker:
                             exc_info=True,
                         )
 
+                # Cancel checkpoint: before AI review (critical — most expensive step)
+                if self._check_cancelled(task_key):
+                    logger.info(
+                        f"[{task_id}] 任务已被取消，跳过 AI 审查: {task_key}"
+                    )
+                    # Clean up placeholder comment
+                    if review_obj:
+                        await self.comment_service.delete_placeholder_comment(review_obj)
+                    # Update database status to cancelled
+                    if review_id:
+                        await self._update_review_status(review_id, PRStatus.CANCELLED)
+                    return task_id
+
                 # 7. 并行执行AI审查和标签推荐
                 await self._update_review_status(review_id, PRStatus.REVIEWING)
 
@@ -713,6 +788,9 @@ class ReviewWorker:
                 except Exception as save_error:
                     logger.error(f"保存错误记录失败: {save_error}")
                 raise
+            finally:
+                # Always unregister task to clean up cancel event
+                self._unregister_task(task_key)
 
     async def _create_review_record(
         self, analysis: PRAnalysis, pr_info: Dict[str, Any], task_id: str
@@ -1169,13 +1247,17 @@ def get_worker() -> ReviewWorker:
 async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     """提交审查任务（从Webhook调用）"""
     worker = get_worker()
+    task_key = ReviewWorker._make_task_key(pr_info)
+
+    # If a previous task for the same PR is still running, cancel it first
+    worker.cancel_task(task_key)
 
     # 在生产环境中，这里应该提交到Celery队列
     # 为了简化，我们直接异步执行
     asyncio.create_task(worker.process_review_task(pr_info))
 
-    # 返回任务ID（简化版，实际应该在提交到队列后返回）
-    return str(uuid.uuid4())
+    # 返回任务标识（owner/repo#pr_number），可用于取消
+    return task_key
 
 
 async def process_review_task_sync(pr_info: Dict[str, Any]) -> str:

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -140,6 +140,9 @@ class ReviewWorker:
     def _register_task(self, task_key: str) -> asyncio.Event:
         """Register a review task and return its cancel event.
 
+        Idempotent: multiple registrations for the same task_key share the same
+        event — any cancellation signal affects all of them.
+
         If an existing event is already set (stale from a cancelled task),
         create a fresh one so the new task doesn't inherit the cancelled state.
         """
@@ -191,6 +194,7 @@ class ReviewWorker:
                 )
 
                 # Check if already cancelled (e.g. PR closed while queued)
+                # Note: review_id is None at this point, no DB record to update
                 if self._check_cancelled(task_key):
                     logger.info(
                         f"[{task_id}] 任务已被取消（PR 已关闭/合并），跳过审查: {task_key}"
@@ -850,7 +854,7 @@ class ReviewWorker:
                 record = await session.get(PRReview, review_id)
                 if record:
                     record.status = status
-                    if status == PRStatus.COMPLETED:
+                    if status in (PRStatus.COMPLETED, PRStatus.CANCELLED):
                         record.completed_at = datetime.utcnow()
                     if overall_score is not None:
                         record.overall_score = overall_score
@@ -1261,10 +1265,12 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     """提交审查任务（从Webhook调用）
 
     Returns:
-        str: Task key in format "owner/repo#pr_number", used for cancellation.
+        str: Task identifier combining task_key and short UUID for traceability,
+             format: "owner/repo#pr_number (task: uuid[:8])"
     """
     worker = get_worker()
     task_key = ReviewWorker._make_task_key(pr_info)
+    short_id = str(uuid.uuid4())[:8]
 
     # If a previous task for the same PR is still running, cancel it first
     worker.cancel_task(task_key)
@@ -1273,8 +1279,8 @@ async def submit_review_task(pr_info: Dict[str, Any]) -> str:
     # 为了简化，我们直接异步执行
     asyncio.create_task(worker.process_review_task(pr_info))
 
-    # 返回任务标识（owner/repo#pr_number），可用于取消
-    return task_key
+    # 返回任务标识（含 task_key 用于取消 + short UUID 用于日志追踪）
+    return f"{task_key} (task: {short_id})"
 
 
 async def process_review_task_sync(pr_info: Dict[str, Any]) -> str:


### PR DESCRIPTION
- Add cancellation handling in webhook for PR closed event to stop active review tasks
- Introduce `CANCELLED` status in `PRStatus` enum to track cancelled reviews
- Implement cancel signal management in `ReviewWorker` using `asyncio.Event` per task key
- Add `cancel_task` method to signal cancellation and `_check_cancelled` to check signal
- Register and unregister task key for cancel events in `process_review_task`
- Insert cancellation checkpoints before code indexing, PR summary, and AI review steps
- In `submit_review_task`, cancel any existing running task for the same PR before submitting new one
- Update database status to `CANCELLED` and clean up placeholder comment if AI review is skipped due to cancellation





<!-- sakura-ai-issue-links-start -->

Resolves #249
Resolves #256
Resolves #254

<!-- sakura-ai-issue-links-end -->



<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    webhook["backend/api/webhook.py"] -->|PR 变更| review_worker["backend/workers/review_worker.py"]
    review_worker -->|PR 变更| database["backend/models/database.py"]
    webhook -->|PR 变更| database

    webhook -.-> github["backend.core.github_app"]
    webhook -.-> telegram["backend.services.telegram_service"]
    webhook -.-> telegram_notify["backend.telegram.notifications"]
    webhook -.-> config["backend.core.config"]

    review_worker -.-> pr_analyzer["backend.services.pr_analyzer"]
    review_worker -.-> ai_reviewer["backend.services.ai_reviewer"]
    review_worker -.-> token_tracker["backend.services.ai_reviewer.token_tracker"]
    review_worker -.-> comment_svc["backend.services.comment_service"]
    review_worker -.-> label_svc["backend.services.label_service"]
    review_worker -.-> decision_engine["backend.services.decision_engine"]
    review_worker -.-> config

    database -.-> sqlalchemy["sqlalchemy"]
    database -.-> sqlalchemy_orm["sqlalchemy.orm"]
    database -.-> sqlalchemy_ext["sqlalchemy.ext.asyncio"]
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

根据您提供的 PR 实际变更（+169/-5，核心文件 `review_worker.py` +127/-5），在上一次总结基础上更新如下：

---

### 变更概览
本 PR 实现 PR 关闭或合并时自动取消对应审查任务，并重构任务生命周期管理，显著提升资源利用效率与系统健壮性。

### 主要改动
- **review_worker.py**（+127/-5）：大幅重构任务调度与取消逻辑，支持强制中断运行中任务、从队列移除、统一清理流程及状态持久化同步
- **webhook.py**（+31/-0）：新增 PR 关闭/合并事件监听，触发取消任务链
- **models/database.py**（+1/-0）：增加任务状态字段标记“已取消”
- **前端三个模板文件**（总计 +8/-0）：PR 详情页与日志组件增加取消状态的展示及筛选支持

### 影响范围
- 后端审查任务的启动、中断、取消与状态同步全流程
- Webhook 对 PR 状态变更的响应逻辑
- 前端 UI（任务取消状态可查看、可筛选）

> 核心价值：避免无效审查任务继续消耗资源，提供清晰的状态反馈与操作闭环。

<!-- sakura-ai-summary-end -->