### PR TITLE
chore(version): Bump version from 2.9.3 to 2.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-2.9.3-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.9.4-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-2.9.3-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.9.4-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,3 @@
 """Sakura AI Reviewer Backend"""
 
-__version__ = "2.9.3"
+__version__ = "2.9.4"

--- a/backend/main.py
+++ b/backend/main.py
@@ -178,7 +178,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Sakura AI Reviewer",
     description="GitHub AI代码审查机器人",
-    version="2.9.3",
+    version="2.9.4",
     lifespan=lifespan,
 )
 
@@ -248,7 +248,7 @@ async def root():
     """根路径"""
     return {
         "service": "Sakura AI Reviewer",
-        "version": "2.9.3",
+        "version": "2.9.4",
         "status": "running",
         "docs": "/docs",
     }

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -522,7 +522,7 @@ async def insert_default_configs_async():
         raise RuntimeError("异步会话工厂未初始化,请先调用 init_async_db()")
 
     default_configs = [
-        AppConfig(key_name="app_version", key_value="2.9.3", description="应用版本号"),
+        AppConfig(key_name="app_version", key_value="2.9.4", description="应用版本号"),
         AppConfig(
             key_name="max_concurrent_reviews",
             key_value="5",
@@ -641,7 +641,7 @@ def init_database(database_url: str):
 
             default_configs = [
                 AppConfig(
-                    key_name="app_version", key_value="2.9.3", description="应用版本号"
+                    key_name="app_version", key_value="2.9.4", description="应用版本号"
                 ),
                 AppConfig(
                     key_name="max_concurrent_reviews",

--- a/backend/webui/routes/auth.py
+++ b/backend/webui/routes/auth.py
@@ -37,7 +37,7 @@ def _get_telegram_deep_link() -> str | None:
     return None
 
 
-APP_VERSION = "2.9.3"
+APP_VERSION = "2.9.4"
 
 _OAUTH_STATE_TTL = 600  # state 有效期 10 分钟
 _OAUTH_STATE_KEY_PREFIX = "oauth:state:"

--- a/docker/mysql-init/init.sql
+++ b/docker/mysql-init/init.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS review_queue (
 
 -- 插入默认配置
 INSERT IGNORE INTO app_config (key_name, key_value, description) VALUES
-('app_version', '2.9.3', '应用版本号'),
+('app_version', '2.9.4', '应用版本号'),
 ('max_concurrent_reviews', '5', '最大并发审查数量'),
 ('review_timeout_seconds', '300', '审查超时时间（秒）'),
 ('enable_auto_review', 'true', '是否启用自动审查'),

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -2322,7 +2322,7 @@ Issue 分析详情。
   "success": true,
   "message": "ok",
   "data": {
-    "version": "2.9.3",
+    "version": "2.9.4",
     "build_date": "2026-05-06"
   }
 }


### PR DESCRIPTION
- Update version badge in README.md and README_EN.md from 2.9.3 to 2.9.4
- Change __version__ in backend/__init__.py from 2.9.3 to 2.9.4
- Update version field in backend/main.py FastAPI app and root endpoint from 2.9.3 to 2.9.4
- Replace app_version key_value from 2.9.3 to 2.9.4 in backend/models/database.py (both async insert and init functions)
- Change APP_VERSION constant in backend/webui/routes/auth.py from 2.9.3 to 2.9.4
- Update app_version INSERT statement in docker/mysql-init/init.sql from 2.9.3 to 2.9.4
- Bump version field in docs/api-v1-reference.md response example from 2.9.3 to 2.9.4

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**  
版本号从 2.9.3 升级至 2.9.4，共修改 8 个文件，变更量为 +10/-10，属于常规版本号更新。

**主要改动列表**  
- 更新 `backend/__init__.py` 中的版本标识  
- 调整 `backend/main.py` 中涉及的版本引用（2 处）  
- 修改 `backend/models/database.py` 中的版本相关信息（2 处）  
- 更新 `backend/webui/routes/auth.py` 中的版本号  
- 同步更新 `docker/mysql-init/init.sql` 中的版本注释或默认数据  

**影响范围**  
- 后端启动模块、数据库模型、WebUI 认证路由以及 Docker 初始化脚本均受版本号更新影响。  
- 无功能变更、新特性或 Bug 修复，仅为版本号提升操作。

<!-- sakura-ai-summary-end -->