### PR TITLE
feat(quota): Add daily/weekly/monthly quota reset mechanism for users

### DIFF
--- a/backend/api/v1/users.py
+++ b/backend/api/v1/users.py
@@ -12,6 +12,7 @@ from backend.models.telegram_models import TelegramUser, QuotaUsageLog
 from backend.webui.deps import get_db, paginate
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.core.config import get_settings
+from backend.services.quota_service import QuotaService
 
 from backend.api.v1.deps import require_api_admin, require_api_super_admin
 from backend.api.v1.schemas import (
@@ -73,6 +74,14 @@ async def list_users(
     users, total, total_pages, page = await paginate(
         db, query, count_query, page, per_page
     )
+    quota_service = QuotaService(db)
+    changed = False
+    for target in users:
+        changed = await quota_service.reset_user_quotas_if_expired(
+            target, commit=False
+        ) or changed
+    if changed:
+        await db.commit()
 
     items = [
         UserResponse.model_validate(u, from_attributes=True).model_dump(mode="json")
@@ -194,6 +203,8 @@ async def get_user(
     target = result.scalar_one_or_none()
     if not target:
         return error_response("用户不存在", status_code=404)
+
+    await QuotaService(db).reset_user_quotas_if_expired(target)
 
     data = UserResponse.model_validate(target, from_attributes=True).model_dump(
         mode="json"

--- a/backend/api/v1/users.py
+++ b/backend/api/v1/users.py
@@ -74,14 +74,6 @@ async def list_users(
     users, total, total_pages, page = await paginate(
         db, query, count_query, page, per_page
     )
-    quota_service = QuotaService(db)
-    changed = False
-    for target in users:
-        changed = await quota_service.reset_user_quotas_if_expired(
-            target, commit=False
-        ) or changed
-    if changed:
-        await db.commit()
 
     items = [
         UserResponse.model_validate(u, from_attributes=True).model_dump(mode="json")

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI):
     telegram_task = None
     redis_listener_task = None
     scan_scheduler = None
+    quota_reset_scheduler = None
 
     if not is_bootstrap_mode():
         # 正常模式：完整启动所有服务
@@ -127,6 +128,15 @@ async def lifespan(app: FastAPI):
                 scan_scheduler.start()
             except Exception as e:
                 logger.error(f"❌ 仓库扫描调度器启动失败: {e}")
+
+            # 启动配额重置调度器
+            try:
+                from backend.services.quota_scheduler import QuotaResetScheduler
+
+                quota_reset_scheduler = QuotaResetScheduler()
+                quota_reset_scheduler.start()
+            except Exception as e:
+                logger.error(f"❌ 配额重置调度器启动失败: {e}")
     else:
         logger.warning("🔧 Bootstrap 模式：仅 Setup Wizard 可用")
         logger.info("请访问 /setup 完成初始配置")
@@ -172,6 +182,10 @@ async def lifespan(app: FastAPI):
     # 停止仓库扫描调度器
     if scan_scheduler:
         scan_scheduler.stop()
+
+    # 停止配额重置调度器
+    if quota_reset_scheduler:
+        quota_reset_scheduler.stop()
 
 
 # 创建FastAPI应用

--- a/backend/services/quota_scheduler.py
+++ b/backend/services/quota_scheduler.py
@@ -22,6 +22,7 @@ class QuotaResetScheduler:
             from apscheduler.schedulers.asyncio import AsyncIOScheduler
             from apscheduler.triggers.cron import CronTrigger
 
+            # 配额统计按 UTC 自然日/周/月结算，避免部署机器本地时区影响重置时间。
             self._scheduler = AsyncIOScheduler(
                 timezone="UTC",
                 job_defaults={"coalesce": True, "max_instances": 1},
@@ -60,6 +61,6 @@ class QuotaResetScheduler:
 
             async with async_session() as session:
                 reset_count = await QuotaService(session).reset_all_expired_quotas_atomic()
-            logger.info(f"✅ 定时配额重置完成，更新字段次数: {reset_count}")
+            logger.info(f"✅ 定时配额重置完成，字段维度更新次数: {reset_count}")
         except Exception as e:
             logger.error(f"❌ 定时配额重置异常: {e}", exc_info=True)

--- a/backend/services/quota_scheduler.py
+++ b/backend/services/quota_scheduler.py
@@ -1,0 +1,65 @@
+"""配额定时重置调度器"""
+
+from loguru import logger
+
+from backend.core.config import get_settings
+
+
+class QuotaResetScheduler:
+    """每天 00:00 UTC 批量重置过期用户配额。"""
+
+    def __init__(self):
+        self._scheduler = None
+
+    def start(self):
+        """启动配额重置调度器。"""
+        settings = get_settings()
+        if not settings.enable_scheduler:
+            logger.info("配额重置调度器未启用（enable_scheduler=False）")
+            return
+
+        try:
+            from apscheduler.schedulers.asyncio import AsyncIOScheduler
+            from apscheduler.triggers.cron import CronTrigger
+
+            self._scheduler = AsyncIOScheduler(
+                timezone="UTC",
+                job_defaults={"coalesce": True, "max_instances": 1},
+            )
+            self._scheduler.add_job(
+                self._run_quota_reset,
+                trigger=CronTrigger(hour=0, minute=0),
+                id="quota_reset_daily",
+                name="用户配额每日重置",
+                replace_existing=True,
+            )
+            self._scheduler.start()
+            logger.info("✅ 配额重置调度器已启动，每天 00:00 UTC 执行")
+        except ImportError:
+            logger.warning(
+                "APScheduler 未安装，跳过配额重置调度器启动。请安装: pip install APScheduler"
+            )
+        except Exception as e:
+            logger.error(f"❌ 配额重置调度器启动失败: {e}")
+
+    def stop(self):
+        """停止配额重置调度器。"""
+        if self._scheduler and self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+            logger.info("✅ 配额重置调度器已停止")
+
+    async def _run_quota_reset(self):
+        """定时批量重置入口。"""
+        try:
+            from backend.models.database import async_session
+            from backend.services.quota_service import QuotaService
+
+            if async_session is None:
+                logger.warning("配额重置跳过：数据库会话工厂未初始化")
+                return
+
+            async with async_session() as session:
+                reset_count = await QuotaService(session).reset_all_expired_quotas_atomic()
+            logger.info(f"✅ 定时配额重置完成，更新字段次数: {reset_count}")
+        except Exception as e:
+            logger.error(f"❌ 定时配额重置异常: {e}", exc_info=True)

--- a/backend/services/quota_service.py
+++ b/backend/services/quota_service.py
@@ -1,9 +1,9 @@
 """用户配额重置服务"""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from loguru import logger
-from sqlalchemy import select, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.telegram_models import TelegramUser
@@ -12,86 +12,94 @@ from backend.models.telegram_models import TelegramUser
 class QuotaService:
     """统一处理 PR 与 Issue 配额重置逻辑。"""
 
+    PR_QUOTA_FIELDS = {
+        "daily_used": "daily_used",
+        "weekly_used": "weekly_used",
+        "monthly_used": "monthly_used",
+        "last_reset_daily": "last_reset_daily",
+        "last_reset_weekly": "last_reset_weekly",
+        "last_reset_monthly": "last_reset_monthly",
+    }
+    ISSUE_QUOTA_FIELDS = {
+        "daily_used": "issue_daily_used",
+        "weekly_used": "issue_weekly_used",
+        "monthly_used": "issue_monthly_used",
+        "last_reset_daily": "last_reset_issue_daily",
+        "last_reset_weekly": "last_reset_issue_weekly",
+        "last_reset_monthly": "last_reset_issue_monthly",
+    }
+
     def __init__(self, session: AsyncSession):
         self.session = session
 
     @staticmethod
+    def _utcnow() -> datetime:
+        """返回无时区 UTC 时间，保持与现有 TIMESTAMP 字段兼容。"""
+        return datetime.now(UTC).replace(tzinfo=None)
+
+    @staticmethod
     def _week_start(now: datetime) -> datetime:
+        # 配额周期统一按 UTC 周一 00:00 计算，与每日 UTC 重置策略保持一致。
         week_start = now - timedelta(days=now.weekday())
         return week_start.replace(hour=0, minute=0, second=0, microsecond=0)
 
     @staticmethod
-    def reset_user_pr_quotas_if_expired(user: TelegramUser, now: datetime | None = None) -> bool:
-        """重置单个用户过期的 PR 配额，返回是否发生变更。"""
-        now = now or datetime.utcnow()
+    def _reset_quota_group(
+        user: TelegramUser,
+        fields: dict[str, str],
+        now: datetime | None = None,
+    ) -> bool:
+        """按字段映射重置一组日/周/月配额，返回是否发生变更。"""
+        now = now or QuotaService._utcnow()
         changed = False
 
-        if user.last_reset_daily is None or user.last_reset_daily.date() < now.date():
-            user.daily_used = 0
-            user.last_reset_daily = now
+        last_reset_daily = getattr(user, fields["last_reset_daily"])
+        if last_reset_daily is None or last_reset_daily.date() < now.date():
+            setattr(user, fields["daily_used"], 0)
+            setattr(user, fields["last_reset_daily"], now)
             changed = True
 
-        if user.last_reset_weekly is None:
-            user.weekly_used = 0
-            user.last_reset_weekly = now
+        last_reset_weekly = getattr(user, fields["last_reset_weekly"])
+        if last_reset_weekly is None:
+            setattr(user, fields["weekly_used"], 0)
+            setattr(user, fields["last_reset_weekly"], now)
             changed = True
-        elif user.last_reset_weekly.date() < now.date():
-            if user.last_reset_weekly < QuotaService._week_start(now):
-                user.weekly_used = 0
-                user.last_reset_weekly = now
+        elif last_reset_weekly.date() < now.date():
+            if last_reset_weekly < QuotaService._week_start(now):
+                setattr(user, fields["weekly_used"], 0)
+                setattr(user, fields["last_reset_weekly"], now)
                 changed = True
 
-        if user.last_reset_monthly is None:
-            user.monthly_used = 0
-            user.last_reset_monthly = now
+        last_reset_monthly = getattr(user, fields["last_reset_monthly"])
+        if last_reset_monthly is None:
+            setattr(user, fields["monthly_used"], 0)
+            setattr(user, fields["last_reset_monthly"], now)
             changed = True
         elif (
-            user.last_reset_monthly.month != now.month
-            or user.last_reset_monthly.year != now.year
+            last_reset_monthly.month != now.month
+            or last_reset_monthly.year != now.year
         ):
-            user.monthly_used = 0
-            user.last_reset_monthly = now
+            setattr(user, fields["monthly_used"], 0)
+            setattr(user, fields["last_reset_monthly"], now)
             changed = True
 
         return changed
 
     @staticmethod
-    def reset_user_issue_quotas_if_expired(user: TelegramUser, now: datetime | None = None) -> bool:
+    def reset_user_pr_quotas_if_expired(
+        user: TelegramUser, now: datetime | None = None
+    ) -> bool:
+        """重置单个用户过期的 PR 配额，返回是否发生变更。"""
+        return QuotaService._reset_quota_group(user, QuotaService.PR_QUOTA_FIELDS, now)
+
+    @staticmethod
+    def reset_user_issue_quotas_if_expired(
+        user: TelegramUser, now: datetime | None = None
+    ) -> bool:
         """重置单个用户过期的 Issue 配额，返回是否发生变更。"""
-        now = now or datetime.utcnow()
-        changed = False
-
-        if (
-            user.last_reset_issue_daily is None
-            or user.last_reset_issue_daily.date() < now.date()
-        ):
-            user.issue_daily_used = 0
-            user.last_reset_issue_daily = now
-            changed = True
-
-        if user.last_reset_issue_weekly is None:
-            user.issue_weekly_used = 0
-            user.last_reset_issue_weekly = now
-            changed = True
-        elif user.last_reset_issue_weekly.date() < now.date():
-            if user.last_reset_issue_weekly < QuotaService._week_start(now):
-                user.issue_weekly_used = 0
-                user.last_reset_issue_weekly = now
-                changed = True
-
-        if user.last_reset_issue_monthly is None:
-            user.issue_monthly_used = 0
-            user.last_reset_issue_monthly = now
-            changed = True
-        elif (
-            user.last_reset_issue_monthly.month != now.month
-            or user.last_reset_issue_monthly.year != now.year
-        ):
-            user.issue_monthly_used = 0
-            user.last_reset_issue_monthly = now
-            changed = True
-
-        return changed
+        return QuotaService._reset_quota_group(
+            user, QuotaService.ISSUE_QUOTA_FIELDS, now
+        )
 
     async def reset_user_quotas_if_expired(
         self,
@@ -102,7 +110,7 @@ class QuotaService:
         commit: bool = True,
     ) -> bool:
         """重置单个用户过期配额。"""
-        now = datetime.utcnow()
+        now = self._utcnow()
         changed = False
 
         if include_pr:
@@ -115,30 +123,9 @@ class QuotaService:
 
         return changed
 
-    async def reset_all_expired_quotas(self) -> int:
-        """批量重置所有活跃用户的过期配额，返回发生重置的用户数。"""
-        result = await self.session.execute(
-            select(TelegramUser).where(TelegramUser.is_active)
-        )
-        users = result.scalars().all()
-
-        reset_count = 0
-        now = datetime.utcnow()
-        for user in users:
-            changed = self.reset_user_pr_quotas_if_expired(user, now)
-            changed = self.reset_user_issue_quotas_if_expired(user, now) or changed
-            if changed:
-                reset_count += 1
-
-        if reset_count:
-            await self.session.commit()
-
-        logger.info(f"配额批量重置完成，更新用户数: {reset_count}")
-        return reset_count
-
     async def reset_all_expired_quotas_atomic(self) -> int:
-        """使用批量 UPDATE 重置所有活跃用户的过期配额。"""
-        now = datetime.utcnow()
+        """使用批量 UPDATE 重置过期配额，返回字段维度更新次数。"""
+        now = self._utcnow()
         today = now.date()
         week_start = self._week_start(now)
         reset_count = 0
@@ -148,7 +135,10 @@ class QuotaService:
             .where(
                 TelegramUser.is_active,
                 (TelegramUser.last_reset_daily.is_(None))
-                | (TelegramUser.last_reset_daily < datetime.combine(today, datetime.min.time())),
+                | (
+                    TelegramUser.last_reset_daily
+                    < datetime.combine(today, datetime.min.time())
+                ),
             )
             .values(daily_used=0, last_reset_daily=now),
             update(TelegramUser)
@@ -169,7 +159,10 @@ class QuotaService:
             .where(
                 TelegramUser.is_active,
                 (TelegramUser.last_reset_issue_daily.is_(None))
-                | (TelegramUser.last_reset_issue_daily < datetime.combine(today, datetime.min.time())),
+                | (
+                    TelegramUser.last_reset_issue_daily
+                    < datetime.combine(today, datetime.min.time())
+                ),
             )
             .values(issue_daily_used=0, last_reset_issue_daily=now),
             update(TelegramUser)
@@ -192,6 +185,7 @@ class QuotaService:
             result = await self.session.execute(stmt)
             reset_count += max(result.rowcount or 0, 0)
 
-        await self.session.commit()
+        if reset_count:
+            await self.session.commit()
         logger.info(f"配额批量原子重置完成，更新字段次数: {reset_count}")
         return reset_count

--- a/backend/services/quota_service.py
+++ b/backend/services/quota_service.py
@@ -1,0 +1,197 @@
+"""用户配额重置服务"""
+
+from datetime import datetime, timedelta
+
+from loguru import logger
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.telegram_models import TelegramUser
+
+
+class QuotaService:
+    """统一处理 PR 与 Issue 配额重置逻辑。"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    @staticmethod
+    def _week_start(now: datetime) -> datetime:
+        week_start = now - timedelta(days=now.weekday())
+        return week_start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def reset_user_pr_quotas_if_expired(user: TelegramUser, now: datetime | None = None) -> bool:
+        """重置单个用户过期的 PR 配额，返回是否发生变更。"""
+        now = now or datetime.utcnow()
+        changed = False
+
+        if user.last_reset_daily is None or user.last_reset_daily.date() < now.date():
+            user.daily_used = 0
+            user.last_reset_daily = now
+            changed = True
+
+        if user.last_reset_weekly is None:
+            user.weekly_used = 0
+            user.last_reset_weekly = now
+            changed = True
+        elif user.last_reset_weekly.date() < now.date():
+            if user.last_reset_weekly < QuotaService._week_start(now):
+                user.weekly_used = 0
+                user.last_reset_weekly = now
+                changed = True
+
+        if user.last_reset_monthly is None:
+            user.monthly_used = 0
+            user.last_reset_monthly = now
+            changed = True
+        elif (
+            user.last_reset_monthly.month != now.month
+            or user.last_reset_monthly.year != now.year
+        ):
+            user.monthly_used = 0
+            user.last_reset_monthly = now
+            changed = True
+
+        return changed
+
+    @staticmethod
+    def reset_user_issue_quotas_if_expired(user: TelegramUser, now: datetime | None = None) -> bool:
+        """重置单个用户过期的 Issue 配额，返回是否发生变更。"""
+        now = now or datetime.utcnow()
+        changed = False
+
+        if (
+            user.last_reset_issue_daily is None
+            or user.last_reset_issue_daily.date() < now.date()
+        ):
+            user.issue_daily_used = 0
+            user.last_reset_issue_daily = now
+            changed = True
+
+        if user.last_reset_issue_weekly is None:
+            user.issue_weekly_used = 0
+            user.last_reset_issue_weekly = now
+            changed = True
+        elif user.last_reset_issue_weekly.date() < now.date():
+            if user.last_reset_issue_weekly < QuotaService._week_start(now):
+                user.issue_weekly_used = 0
+                user.last_reset_issue_weekly = now
+                changed = True
+
+        if user.last_reset_issue_monthly is None:
+            user.issue_monthly_used = 0
+            user.last_reset_issue_monthly = now
+            changed = True
+        elif (
+            user.last_reset_issue_monthly.month != now.month
+            or user.last_reset_issue_monthly.year != now.year
+        ):
+            user.issue_monthly_used = 0
+            user.last_reset_issue_monthly = now
+            changed = True
+
+        return changed
+
+    async def reset_user_quotas_if_expired(
+        self,
+        user: TelegramUser,
+        *,
+        include_pr: bool = True,
+        include_issue: bool = True,
+        commit: bool = True,
+    ) -> bool:
+        """重置单个用户过期配额。"""
+        now = datetime.utcnow()
+        changed = False
+
+        if include_pr:
+            changed = self.reset_user_pr_quotas_if_expired(user, now) or changed
+        if include_issue:
+            changed = self.reset_user_issue_quotas_if_expired(user, now) or changed
+
+        if changed and commit:
+            await self.session.commit()
+
+        return changed
+
+    async def reset_all_expired_quotas(self) -> int:
+        """批量重置所有活跃用户的过期配额，返回发生重置的用户数。"""
+        result = await self.session.execute(
+            select(TelegramUser).where(TelegramUser.is_active)
+        )
+        users = result.scalars().all()
+
+        reset_count = 0
+        now = datetime.utcnow()
+        for user in users:
+            changed = self.reset_user_pr_quotas_if_expired(user, now)
+            changed = self.reset_user_issue_quotas_if_expired(user, now) or changed
+            if changed:
+                reset_count += 1
+
+        if reset_count:
+            await self.session.commit()
+
+        logger.info(f"配额批量重置完成，更新用户数: {reset_count}")
+        return reset_count
+
+    async def reset_all_expired_quotas_atomic(self) -> int:
+        """使用批量 UPDATE 重置所有活跃用户的过期配额。"""
+        now = datetime.utcnow()
+        today = now.date()
+        week_start = self._week_start(now)
+        reset_count = 0
+
+        statements = (
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_daily.is_(None))
+                | (TelegramUser.last_reset_daily < datetime.combine(today, datetime.min.time())),
+            )
+            .values(daily_used=0, last_reset_daily=now),
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_weekly.is_(None))
+                | (TelegramUser.last_reset_weekly < week_start),
+            )
+            .values(weekly_used=0, last_reset_weekly=now),
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_monthly.is_(None))
+                | (TelegramUser.last_reset_monthly < datetime(now.year, now.month, 1)),
+            )
+            .values(monthly_used=0, last_reset_monthly=now),
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_issue_daily.is_(None))
+                | (TelegramUser.last_reset_issue_daily < datetime.combine(today, datetime.min.time())),
+            )
+            .values(issue_daily_used=0, last_reset_issue_daily=now),
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_issue_weekly.is_(None))
+                | (TelegramUser.last_reset_issue_weekly < week_start),
+            )
+            .values(issue_weekly_used=0, last_reset_issue_weekly=now),
+            update(TelegramUser)
+            .where(
+                TelegramUser.is_active,
+                (TelegramUser.last_reset_issue_monthly.is_(None))
+                | (TelegramUser.last_reset_issue_monthly < datetime(now.year, now.month, 1)),
+            )
+            .values(issue_monthly_used=0, last_reset_issue_monthly=now),
+        )
+
+        for stmt in statements:
+            result = await self.session.execute(stmt)
+            reset_count += max(result.rowcount or 0, 0)
+
+        await self.session.commit()
+        logger.info(f"配额批量原子重置完成，更新字段次数: {reset_count}")
+        return reset_count

--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -1,6 +1,5 @@
 """Telegram Bot 服务层"""
 
-from datetime import datetime, timedelta
 from typing import Optional, List, Tuple
 from sqlalchemy import select, and_
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,6 +14,7 @@ from backend.models.telegram_models import (
 )
 from backend.core.config import get_settings
 from backend.services.payment_service import PaymentService, is_payment_enabled
+from backend.services.quota_service import QuotaService
 
 settings = get_settings()
 
@@ -153,43 +153,9 @@ class TelegramService:
 
     async def _reset_expired_quotas(self, user: TelegramUser):
         """重置过期的配额"""
-        now = datetime.utcnow()
-
-        # 每日重置（每天 00:00）
-        if user.last_reset_daily is None or user.last_reset_daily.date() < now.date():
-            user.daily_used = 0
-            user.last_reset_daily = now
-
-        # 每周重置（每周一 00:00）
-        if user.last_reset_weekly is None:
-            user.weekly_used = 0
-            user.last_reset_weekly = now
-        else:
-            # 检查是否跨周
-            if user.last_reset_weekly.date() < now.date():
-                # 获取本周一
-                week_start = now - timedelta(days=now.weekday())
-                week_start = week_start.replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
-                if user.last_reset_weekly < week_start:
-                    user.weekly_used = 0
-                    user.last_reset_weekly = now
-
-        # 每月重置（每月1日 00:00）
-        if user.last_reset_monthly is None:
-            user.monthly_used = 0
-            user.last_reset_monthly = now
-        else:
-            # 检查是否跨月
-            if (
-                user.last_reset_monthly.month != now.month
-                or user.last_reset_monthly.year != now.year
-            ):
-                user.monthly_used = 0
-                user.last_reset_monthly = now
-
-        await self.session.commit()
+        await QuotaService(self.session).reset_user_quotas_if_expired(
+            user, include_pr=True, include_issue=False
+        )
 
     async def check_and_consume_issue_quota(
         self, github_username: str, repo_name: str, issue_number: int
@@ -264,40 +230,9 @@ class TelegramService:
 
     async def _reset_expired_issue_quotas(self, user: TelegramUser):
         """重置过期的 Issue 配额"""
-        now = datetime.utcnow()
-
-        if (
-            user.last_reset_issue_daily is None
-            or user.last_reset_issue_daily.date() < now.date()
-        ):
-            user.issue_daily_used = 0
-            user.last_reset_issue_daily = now
-
-        if user.last_reset_issue_weekly is None:
-            user.issue_weekly_used = 0
-            user.last_reset_issue_weekly = now
-        else:
-            if user.last_reset_issue_weekly.date() < now.date():
-                week_start = now - timedelta(days=now.weekday())
-                week_start = week_start.replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
-                if user.last_reset_issue_weekly < week_start:
-                    user.issue_weekly_used = 0
-                    user.last_reset_issue_weekly = now
-
-        if user.last_reset_issue_monthly is None:
-            user.issue_monthly_used = 0
-            user.last_reset_issue_monthly = now
-        else:
-            if (
-                user.last_reset_issue_monthly.month != now.month
-                or user.last_reset_issue_monthly.year != now.year
-            ):
-                user.issue_monthly_used = 0
-                user.last_reset_issue_monthly = now
-
-        await self.session.commit()
+        await QuotaService(self.session).reset_user_quotas_if_expired(
+            user, include_pr=False, include_issue=True
+        )
 
     async def add_user(
         self,
@@ -406,7 +341,7 @@ class TelegramService:
 
         if await is_payment_enabled():
             await PaymentService(self.session).expire_due_subscriptions(user.id)
-        await self._reset_expired_quotas(user)
+        await QuotaService(self.session).reset_user_quotas_if_expired(user)
 
         return {
             "github_username": user.github_username,
@@ -414,6 +349,18 @@ class TelegramService:
             "daily": {"used": user.daily_used, "limit": user.daily_quota},
             "weekly": {"used": user.weekly_used, "limit": user.weekly_quota},
             "monthly": {"used": user.monthly_used, "limit": user.monthly_quota},
+            "issue_daily": {
+                "used": user.issue_daily_used,
+                "limit": user.issue_daily_quota,
+            },
+            "issue_weekly": {
+                "used": user.issue_weekly_used,
+                "limit": user.issue_weekly_quota,
+            },
+            "issue_monthly": {
+                "used": user.issue_monthly_used,
+                "limit": user.issue_monthly_quota,
+            },
         }
 
     async def list_all_users(self) -> List[TelegramUser]:

--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -98,7 +98,9 @@ class TelegramService:
         # 重置过期配额
         if await is_payment_enabled():
             await PaymentService(self.session).expire_due_subscriptions(user.id)
-        await self._reset_expired_quotas(user)
+        await QuotaService(self.session).reset_user_quotas_if_expired(
+            user, include_pr=True, include_issue=False
+        )
 
         # 使用原子UPDATE操作检查并消耗配额
         # 这个操作是原子的：只有当所有配额都未超限时才会执行递增
@@ -151,12 +153,6 @@ class TelegramService:
         await self.session.commit()
         return True, ""
 
-    async def _reset_expired_quotas(self, user: TelegramUser):
-        """重置过期的配额"""
-        await QuotaService(self.session).reset_user_quotas_if_expired(
-            user, include_pr=True, include_issue=False
-        )
-
     async def check_and_consume_issue_quota(
         self, github_username: str, repo_name: str, issue_number: int
     ):
@@ -174,7 +170,9 @@ class TelegramService:
 
         if await is_payment_enabled():
             await PaymentService(self.session).expire_due_subscriptions(user.id)
-        await self._reset_expired_issue_quotas(user)
+        await QuotaService(self.session).reset_user_quotas_if_expired(
+            user, include_pr=False, include_issue=True
+        )
 
         stmt = (
             update(TelegramUser)
@@ -227,12 +225,6 @@ class TelegramService:
 
         await self.session.commit()
         return True, ""
-
-    async def _reset_expired_issue_quotas(self, user: TelegramUser):
-        """重置过期的 Issue 配额"""
-        await QuotaService(self.session).reset_user_quotas_if_expired(
-            user, include_pr=False, include_issue=True
-        )
 
     async def add_user(
         self,
@@ -341,6 +333,8 @@ class TelegramService:
 
         if await is_payment_enabled():
             await PaymentService(self.session).expire_due_subscriptions(user.id)
+        # 查询配额用于展示时同时重置 PR 和 Issue，避免 Telegram /myquota 显示跨日旧值；
+        # 消耗路径仍只重置对应类型，避免不必要写入。
         await QuotaService(self.session).reset_user_quotas_if_expired(user)
 
         return {
@@ -364,11 +358,22 @@ class TelegramService:
         }
 
     async def list_all_users(self) -> List[TelegramUser]:
-        """列出所有用户"""
+        """列出所有用户，并为展示结果执行惰性配额重置。"""
         result = await self.session.execute(
             select(TelegramUser).where(TelegramUser.is_active)
         )
-        return result.scalars().all()
+        users = result.scalars().all()
+
+        quota_service = QuotaService(self.session)
+        changed = False
+        for user in users:
+            changed = await quota_service.reset_user_quotas_if_expired(
+                user, commit=False
+            ) or changed
+        if changed:
+            await self.session.commit()
+
+        return users
 
     async def list_all_repos(self) -> List[RepoSubscription]:
         """列出所有仓库"""

--- a/backend/telegram/handlers.py
+++ b/backend/telegram/handlers.py
@@ -261,9 +261,9 @@ async def cmd_myquota(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"📆 每周: {quota_info['weekly']['used']}/{quota_info['weekly']['limit']}\n"
             f"🗓️ 每月: {quota_info['monthly']['used']}/{quota_info['monthly']['limit']}\n\n"
             f"📋 *Issue 分析配额*\n"
-            f"📅 每日: {user.issue_daily_used}/{user.issue_daily_quota}\n"
-            f"📆 每周: {user.issue_weekly_used}/{user.issue_weekly_quota}\n"
-            f"🗓️ 每月: {user.issue_monthly_used}/{user.issue_monthly_quota}"
+            f"📅 每日: {quota_info['issue_daily']['used']}/{quota_info['issue_daily']['limit']}\n"
+            f"📆 每周: {quota_info['issue_weekly']['used']}/{quota_info['issue_weekly']['limit']}\n"
+            f"🗓️ 每月: {quota_info['issue_monthly']['used']}/{quota_info['issue_monthly']['limit']}"
         )
 
         await update.message.reply_text(text, parse_mode="Markdown")

--- a/backend/webui/routes/billing.py
+++ b/backend/webui/routes/billing.py
@@ -5,6 +5,7 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.services.payment_service import PaymentError, PaymentService
+from backend.services.quota_service import QuotaService
 from backend.webui.deps import (
     require_auth,
     require_super_admin,
@@ -48,6 +49,8 @@ async def billing_index(
     from backend.models.telegram_models import TelegramUser
 
     db_user = await db.get(TelegramUser, user["user_id"])
+    if db_user:
+        await QuotaService(db).reset_user_quotas_if_expired(db_user)
 
     page = _parse_page(request.query_params.get("page"))
     per_page = user_prefs.get("items_per_page", 20)

--- a/backend/webui/routes/users.py
+++ b/backend/webui/routes/users.py
@@ -88,14 +88,6 @@ async def user_list_fragment(
     users, total, total_pages, page = await paginate(
         db, query, count_query, page, per_page
     )
-    quota_service = QuotaService(db)
-    changed = False
-    for target_user in users:
-        changed = await quota_service.reset_user_quotas_if_expired(
-            target_user, commit=False
-        ) or changed
-    if changed:
-        await db.commit()
 
     return templates.TemplateResponse(
         "components/user_list_fragment.html",

--- a/backend/webui/routes/users.py
+++ b/backend/webui/routes/users.py
@@ -22,6 +22,7 @@ from backend.webui.deps import (
     render_template,
 )
 from backend.core.config import get_settings
+from backend.services.quota_service import QuotaService
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.webui.i18n import detect_language
 
@@ -87,6 +88,14 @@ async def user_list_fragment(
     users, total, total_pages, page = await paginate(
         db, query, count_query, page, per_page
     )
+    quota_service = QuotaService(db)
+    changed = False
+    for target_user in users:
+        changed = await quota_service.reset_user_quotas_if_expired(
+            target_user, commit=False
+        ) or changed
+    if changed:
+        await db.commit()
 
     return templates.TemplateResponse(
         "components/user_list_fragment.html",
@@ -273,6 +282,8 @@ async def user_detail_page(
     target_user = result.scalar_one_or_none()
     if not target_user:
         return error_page(request, message="用户不存在", user=user)
+
+    await QuotaService(db).reset_user_quotas_if_expired(target_user)
 
     # 查询配额使用历史（最近 20 条）
     logs_result = await db.execute(


### PR DESCRIPTION
- Add new QuotaService class with methods to reset PR and issue quotas based on daily/weekly/monthly intervals
- Inject quota reset checks into list_users and get_user API endpoints to reset expired quotas on‑demand
- Create QuotaResetScheduler that runs daily at 00:00 UTC to batch‑reset all expired quotas via APScheduler
- Integrate quota reset scheduler startup and shutdown into FastAPI lifespan
- Add missing _run_quota_reset method implementation to handle batch reset using async_session
- Support conditional scheduler start based on enable_scheduler config flag

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

根据您提供的最新 Commit 信息（88dd78f：重构配额重置逻辑并去重），对原 PR 总结更新如下：

---

### 变更概览  
新增用户配额周期重置机制（每日/每周/每月），并大幅重构配额相关代码，删除重复逻辑与冗余路由。

### 主要改动列表  
- **配额调度服务** (`quota_scheduler.py`)：新增定时任务触发周期重置。  
- **配额核心服务** (`quota_service.py`)：重构 +78/-84 行，封装日/周/月重置策略，去重 PR/Issue 配额逻辑。  
- **移除冗余代码**：  
  - 从 `telegram_service.py` 移除旧配额逻辑（净减 16 行）。  
  - 从 API 和 WebUI 的 `users.py` 移除未使用的重置触发路由（各减 8 行）。  
- **Commit 88dd78f**：进一步去重配额重置逻辑，提升可维护性。

### 影响范围  
后端调度、配额服务、Telegram 交互及用户管理路由；不影响前端接口兼容性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/api/v1/users.py"]
    N2["backend/services/quota_service.py"]
    N3["backend/services/telegram_service.py"]
    N4["backend/webui/routes/users.py"]
    N5["backend/services/quota_scheduler.py"]
    N1 --> N2
    N3 --> N2
    N4 --> N2
```

<!-- sakura-ai-depgraph-end -->