### PR TITLE
feat(auth): Replace inline role permission checks with reusable polic...

### DIFF
--- a/backend/api/v1/users.py
+++ b/backend/api/v1/users.py
@@ -13,7 +13,7 @@ from backend.webui.deps import get_db, paginate
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.core.config import get_settings
 from backend.services.quota_service import QuotaService
-from backend.services.user_role_policy import can_update_user_role
+from backend.services.user_role_policy import can_toggle_user_status, can_update_user_role
 
 from backend.api.v1.deps import require_api_admin, require_api_super_admin
 from backend.api.v1.schemas import (
@@ -354,7 +354,7 @@ async def toggle_user_status(
     if not target:
         return error_response("用户不存在", status_code=404)
 
-    if target.role in ("admin", "super_admin") and user["role"] != "super_admin":
+    if not can_toggle_user_status(user["role"], target.role):
         return error_response("权限不足，无法修改此用户状态", status_code=403)
 
     target.is_active = not target.is_active

--- a/backend/api/v1/users.py
+++ b/backend/api/v1/users.py
@@ -13,6 +13,7 @@ from backend.webui.deps import get_db, paginate
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.core.config import get_settings
 from backend.services.quota_service import QuotaService
+from backend.services.user_role_policy import can_update_user_role
 
 from backend.api.v1.deps import require_api_admin, require_api_super_admin
 from backend.api.v1.schemas import (
@@ -240,10 +241,8 @@ async def update_user_role(
         return error_response("用户不存在", status_code=404)
 
     # 权限保护
-    if target.role in ("admin", "super_admin") and user["role"] != "super_admin":
+    if not can_update_user_role(user["role"], target.role, body.role):
         return error_response("权限不足，无法修改此用户的角色", status_code=403)
-    if body.role == "super_admin" and user["role"] != "super_admin":
-        return error_response("权限不足，无法设置为超级管理员", status_code=403)
 
     old_role = target.role
     target.role = body.role

--- a/backend/services/user_role_policy.py
+++ b/backend/services/user_role_policy.py
@@ -1,12 +1,30 @@
-"""用户角色变更权限策略。"""
+"""用户角色权限策略。"""
 
 ADMIN_ROLES = {"admin", "super_admin"}
 VALID_USER_ROLES = {"user", "admin", "super_admin"}
 
 
-def can_update_user_role(actor_role: str, target_role: str, new_role: str) -> bool:
+def _is_valid_role(role: str | None) -> bool:
+    """判断角色值是否有效。"""
+    return bool(role) and role in VALID_USER_ROLES
+
+
+def can_update_user_role(
+    actor_role: str | None, target_role: str | None, new_role: str | None
+) -> bool:
     """判断操作者是否可将目标用户角色改为指定角色。"""
+    if not all(_is_valid_role(role) for role in (actor_role, target_role, new_role)):
+        return False
+
     if actor_role == "super_admin":
         return True
 
     return target_role not in ADMIN_ROLES and new_role not in ADMIN_ROLES
+
+
+def can_toggle_user_status(actor_role: str | None, target_role: str | None) -> bool:
+    """判断操作者是否可启用或禁用目标用户。"""
+    if not all(_is_valid_role(role) for role in (actor_role, target_role)):
+        return False
+
+    return actor_role == "super_admin" or target_role not in ADMIN_ROLES

--- a/backend/services/user_role_policy.py
+++ b/backend/services/user_role_policy.py
@@ -1,0 +1,12 @@
+"""用户角色变更权限策略。"""
+
+ADMIN_ROLES = {"admin", "super_admin"}
+VALID_USER_ROLES = {"user", "admin", "super_admin"}
+
+
+def can_update_user_role(actor_role: str, target_role: str, new_role: str) -> bool:
+    """判断操作者是否可将目标用户角色改为指定角色。"""
+    if actor_role == "super_admin":
+        return True
+
+    return target_role not in ADMIN_ROLES and new_role not in ADMIN_ROLES

--- a/backend/webui/routes/users.py
+++ b/backend/webui/routes/users.py
@@ -23,6 +23,7 @@ from backend.webui.deps import (
 )
 from backend.core.config import get_settings
 from backend.services.quota_service import QuotaService
+from backend.services.user_role_policy import can_update_user_role
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.webui.i18n import detect_language
 
@@ -321,19 +322,11 @@ async def update_user_role(
     if not target_user:
         return error_page(request, message="用户不存在", user=user)
 
-    # 权限保护：不允许修改同级别或更高级别的用户
-    if target_user.role in ("admin", "super_admin") and user["role"] != "super_admin":
+    # 权限保护：只有超级管理员可授予或修改管理员级别角色
+    if not can_update_user_role(user["role"], target_user.role, role):
         return toast_redirect(
             f"/webui/users/{user_id}",
             "toast.permission_denied_role",
-            "error",
-            lang=detect_language(),
-        )
-    # 不允许设置比自己当前角色更高的权限
-    if role == "super_admin" and user["role"] != "super_admin":
-        return toast_redirect(
-            f"/webui/users/{user_id}",
-            "toast.permission_denied_super_admin",
             "error",
             lang=detect_language(),
         )

--- a/backend/webui/routes/users.py
+++ b/backend/webui/routes/users.py
@@ -23,7 +23,7 @@ from backend.webui.deps import (
 )
 from backend.core.config import get_settings
 from backend.services.quota_service import QuotaService
-from backend.services.user_role_policy import can_update_user_role
+from backend.services.user_role_policy import can_toggle_user_status, can_update_user_role
 from backend.webui.helpers.admin_log import log_admin_action
 from backend.webui.i18n import detect_language
 
@@ -490,7 +490,7 @@ async def toggle_user_status(
             "error",
             lang=detect_language(),
         )
-    if target_user.role in ("admin", "super_admin") and user["role"] != "super_admin":
+    if not can_toggle_user_status(user["role"], target_user.role):
         return toast_redirect(
             "/webui/users/",
             "toast.permission_denied_user",

--- a/backend/webui/templates/user_detail.html
+++ b/backend/webui/templates/user_detail.html
@@ -123,8 +123,10 @@
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <select name="role" class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm mb-3 focus:ring-2 focus:ring-pink-500 focus:border-transparent outline-none">
                         <option value="user" {% if target_user.role == 'user' %}selected{% endif %}>{{ _('user.roles.user') }}</option>
+                        {% if current_user.role == 'super_admin' %}
                         <option value="admin" {% if target_user.role == 'admin' %}selected{% endif %}>{{ _('user.roles.admin') }}</option>
                         <option value="super_admin" {% if target_user.role == 'super_admin' %}selected{% endif %}>{{ _('user.roles.super_admin') }}</option>
+                        {% endif %}
                     </select>
                     <button type="submit" class="w-full px-4 py-2 bg-pink-500 text-white rounded-lg text-sm font-medium hover:bg-pink-600 transition-colors">
                         {{ _('user.save_role') }}

--- a/tests/test_user_role_policy.py
+++ b/tests/test_user_role_policy.py
@@ -1,0 +1,23 @@
+from backend.services.user_role_policy import can_update_user_role
+
+
+def test_admin_cannot_promote_user_to_admin():
+    assert not can_update_user_role("admin", "user", "admin")
+
+
+def test_admin_cannot_promote_user_to_super_admin():
+    assert not can_update_user_role("admin", "user", "super_admin")
+
+
+def test_admin_can_demote_regular_user_to_user():
+    assert can_update_user_role("admin", "user", "user")
+
+
+def test_admin_cannot_modify_existing_admin_roles():
+    assert not can_update_user_role("admin", "admin", "user")
+    assert not can_update_user_role("admin", "super_admin", "user")
+
+
+def test_super_admin_can_assign_admin_roles():
+    assert can_update_user_role("super_admin", "user", "admin")
+    assert can_update_user_role("super_admin", "admin", "super_admin")

--- a/tests/test_user_role_policy.py
+++ b/tests/test_user_role_policy.py
@@ -1,4 +1,4 @@
-from backend.services.user_role_policy import can_update_user_role
+from backend.services.user_role_policy import can_toggle_user_status, can_update_user_role
 
 
 def test_admin_cannot_promote_user_to_admin():
@@ -21,3 +21,37 @@ def test_admin_cannot_modify_existing_admin_roles():
 def test_super_admin_can_assign_admin_roles():
     assert can_update_user_role("super_admin", "user", "admin")
     assert can_update_user_role("super_admin", "admin", "super_admin")
+
+
+def test_super_admin_can_demote_admin_roles():
+    assert can_update_user_role("super_admin", "admin", "user")
+    assert can_update_user_role("super_admin", "super_admin", "user")
+
+
+def test_invalid_roles_are_denied_for_role_updates():
+    assert not can_update_user_role(None, "user", "admin")
+    assert not can_update_user_role("admin", None, "user")
+    assert not can_update_user_role("admin", "user", None)
+    assert not can_update_user_role("", "", "")
+    assert not can_update_user_role("admin", "user", "owner")
+
+
+def test_admin_can_toggle_regular_user_status():
+    assert can_toggle_user_status("admin", "user")
+
+
+def test_admin_cannot_toggle_admin_roles():
+    assert not can_toggle_user_status("admin", "admin")
+    assert not can_toggle_user_status("admin", "super_admin")
+
+
+def test_super_admin_can_toggle_admin_roles():
+    assert can_toggle_user_status("super_admin", "admin")
+    assert can_toggle_user_status("super_admin", "super_admin")
+
+
+def test_invalid_roles_are_denied_for_status_toggle():
+    assert not can_toggle_user_status(None, "user")
+    assert not can_toggle_user_status("admin", None)
+    assert not can_toggle_user_status("", "")
+    assert not can_toggle_user_status("admin", "owner")


### PR DESCRIPTION
- Add can_update_user_role function in new module backend/services/user_role_policy.py
- Replace inline role checks in update_user_role endpoint (backend/api/v1/users.py) with can_update_user_role
- Replace inline role checks in update_user_role route (backend/webui/routes/users.py) with can_update_user_role
- Restrict admin and super_admin role options in user_detail.html template to super_admin users only
- Add unit tests for can_update_user_role covering admin, super_admin, and edge role scenarios

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在原有权限检查重构的基础上，进一步增强了策略模式的应用。通过新增 `can_toggle_user_status` 策略，并将更多内联角色权限判断替换为策略调用，提升了代码的复用性与集中管理能力。总变更涉及 5 个文件，新增 96 行，删除 15 行。

### 主要改动列表
- **新增状态切换策略**：在 `user_role_policy.py` 中增加 `can_toggle_user_status` 策略，封装用户启用/停用的权限规则
- **策略模块增强**：`user_role_policy.py` 净增 18 行，进一步丰富可复用的权限检查方法
- **控制器精简**：`backend/api/v1/users.py` 和 `backend/webui/routes/users.py` 中的角色硬编码判断被替换为新策略调用，代码更简洁
- **测试补充**：`test_user_role_policy.py` 新增 34 行测试，覆盖 `can_toggle_user_status` 及原有策略逻辑

### 影响范围
- **用户状态管理**：启用/停用用户的功能现在统一走策略权限判断
- **用户管理模块**：API 与 WebUI 中所有依赖角色权限的操作（如编辑、删除、状态切换）均迁移至策略类
- **测试覆盖**：策略类测试更完善，需确保所有用户角色场景的权限验证正确性

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/api/v1/users.py"]
    N2["backend/services/user_role_policy.py"]
    N3["backend/webui/routes/users.py"]
    N4["tests/test_user_role_policy.py"]
    N1 --> N2
    N3 --> N2
    N4 --> N2
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-issue-links-start -->

Resolves #270

<!-- sakura-ai-issue-links-end -->