### PR TITLE
feat(dev): Add isolated dev bootstrap mode for local Setup Wizard deb...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ htmlcov/
 
 # Config (contains sensitive database credentials)
 config/connection.json
+.sakura/dev/
 
 # Temporary files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -295,6 +295,18 @@ python -m backend.main
 
 > 首次启动将进入 Bootstrap 模式，访问 `http://localhost:8000/setup` 通过 Setup Wizard 完成配置。
 
+如果只想在本地调试首次部署/Setup Wizard 流程，使用独立的 dev 配置文件启动：
+
+```bash
+py scripts/dev_bootstrap.py
+```
+
+该脚本会使用 `.sakura/dev/connection.json`，不会覆盖正式的 `config/connection.json`，并会跳过 Telegram、SSE、扫描、配额等后台任务。需要重新从第 0 步调试时：
+
+```bash
+py scripts/dev_bootstrap.py --reset
+```
+
 ### 代码检查
 
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -296,6 +296,18 @@ python -m backend.main
 
 > First launch will enter Bootstrap mode. Visit `http://localhost:8000/setup` to complete configuration via Setup Wizard.
 
+To debug the first-run deployment / Setup Wizard flow locally, start with an isolated dev config:
+
+```bash
+py scripts/dev_bootstrap.py
+```
+
+The script uses `.sakura/dev/connection.json`, so it will not overwrite the production `config/connection.json`, and it skips Telegram, SSE, scan, and quota background tasks. To restart from step 0:
+
+```bash
+py scripts/dev_bootstrap.py --reset
+```
+
 ### Code Linting
 
 ```bash

--- a/backend/core/bootstrap.py
+++ b/backend/core/bootstrap.py
@@ -27,16 +27,25 @@ _cache_ts: float = 0
 _CACHE_TTL = 5.0  # 秒
 
 
+def get_connection_config_path() -> Path:
+    """获取当前使用的连接配置路径，支持本地开发脚本隔离配置。"""
+    override = os.getenv("SAKURA_CONNECTION_CONFIG_PATH", "").strip()
+    if override:
+        return Path(override)
+    return CONNECTION_CONFIG_PATH
+
+
 def read_connection_config() -> dict:
     """读取 config/connection.json
 
     Returns:
         连接配置字典，文件不存在时返回空字典
     """
-    if not CONNECTION_CONFIG_PATH.exists():
+    config_path = get_connection_config_path()
+    if not config_path.exists():
         return {}
     try:
-        text = CONNECTION_CONFIG_PATH.read_text(encoding="utf-8")
+        text = config_path.read_text(encoding="utf-8")
         return json.loads(text)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"读取连接配置失败: {e}")
@@ -61,14 +70,15 @@ def write_connection_config(
         config["completed_at"] = datetime.now(timezone.utc).isoformat()
 
     # 确保 config 目录存在
-    CONNECTION_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONNECTION_CONFIG_PATH.write_text(
+    config_path = get_connection_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
         json.dumps(config, indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
     # 限制文件权限为仅所有者可读写（包含数据库凭证等敏感信息）
     try:
-        os.chmod(CONNECTION_CONFIG_PATH, 0o600)
+        os.chmod(config_path, 0o600)
     except OSError:
         logger.debug("无法设置 connection.json 文件权限（Windows 可忽略）")
     clear_bootstrap_cache()
@@ -93,7 +103,8 @@ def check_setup_state() -> SetupState:
     - completed: 文件存在且 setup_completed == True
     - in_progress: 文件存在但 setup_completed != True
     """
-    if not CONNECTION_CONFIG_PATH.exists():
+    config_path = get_connection_config_path()
+    if not config_path.exists():
         return "not_configured"
 
     config = read_connection_config()

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -62,6 +62,18 @@ class Settings(BaseSettings):
     app_domain: str = "localhost"
     app_port: int = 8000
     log_level: str = "INFO"
+    sakura_env: str = Field(
+        "production",
+        description="运行环境标识（production / development）",
+    )
+    sakura_dev_bootstrap: bool = Field(
+        False,
+        description="是否启用本地 Setup Wizard 调试模式",
+    )
+    sakura_skip_background_tasks: bool = Field(
+        False,
+        description="是否跳过 Telegram、SSE、扫描、配额等后台任务",
+    )
 
     # 审查策略配置
     max_file_count: int = 100
@@ -209,6 +221,11 @@ class Settings(BaseSettings):
             if getattr(self, field_name, None) is None:
                 missing.append(field_name)
         return missing
+
+    @property
+    def is_development(self) -> bool:
+        """是否为本地开发环境"""
+        return self.sakura_env.lower() in {"dev", "development", "local"}
 
     @property
     def webhook_url(self) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,29 @@ logger.add("logs/app.log", rotation="500 MB", retention="10 days", level="DEBUG"
 settings = get_settings()
 
 
+def _get_allowed_origins(app_settings) -> list[str]:
+    """构造 CORS origin 列表。开发模式下放行本地调试地址。"""
+    origins = {f"https://{app_settings.app_domain}"}
+    if app_settings.is_development:
+        port = app_settings.app_port
+        origins.update(
+            {
+                f"http://localhost:{port}",
+                f"http://127.0.0.1:{port}",
+                f"https://localhost:{port}",
+                f"https://127.0.0.1:{port}",
+            }
+        )
+    return sorted(origins)
+
+
+def _should_start_background_tasks(app_settings) -> bool:
+    """本地调试 Setup Wizard 时可关闭有外部副作用的后台任务。"""
+    return not (
+        app_settings.sakura_skip_background_tasks or app_settings.sakura_dev_bootstrap
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """应用生命周期管理"""
@@ -105,39 +128,42 @@ async def lifespan(app: FastAPI):
                     f"⚠️ 以下配置项未设置: {', '.join(missing)}，部分功能可能不可用"
                 )
 
-            # 启动 Telegram Bot（后台任务）
-            try:
-                telegram_task = asyncio.create_task(start_telegram_bot())
-                logger.info("✅ Telegram Bot 已启动")
-            except Exception as e:
-                logger.error(f"❌ Telegram Bot 启动失败: {e}")
+            if _should_start_background_tasks(settings):
+                # 启动 Telegram Bot（后台任务）
+                try:
+                    telegram_task = asyncio.create_task(start_telegram_bot())
+                    logger.info("✅ Telegram Bot 已启动")
+                except Exception as e:
+                    logger.error(f"❌ Telegram Bot 启动失败: {e}")
 
-            # 启动 Redis Pub/Sub 监听（SSE 多进程支持）
-            try:
-                from backend.webui.sse import start_redis_listener
+                # 启动 Redis Pub/Sub 监听（SSE 多进程支持）
+                try:
+                    from backend.webui.sse import start_redis_listener
 
-                redis_listener_task = asyncio.create_task(start_redis_listener())
-                logger.info("✅ SSE Redis Pub/Sub 监听已启动")
-            except Exception as e:
-                logger.error(f"❌ SSE Redis Pub/Sub 监听启动失败: {e}")
+                    redis_listener_task = asyncio.create_task(start_redis_listener())
+                    logger.info("✅ SSE Redis Pub/Sub 监听已启动")
+                except Exception as e:
+                    logger.error(f"❌ SSE Redis Pub/Sub 监听启动失败: {e}")
 
-            # 启动仓库扫描调度器
-            try:
-                from backend.services.scan_scheduler import ScanScheduler
+                # 启动仓库扫描调度器
+                try:
+                    from backend.services.scan_scheduler import ScanScheduler
 
-                scan_scheduler = ScanScheduler()
-                scan_scheduler.start()
-            except Exception as e:
-                logger.error(f"❌ 仓库扫描调度器启动失败: {e}")
+                    scan_scheduler = ScanScheduler()
+                    scan_scheduler.start()
+                except Exception as e:
+                    logger.error(f"❌ 仓库扫描调度器启动失败: {e}")
 
-            # 启动配额重置调度器
-            try:
-                from backend.services.quota_scheduler import QuotaResetScheduler
+                # 启动配额重置调度器
+                try:
+                    from backend.services.quota_scheduler import QuotaResetScheduler
 
-                quota_reset_scheduler = QuotaResetScheduler()
-                quota_reset_scheduler.start()
-            except Exception as e:
-                logger.error(f"❌ 配额重置调度器启动失败: {e}")
+                    quota_reset_scheduler = QuotaResetScheduler()
+                    quota_reset_scheduler.start()
+                except Exception as e:
+                    logger.error(f"❌ 配额重置调度器启动失败: {e}")
+            else:
+                logger.warning("🧪 本地开发模式：已跳过后台任务启动")
     else:
         logger.warning("🔧 Bootstrap 模式：仅 Setup Wizard 可用")
         logger.info("请访问 /setup 完成初始配置")
@@ -198,10 +224,9 @@ app = FastAPI(
 )
 
 # 配置CORS
-_allowed_origins = [f"https://{settings.app_domain}"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_allowed_origins,
+    allow_origins=_get_allowed_origins(settings),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ import sys
 import asyncio
 
 from backend import __version__
-from backend.core.config import get_settings
+from backend.core.config import Settings, get_settings
 from backend.core.bootstrap import (
     BootstrapMiddleware,
     is_bootstrap_mode,
@@ -38,7 +38,7 @@ logger.add("logs/app.log", rotation="500 MB", retention="10 days", level="DEBUG"
 settings = get_settings()
 
 
-def _get_allowed_origins(app_settings) -> list[str]:
+def _get_allowed_origins(app_settings: Settings) -> list[str]:
     """构造 CORS origin 列表。开发模式下放行本地调试地址。"""
     origins = {f"https://{app_settings.app_domain}"}
     if app_settings.is_development:
@@ -54,7 +54,7 @@ def _get_allowed_origins(app_settings) -> list[str]:
     return sorted(origins)
 
 
-def _should_start_background_tasks(app_settings) -> bool:
+def _should_start_background_tasks(app_settings: Settings) -> bool:
     """本地调试 Setup Wizard 时可关闭有外部副作用的后台任务。"""
     return not (
         app_settings.sakura_skip_background_tasks or app_settings.sakura_dev_bootstrap

--- a/scripts/dev_bootstrap.py
+++ b/scripts/dev_bootstrap.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+DEFAULT_DEV_CONFIG_PATH = ".sakura/dev/connection.json"
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -18,7 +20,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=8000, help="Bind port")
     parser.add_argument(
         "--config-path",
-        default=".sakura/dev/connection.json",
+        default=DEFAULT_DEV_CONFIG_PATH,
         help="Isolated connection config path for local setup debugging",
     )
     parser.add_argument(
@@ -78,8 +80,13 @@ def main() -> int:
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
+    # SAKURA_ENV enables local runtime conveniences such as localhost CORS.
     env.setdefault("SAKURA_ENV", "development")
+    # SAKURA_DEV_BOOTSTRAP identifies first-run setup debugging and also skips
+    # background tasks if the generic skip flag is not explicitly set.
     env.setdefault("SAKURA_DEV_BOOTSTRAP", "1")
+    # SAKURA_SKIP_BACKGROUND_TASKS is a broader switch that can be reused by CI
+    # or other local runners without implying Setup Wizard debugging.
     env.setdefault("SAKURA_SKIP_BACKGROUND_TASKS", "1")
     env.setdefault("SAKURA_CONNECTION_CONFIG_PATH", str(config_path))
     env.setdefault("APP_DOMAIN", "localhost")
@@ -107,6 +114,7 @@ def main() -> int:
     print("Sakura AI Reviewer 本地 Setup Wizard 调试模式")
     print(f"访问地址: http://{args.host}:{args.port}/setup")
     print(f"连接配置: {config_path}")
+    print("安全提示: dev 配置可能包含数据库凭证，默认路径 .sakura/dev/ 已加入 .gitignore")
     print(f"Python: {server_python}")
     print("后台任务: 已跳过")
     print("")

--- a/scripts/dev_bootstrap.py
+++ b/scripts/dev_bootstrap.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Start Sakura AI Reviewer in local Setup Wizard development mode."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Start local development server for debugging Setup Wizard.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    parser.add_argument(
+        "--config-path",
+        default=".sakura/dev/connection.json",
+        help="Isolated connection config path for local setup debugging",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Delete the isolated dev connection config before starting",
+    )
+    parser.add_argument(
+        "--no-reload",
+        action="store_true",
+        help="Disable uvicorn auto reload",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="debug",
+        choices=("critical", "error", "warning", "info", "debug", "trace"),
+        help="Uvicorn log level",
+    )
+    parser.add_argument(
+        "--python",
+        default="",
+        help="Python executable used to run uvicorn; defaults to .venv if present",
+    )
+    return parser.parse_args()
+
+
+def resolve_config_path(repo_root: Path, path_value: str) -> Path:
+    config_path = Path(path_value)
+    if not config_path.is_absolute():
+        config_path = repo_root / config_path
+    return config_path
+
+
+def find_server_python(repo_root: Path, python_arg: str) -> Path:
+    if python_arg:
+        return Path(python_arg)
+
+    venv_python = repo_root / ".venv" / (
+        "Scripts/python.exe" if os.name == "nt" else "bin/python"
+    )
+    if venv_python.exists():
+        return venv_python
+
+    return Path(sys.executable)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    config_path = resolve_config_path(repo_root, args.config_path)
+    server_python = find_server_python(repo_root, args.python)
+
+    if args.reset and config_path.exists():
+        config_path.unlink()
+        print(f"已重置本地 dev 配置: {config_path}")
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.setdefault("SAKURA_ENV", "development")
+    env.setdefault("SAKURA_DEV_BOOTSTRAP", "1")
+    env.setdefault("SAKURA_SKIP_BACKGROUND_TASKS", "1")
+    env.setdefault("SAKURA_CONNECTION_CONFIG_PATH", str(config_path))
+    env.setdefault("APP_DOMAIN", "localhost")
+    env.setdefault("APP_PORT", str(args.port))
+    env.setdefault("LOG_LEVEL", args.log_level.upper())
+    env.setdefault("WEBUI_COOKIE_SECURE", "false")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("PYTHONUTF8", "1")
+
+    command = [
+        str(server_python),
+        "-m",
+        "uvicorn",
+        "backend.main:app",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--log-level",
+        args.log_level,
+    ]
+    if not args.no_reload:
+        command.append("--reload")
+
+    print("Sakura AI Reviewer 本地 Setup Wizard 调试模式")
+    print(f"访问地址: http://{args.host}:{args.port}/setup")
+    print(f"连接配置: {config_path}")
+    print(f"Python: {server_python}")
+    print("后台任务: 已跳过")
+    print("")
+
+    try:
+        return subprocess.call(command, cwd=repo_root, env=env)
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bootstrap_dev.py
+++ b/tests/test_bootstrap_dev.py
@@ -1,0 +1,24 @@
+"""Bootstrap development mode tests."""
+
+from backend.core.bootstrap import (
+    clear_bootstrap_cache,
+    get_connection_config_path,
+    read_connection_config,
+    write_connection_config,
+)
+
+
+def test_connection_config_path_can_be_overridden(monkeypatch, tmp_path):
+    dev_config = tmp_path / "connection.dev.json"
+    monkeypatch.setenv("SAKURA_CONNECTION_CONFIG_PATH", str(dev_config))
+    clear_bootstrap_cache()
+
+    assert get_connection_config_path() == dev_config
+
+    write_connection_config(
+        "mysql+aiomysql://user:pass@localhost:3306/sakura_dev",
+        setup_completed=True,
+    )
+
+    assert dev_config.exists()
+    assert read_connection_config()["setup_completed"] is True

--- a/tests/test_dev_bootstrap_script.py
+++ b/tests/test_dev_bootstrap_script.py
@@ -1,0 +1,18 @@
+"""Local dev bootstrap script tests."""
+
+from scripts.dev_bootstrap import find_server_python
+
+
+def test_find_server_python_prefers_repo_venv_on_windows(monkeypatch, tmp_path):
+    venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+    monkeypatch.setattr("scripts.dev_bootstrap.os.name", "nt")
+
+    assert find_server_python(tmp_path, "") == venv_python
+
+
+def test_find_server_python_allows_explicit_override(tmp_path):
+    explicit_python = tmp_path / "custom-python"
+
+    assert find_server_python(tmp_path, str(explicit_python)) == explicit_python

--- a/tests/test_dev_bootstrap_script.py
+++ b/tests/test_dev_bootstrap_script.py
@@ -1,6 +1,20 @@
 """Local dev bootstrap script tests."""
 
-from scripts.dev_bootstrap import find_server_python
+from scripts.dev_bootstrap import find_server_python, resolve_config_path
+
+
+def test_resolve_config_path_relative(tmp_path):
+    result = resolve_config_path(tmp_path, "sub/file.json")
+
+    assert result == tmp_path / "sub" / "file.json"
+
+
+def test_resolve_config_path_absolute(tmp_path):
+    abs_path = tmp_path / "abs" / "config.json"
+
+    result = resolve_config_path(tmp_path, str(abs_path))
+
+    assert result == abs_path
 
 
 def test_find_server_python_prefers_repo_venv_on_windows(monkeypatch, tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,6 +53,16 @@ def test_get_allowed_origins_includes_local_development_origins():
     assert "http://127.0.0.1:9000" in origins
 
 
+def test_get_allowed_origins_production_excludes_localhost():
+    settings = Settings(app_domain="example.com", app_port=9000)
+
+    origins = _get_allowed_origins(settings)
+
+    assert "https://example.com" in origins
+    assert "http://localhost:9000" not in origins
+    assert "http://127.0.0.1:9000" not in origins
+
+
 def test_background_tasks_can_be_skipped_for_local_development():
     settings = Settings(sakura_skip_background_tasks=True)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import patch
 
+from backend.core.config import Settings
 from backend.main import _get_webui_error_user
+from backend.main import _get_allowed_origins, _should_start_background_tasks
 
 
 class RequestStub:
@@ -35,3 +37,25 @@ def test_get_webui_error_user_returns_none_without_valid_payload():
 def test_get_webui_error_user_returns_none_when_decode_fails():
     with patch("backend.main.decode_access_token", side_effect=RuntimeError("boom")):
         assert _get_webui_error_user(RequestStub("token")) is None
+
+
+def test_get_allowed_origins_includes_local_development_origins():
+    settings = Settings(
+        sakura_env="development",
+        app_domain="example.com",
+        app_port=9000,
+    )
+
+    origins = _get_allowed_origins(settings)
+
+    assert "https://example.com" in origins
+    assert "http://localhost:9000" in origins
+    assert "http://127.0.0.1:9000" in origins
+
+
+def test_background_tasks_can_be_skipped_for_local_development():
+    settings = Settings(sakura_skip_background_tasks=True)
+
+    assert _should_start_background_tasks(settings) is False
+    assert _should_start_background_tasks(Settings(sakura_dev_bootstrap=True)) is False
+    assert _should_start_background_tasks(Settings()) is True


### PR DESCRIPTION
- Add dev bootstrap script scripts/dev_bootstrap.py with --reset option
- Introduce SAKURA_CONNECTION_CONFIG_PATH env to override connection config path
- Add sakura_env, sakura_dev_bootstrap, sakura_skip_background_tasks settings
- Add Settings.is_development property to detect dev environment
- Implement CORS origin helper that allows localhost in dev mode
- Add _should_start_background_tasks to conditionally skip background tasks
- Wrap Telegram, SSE, scan scheduler, quota scheduler startup with dev skip check
- Update README.md and README_EN.md with dev bootstrap usage documentation

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在之前基础上进一步**完善独立开发引导模式**，为本地 Setup Wizard 调试提供更稳定的隔离环境。共涉及 10 个文件，累计新增 339 行，删除 42 行。

### 主要改动列表
- **优化开发引导脚本** (`scripts/dev_bootstrap.py`)：增强本地调试启动逻辑，新增配置隔离处理（+9/-1）。
- **调整主启动模块** (`backend/main.py`)：改进开发模式集成方式，减少对正常流程的侵入（+3/-3）。
- **扩展配置系统**：增加开发模式相关配置项（此前已完成）。
- **补充单元测试**：新增 `tests/test_main.py` 测试用例，并更新 `tests/test_dev_bootstrap_script.py` 和 `tests/test_main.py`，提升测试覆盖率（共 +25/-1）。

### 影响范围
- **开发环境**：开发者可使用更完善的独立引导脚本进行本地 Setup Wizard 调试，配置完全隔离，不影响生产启动。
- **主启动流程**：开发模式条件分支更清晰，正常模式行为保持不变。
- **测试体系**：新增及更新的测试用例覆盖主流程和引导脚本，提高功能可靠性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/main.py"]
    N2["scripts/dev_bootstrap.py"]
    N3["tests/test_dev_bootstrap_script.py"]
    N4["tests/test_main.py"]
    N3 --> N2
    N4 --> N1
```

<!-- sakura-ai-depgraph-end -->