### PR TITLE
Add user-specific output language configuration

### DIFF
--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -212,6 +212,7 @@ class ReviewWorker:
         task_key = self._make_task_key(pr_info)
         review_obj = None  # 用于保存 GitHub Review 对象
         review_id = None  # 用于保存数据库审查记录 ID
+        output_language = None  # 用户级输出语言；异常路径会复用该值
 
         # Cancel event was already registered in submit_review_task
         # before asyncio.create_task, so cancel_task works immediately

--- a/tests/test_user_config_schema.py
+++ b/tests/test_user_config_schema.py
@@ -4,6 +4,11 @@ import pytest
 from pydantic import ValidationError
 
 from backend.api.v1.schemas import UserConfigUpdateRequest
+from backend.core import config as config_module
+from backend.core.config import (
+    get_user_dynamic_config,
+    validate_user_dynamic_config_value,
+)
 
 
 def test_user_config_update_requires_configs_wrapper():
@@ -22,3 +27,61 @@ def test_user_config_update_rejects_non_scalar_values():
         UserConfigUpdateRequest.model_validate(
             {"configs": {"output_language": ["zh-CN", "en"]}}
         )
+
+
+def test_validate_user_dynamic_config_value_only_allows_safe_keys():
+    with pytest.raises(ValueError, match="不允许用户覆盖"):
+        validate_user_dynamic_config_value("openai_api_key", "secret")
+
+
+@pytest.mark.parametrize("value", ["", "zh-CN", "en", None])
+def test_validate_user_dynamic_config_value_accepts_output_language(value):
+    expected = "" if value is None else value
+
+    assert validate_user_dynamic_config_value("output_language", value) == expected
+
+
+def test_validate_user_dynamic_config_value_rejects_invalid_output_language():
+    with pytest.raises(ValueError, match="output_language"):
+        validate_user_dynamic_config_value("output_language", "ja")
+
+
+@pytest.mark.asyncio
+async def test_get_user_dynamic_config_prefers_user_value(monkeypatch):
+    async def fake_read_user_config_from_db(user_id: int, key: str):
+        assert user_id == 42
+        assert key == "output_language"
+        return "en"
+
+    async def fake_get_dynamic_config(key: str):
+        return "zh-CN"
+
+    monkeypatch.setattr(
+        config_module, "_read_user_config_from_db", fake_read_user_config_from_db
+    )
+    monkeypatch.setattr(config_module, "get_dynamic_config", fake_get_dynamic_config)
+    config_module.invalidate_user_dynamic_config_cache()
+
+    assert await get_user_dynamic_config("output_language", 42) == "en"
+
+    config_module.invalidate_user_dynamic_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_get_user_dynamic_config_falls_back_to_global(monkeypatch):
+    async def fake_read_user_config_from_db(user_id: int, key: str):
+        return None
+
+    async def fake_get_dynamic_config(key: str):
+        assert key == "output_language"
+        return "zh-CN"
+
+    monkeypatch.setattr(
+        config_module, "_read_user_config_from_db", fake_read_user_config_from_db
+    )
+    monkeypatch.setattr(config_module, "get_dynamic_config", fake_get_dynamic_config)
+    config_module.invalidate_user_dynamic_config_cache()
+
+    assert await get_user_dynamic_config("output_language", 42) == "zh-CN"
+
+    config_module.invalidate_user_dynamic_config_cache()


### PR DESCRIPTION
Introduce user-specific output language settings with validation and tests. Implement exception handling for invalid configurations and ensure safe keys are enforced. Add tests to verify acceptance of valid values and rejection of invalid ones, along with functionality to prefer user settings over global defaults.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 新增了用户级别的输出语言配置功能，允许用户自定义系统输出的语言偏好。

### 主要改动列表
- **后端 worker 增强**：在 `review_worker.py` 中引入用户语言配置支持（+1 行）
- **新增配置测试**：创建 `test_user_config_schema.py`，包含 63 行新增测试用例，用于验证用户语言配置的 schema 和逻辑

### 影响范围
- **核心功能**：用户现在可以个性化设置输出语言，提升多语言环境下的使用体验
- **测试覆盖**：新增完整的配置 schema 测试，确保配置的正确性和稳定性
- **影响模块**：主要影响代码审查流程中的输出生成环节，以及用户配置管理部分

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/workers/review_worker.py"]
    N2["tests/test_user_config_schema.py"]
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-issue-links-start -->

Resolves #154

<!-- sakura-ai-issue-links-end -->