### PR TITLE
refactor(tests): Replace utcnow with now in branch name tests

### DIFF
--- a/tests/test_agent_team_git_workspace.py
+++ b/tests/test_agent_team_git_workspace.py
@@ -10,7 +10,7 @@ from backend.services.agent_team.git_workspace_service import (
 def test_make_branch_name_for_issue(monkeypatch):
     class FixedDatetime:
         @staticmethod
-        def utcnow():
+        def now(tz=None):
             return datetime(2026, 5, 9, 12, 34, 56)
 
     monkeypatch.setattr(
@@ -30,7 +30,7 @@ def test_make_branch_name_for_issue(monkeypatch):
 def test_make_branch_name_for_source(monkeypatch):
     class FixedDatetime:
         @staticmethod
-        def utcnow():
+        def now(tz=None):
             return datetime(2026, 5, 9, 12, 34, 56)
 
     monkeypatch.setattr(


### PR DESCRIPTION
- Change utcnow method to now(tz=None) in FixedDatetime class for test_make_branch_name_for_issue
- Change utcnow method to now(tz=None) in FixedDatetime class for test_make_branch_name_for_source

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 对单元测试文件中的时间戳生成方式进行了重构，将已弃用的 `utcnow()` 替换为 `now()`。

### 主要改动列表
- **测试代码适配**：在 `tests/test_agent_team_git_workspace.py` 中，将两处用于生成分支名称的 `utcnow()` 方法调用改为 `now()`。

### 影响范围
- **测试文件**：仅影响分支名称生成的测试逻辑，确保测试在时区环境下的一致性。
- **功能变更**：无业务逻辑变更，仅为测试代码的清理与现代化。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["tests/test_agent_team_git_workspace.py"]
```

<!-- sakura-ai-depgraph-end -->