### PR TITLE
refactor(backend): Reorder configuration logging and move JWT key che...

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -93,16 +93,6 @@ async def lifespan(app: FastAPI):
             # 无法连接数据库，进入 bootstrap 模式引导用户配置
             logger.warning("🔧 因缺少 DATABASE_URL 进入 bootstrap 模式，请访问 /setup")
         else:
-            logger.info(f"📊 日志级别: {settings.log_level}")
-            logger.info(f"🌐 应用域名: {settings.app_domain}")
-            logger.info(f"🤖 OpenAI模型: {settings.openai_model}")
-
-            # 检测默认 JWT 密钥
-            if settings.webui_secret_key == "change-me-in-production":
-                logger.warning(
-                    "⚠️  WebUI JWT 密钥使用默认值！请通过 WebUI 配置页面设置 WEBUI_SECRET_KEY。"
-                )
-
             # 2. 初始化数据库
             try:
                 from backend.models import init_db
@@ -120,6 +110,17 @@ async def lifespan(app: FastAPI):
                 logger.info("✅ 配置已从数据库加载到 Settings")
             except Exception as e:
                 logger.warning(f"⚠️ 加载配置失败: {e}")
+
+            # 打印关键配置（在动态配置加载后，确保显示实际值）
+            logger.info(f"📊 日志级别: {settings.log_level}")
+            logger.info(f"🌐 应用域名: {settings.app_domain}")
+            logger.info(f"🤖 OpenAI模型: {settings.openai_model}")
+
+            # 检测默认 JWT 密钥（必须在动态配置加载后检查）
+            if settings.webui_secret_key == "change-me-in-production":
+                logger.warning(
+                    "⚠️  WebUI JWT 密钥使用默认值！请通过 WebUI 配置页面设置 WEBUI_SECRET_KEY。"
+                )
 
             # 4. 动态配置加载后再次校验必填字段（仅警告，不阻止启动）
             missing = settings.validate_required_fields()


### PR DESCRIPTION
- Move log output for log level, app domain, and OpenAI model after dynamic configuration loading in lifespan
- Relocate default JWT secret key warning block to execute after settings are fully loaded
- Remove redundant logging and warning statements from earlier position in bootstrap flow

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 对后端启动流程进行了重构，调整了配置日志的输出顺序，并移动了 JWT 密钥的检查逻辑。

### 主要改动列表
- **调整日志顺序**：将配置信息的打印提前，确保在后续检查前完成基础配置输出。
- **移动 JWT 密钥检查**：将 JWT 密钥的检查逻辑迁移到更合适的位置，优化启动阶段的执行流程。

### 影响范围
- **文件**：`backend/main.py`
- **功能**：仅影响应用启动时的内部执行顺序，不改变业务逻辑或 API 行为。对开发者调试启动日志的阅读顺序可能有轻微影响。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/main.py"]
```

<!-- sakura-ai-depgraph-end -->