### PR TITLE
feat(i18n): Add agent skill installation toast messages for en and zh-CN

### DIFF
--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1063,6 +1063,8 @@ toast:
   passkey_login_failed: "Passkey login failed. Please try again."
   user_not_found: "User not found or disabled"
   config_saved_restart: "Configuration saved (some changes require restart)"
+  agent_skill_installed: "Skill installed successfully"
+  agent_skill_install_failed: "Skill installation failed"
   config_saved_live: "Configuration saved and applied"
   config_validation_failed: "Configuration validation failed: {error}"
   file_permission_denied: "File permission denied"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1063,6 +1063,8 @@ toast:
   passkey_login_failed: "通行密钥登录失败，请重试"
   user_not_found: "用户不存在或已禁用"
   config_saved_restart: "全局配置已保存（部分配置需重启后生效）"
+  agent_skill_installed: "Skill 安装成功"
+  agent_skill_install_failed: "Skill 安装失败"
   config_saved_live: "全局配置已保存并即时生效"
   config_validation_failed: "配置验证失败: {error}"
   file_permission_denied: "文件权限不足"


### PR DESCRIPTION
- Add "agent_skill_installed" and "agent_skill_install_failed" keys to en.yaml toast section
- Add corresponding Chinese translations in zh-CN.yaml toast section