### PR TITLE
refactor(webui): Remove `/webui` prefix from WebUI routes and update ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)
-[![Live Demo](https://img.shields.io/badge/🌐_免费体验-Online-success.svg)](https://pr-bot.firefly520.top/webui)
+[![Live Demo](https://img.shields.io/badge/🌐_免费体验-Online-success.svg)](https://pr-bot.firefly520.top/)
 [![Android App](https://img.shields.io/badge/Android_App-🚧_开发中-orange.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer-APP)
 
 ---
@@ -175,7 +175,7 @@ cd Sakura-AI-Reviewer
 6. 创建后，在 App 页面底部 **Generate a private key**，下载 `.pem` 文件（Setup Wizard 中需粘贴完整私钥内容）
 7. 点击左侧 **Install App**，选择要启用审查的仓库
 
-> WebUI 登录需额外创建 [OAuth App](https://github.com/settings/developers)，回调地址设为 `https://your-domain.com/webui/auth/callback`
+> WebUI 登录需额外创建 [OAuth App](https://github.com/settings/developers)，回调地址设为 `https://your-domain.com/auth/callback`
 
 ### 4. 准备数据库
 
@@ -215,7 +215,7 @@ curl http://your-domain.com:8000/health
 # {"status":"healthy","service":"Sakura AI Reviewer"}
 ```
 
-WebUI：`https://your-domain.com/webui/`
+WebUI：`https://your-domain.com/`
 
 ---
 
@@ -237,7 +237,7 @@ WebUI：`https://your-domain.com/webui/`
 
 ### WebUI 管理
 
-访问 `https://your-domain.com/webui/`，使用 GitHub 账号登录（需先在 Telegram Bot 中注册）。支持仪表盘图表、PR 管理、用户管理、动态配置管理、审查队列监控、操作日志、安全中心、个人 MFA/Passkey 设置等功能。配置修改即时生效，无需重启服务。
+访问 `https://your-domain.com/`，使用 GitHub 账号登录（需先在 Telegram Bot 中注册）。支持仪表盘图表、PR 管理、用户管理、动态配置管理、审查队列监控、操作日志、安全中心、个人 MFA/Passkey 设置等功能。配置修改即时生效，无需重启服务。
 
 ### Telegram Bot
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)
-[![Live Demo](https://img.shields.io/badge/🌐_Free_Demo-Online-success.svg)](https://pr-bot.firefly520.top/webui)
+[![Live Demo](https://img.shields.io/badge/🌐_Free_Demo-Online-success.svg)](https://pr-bot.firefly520.top/)
 [![Android App](https://img.shields.io/badge/Android_App-🚧_In_Development-orange.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer-APP)
 
 ---
@@ -176,7 +176,7 @@ cd Sakura-AI-Reviewer
 6. After creation, click **Generate a private key** at the bottom of the App page, download the `.pem` file (paste the full private key content in Setup Wizard)
 7. Click **Install App** on the left sidebar, select the repositories to enable review
 
-> WebUI login requires an additional [OAuth App](https://github.com/settings/developers) with callback URL set to `https://your-domain.com/webui/auth/callback`
+> WebUI login requires an additional [OAuth App](https://github.com/settings/developers) with callback URL set to `https://your-domain.com/auth/callback`
 
 ### 4. Prepare the Database
 
@@ -216,7 +216,7 @@ curl http://your-domain.com:8000/health
 # {"status":"healthy","service":"Sakura AI Reviewer"}
 ```
 
-WebUI: `https://your-domain.com/webui/`
+WebUI: `https://your-domain.com/`
 
 ---
 
@@ -238,7 +238,7 @@ Create a PR in a repository with the App installed, and the AI will automaticall
 
 ### WebUI Management
 
-Visit `https://your-domain.com/webui/` and log in with your GitHub account (requires prior registration via Telegram Bot). Features include dashboard charts, PR management, user management, dynamic configuration, review queue monitoring, action logs, Security Center, and personal MFA/Passkey settings. Configuration changes take effect immediately without service restart.
+Visit `https://your-domain.com/` and log in with your GitHub account (requires prior registration via Telegram Bot). Features include dashboard charts, PR management, user management, dynamic configuration, review queue monitoring, action logs, Security Center, and personal MFA/Passkey settings. Configuration changes take effect immediately without service restart.
 
 ### Telegram Bot
 

--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -89,7 +89,7 @@ async def github_authorize(request: Request):
         return error_response("GitHub OAuth 回调地址未配置", status_code=500)
 
     state = secrets.token_urlsafe(32)
-    await _save_oauth_state(state, "/webui/")
+    await _save_oauth_state(state, "/")
 
     params = {
         "client_id": settings.github_oauth_client_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -254,11 +254,16 @@ _WEBUI_RATE_LIMIT_JSON_SUFFIXES = frozenset(
 )
 
 
+def _is_webui_path(path: str) -> bool:
+    """Check whether *path* belongs to the WebUI surface (not API/setup/docs)."""
+    return not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health"))
+
+
 @app.exception_handler(RateLimitExceeded)
 async def rate_limit_exception_handler(request: Request, exc: RateLimitExceeded):
     """Return WebUI-friendly rate limit feedback instead of raw JSON pages."""
     path = request.url.path
-    if path.startswith("/webui"):
+    if _is_webui_path(path):
         message = "toast.rate_limit_exceeded"
         if request.headers.get("hx-request") == "true":
             return JSONResponse(
@@ -278,7 +283,7 @@ async def rate_limit_exception_handler(request: Request, exc: RateLimitExceeded)
         redirect_url = (
             referer
             if referer and referer.startswith(str(request.base_url))
-            else "/webui/"
+            else "/"
         )
         return toast_redirect(redirect_url, message, "error", status_code=303)
     return await _rate_limit_exceeded_handler(request, exc)
@@ -308,14 +313,15 @@ def _get_webui_error_user(request: Request) -> dict | None:
 
 @app.exception_handler(HTTPException)
 async def auth_exception_handler(request: Request, exc: HTTPException):
-    if exc.status_code == 401 and request.url.path.startswith("/webui"):
-        return RedirectResponse(url="/webui/auth/login", status_code=302)
-    if exc.status_code == 428 and request.url.path.startswith("/webui"):
+    path = request.url.path
+    if exc.status_code == 401 and _is_webui_path(path):
+        return RedirectResponse(url="/auth/login", status_code=302)
+    if exc.status_code == 428 and _is_webui_path(path):
         return RedirectResponse(
-            url="/webui/settings/?_toast=MFA%20enrollment%20required&_toast_type=error",
+            url="/settings/?_toast=MFA%20enrollment%20required&_toast_type=error",
             status_code=302,
         )
-    if request.url.path.startswith("/webui"):
+    if _is_webui_path(path):
         return error_page(
             request,
             status_code=exc.status_code,
@@ -324,17 +330,6 @@ async def auth_exception_handler(request: Request, exc: HTTPException):
             user=_get_webui_error_user(request),
         )
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
-
-
-@app.get("/")
-async def root():
-    """根路径"""
-    return {
-        "service": "Sakura AI Reviewer",
-        "version": __version__,
-        "status": "running",
-        "docs": "/docs",
-    }
 
 
 @app.get("/health")

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from backend.core.bootstrap import (
 from backend.webui.routes.setup import router as setup_router
 from backend.api import webhook
 from backend.webui.routes import webui_router
-from backend.webui.deps import _is_webui_path, error_page, toast_redirect
+from backend.webui.deps import is_webui_path, error_page, toast_redirect
 from backend.webui.auth import decode_access_token
 from backend.api.v1 import api_v1_router
 from backend.api.v1.deps import limiter
@@ -258,7 +258,7 @@ _WEBUI_RATE_LIMIT_JSON_SUFFIXES = frozenset(
 async def rate_limit_exception_handler(request: Request, exc: RateLimitExceeded):
     """Return WebUI-friendly rate limit feedback instead of raw JSON pages."""
     path = request.url.path
-    if _is_webui_path(path):
+    if is_webui_path(path):
         message = "toast.rate_limit_exceeded"
         if request.headers.get("hx-request") == "true":
             return JSONResponse(
@@ -309,14 +309,14 @@ def _get_webui_error_user(request: Request) -> dict | None:
 @app.exception_handler(HTTPException)
 async def auth_exception_handler(request: Request, exc: HTTPException):
     path = request.url.path
-    if exc.status_code == 401 and _is_webui_path(path):
+    if exc.status_code == 401 and is_webui_path(path):
         return RedirectResponse(url="/auth/login", status_code=302)
-    if exc.status_code == 428 and _is_webui_path(path):
+    if exc.status_code == 428 and is_webui_path(path):
         return RedirectResponse(
             url="/settings/?_toast=MFA%20enrollment%20required&_toast_type=error",
             status_code=302,
         )
-    if _is_webui_path(path):
+    if is_webui_path(path):
         return error_page(
             request,
             status_code=exc.status_code,

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from backend.core.bootstrap import (
 from backend.webui.routes.setup import router as setup_router
 from backend.api import webhook
 from backend.webui.routes import webui_router
-from backend.webui.deps import error_page, toast_redirect
+from backend.webui.deps import _is_webui_path, error_page, toast_redirect
 from backend.webui.auth import decode_access_token
 from backend.api.v1 import api_v1_router
 from backend.api.v1.deps import limiter
@@ -252,11 +252,6 @@ _WEBUI_RATE_LIMIT_JSON_SUFFIXES = frozenset(
         "/passkeys/register/verify",
     }
 )
-
-
-def _is_webui_path(path: str) -> bool:
-    """Check whether *path* belongs to the WebUI surface (not API/setup/docs)."""
-    return not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health"))
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from backend.core.bootstrap import (
 from backend.webui.routes.setup import router as setup_router
 from backend.api import webhook
 from backend.webui.routes import webui_router
-from backend.webui.deps import is_webui_path, error_page, toast_redirect
+from backend.webui.deps import is_webui_request, error_page, toast_redirect
 from backend.webui.auth import decode_access_token
 from backend.api.v1 import api_v1_router
 from backend.api.v1.deps import limiter
@@ -258,7 +258,7 @@ _WEBUI_RATE_LIMIT_JSON_SUFFIXES = frozenset(
 async def rate_limit_exception_handler(request: Request, exc: RateLimitExceeded):
     """Return WebUI-friendly rate limit feedback instead of raw JSON pages."""
     path = request.url.path
-    if is_webui_path(path):
+    if is_webui_request(request):
         message = "toast.rate_limit_exceeded"
         if request.headers.get("hx-request") == "true":
             return JSONResponse(
@@ -308,15 +308,14 @@ def _get_webui_error_user(request: Request) -> dict | None:
 
 @app.exception_handler(HTTPException)
 async def auth_exception_handler(request: Request, exc: HTTPException):
-    path = request.url.path
-    if exc.status_code == 401 and is_webui_path(path):
+    if exc.status_code == 401 and is_webui_request(request):
         return RedirectResponse(url="/auth/login", status_code=302)
-    if exc.status_code == 428 and is_webui_path(path):
+    if exc.status_code == 428 and is_webui_request(request):
         return RedirectResponse(
             url="/settings/?_toast=MFA%20enrollment%20required&_toast_type=error",
             status_code=302,
         )
-    if is_webui_path(path):
+    if is_webui_request(request):
         return error_page(
             request,
             status_code=exc.status_code,

--- a/backend/services/scan_report_service.py
+++ b/backend/services/scan_report_service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 from loguru import logger
 
 from backend.core.config import get_settings
+from backend.webui.deps import get_webui_url
 
 if TYPE_CHECKING:
     from backend.models.scan_models import RepoScan, ScanFinding
@@ -218,7 +219,7 @@ class ScanReportService:
         if link_url:
             lines.append(f"[📎 查看详细报告]({link_url})")
         else:
-            webui_url = f"https://{settings.app_domain}/scans/{scan.id}"
+            webui_url = get_webui_url(f"/scans/{scan.id}")
             lines.append(f"[🌐 WebUI 查看详情]({webui_url})")
 
         return "\n".join(lines)

--- a/backend/services/scan_report_service.py
+++ b/backend/services/scan_report_service.py
@@ -218,7 +218,7 @@ class ScanReportService:
         if link_url:
             lines.append(f"[📎 查看详细报告]({link_url})")
         else:
-            webui_url = f"https://{settings.app_domain}/webui/scans/{scan.id}"
+            webui_url = f"https://{settings.app_domain}/scans/{scan.id}"
             lines.append(f"[🌐 WebUI 查看详情]({webui_url})")
 
         return "\n".join(lines)

--- a/backend/telegram/handlers.py
+++ b/backend/telegram/handlers.py
@@ -197,7 +197,7 @@ async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"👥 注册用户: {len(users)} 人\n"
             f"📦 授权仓库: {len(repos)} 个\n"
             f"🤖 AI模型: {settings.openai_model}\n"
-            f"🌐 应用域名: {settings.app_domain}/webui\n"
+            f"🌐 应用域名: {settings.app_domain}/\n"
         )
 
         await update.message.reply_text(text, parse_mode="Markdown")

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -152,6 +152,14 @@ async def get_db() -> AsyncSession:
         yield session
 
 
+def _is_webui_path(path: str) -> bool:
+    """Check whether *path* belongs to the WebUI surface (not API/setup/docs).
+
+    When adding new non-WebUI root routes, update the exclusion list.
+    """
+    return not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health"))
+
+
 def request_origin(request: Request) -> str:
     """Return request Origin, falling back to scheme + host."""
     return (
@@ -208,7 +216,7 @@ async def enforce_mfa_enrollment(
     if not await user_requires_mfa_enrollment(user_id, db):
         return
     path = request.url.path
-    if not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health")):
+    if _is_webui_path(path):
         if _is_mfa_enrollment_path(path):
             return
         raise HTTPException(status_code=428, detail="mfa_enrollment_required")

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -152,7 +152,7 @@ async def get_db() -> AsyncSession:
         yield session
 
 
-def _is_webui_path(path: str) -> bool:
+def is_webui_path(path: str) -> bool:
     """Check whether *path* belongs to the WebUI surface (not API/setup/docs).
 
     When adding new non-WebUI root routes, update the exclusion list.
@@ -216,7 +216,7 @@ async def enforce_mfa_enrollment(
     if not await user_requires_mfa_enrollment(user_id, db):
         return
     path = request.url.path
-    if _is_webui_path(path):
+    if is_webui_path(path):
         if _is_mfa_enrollment_path(path):
             return
         raise HTTPException(status_code=428, detail="mfa_enrollment_required")

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -152,12 +152,28 @@ async def get_db() -> AsyncSession:
         yield session
 
 
-def is_webui_path(path: str) -> bool:
-    """Check whether *path* belongs to the WebUI surface (not API/setup/docs).
+async def mark_webui_request(request: Request):
+    """Mark the request as originating from a WebUI route."""
+    request.state.is_webui = True
 
-    When adding new non-WebUI root routes, update the exclusion list.
+
+def is_webui_request(request: Request) -> bool:
+    """Check whether the request belongs to the WebUI surface.
+
+    Relies on the explicit ``mark_webui_request`` dependency attached to
+    ``webui_router``.  Non-WebUI routes (API, setup, docs) never carry this
+    mark, so no exclusion list needs to be maintained.
     """
-    return not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health"))
+    return getattr(request.state, "is_webui", False)
+
+
+def get_webui_url(path: str = "") -> str:
+    """Build an absolute WebUI URL for external consumption (Telegram, GitHub, etc.).
+
+    ``path`` should start with ``/`` (e.g. ``"/scans/42"``).
+    """
+    domain = get_settings().app_domain
+    return f"https://{domain}{path}"
 
 
 def request_origin(request: Request) -> str:
@@ -216,7 +232,7 @@ async def enforce_mfa_enrollment(
     if not await user_requires_mfa_enrollment(user_id, db):
         return
     path = request.url.path
-    if is_webui_path(path):
+    if is_webui_request(request):
         if _is_mfa_enrollment_path(path):
             return
         raise HTTPException(status_code=428, detail="mfa_enrollment_required")

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -162,14 +162,14 @@ def request_origin(request: Request) -> str:
 def _is_mfa_enrollment_path(path: str) -> bool:
     """Return whether a WebUI path is allowed while forced MFA enrollment is pending."""
     allowed_exact = {
-        "/webui/settings/",
-        "/webui/auth/logout",
+        "/settings/",
+        "/auth/logout",
     }
     allowed_prefixes = (
-        "/webui/settings/2fa/",
-        "/webui/settings/passkeys/",
-        "/webui/auth/",
-        "/webui/static/",
+        "/settings/2fa/",
+        "/settings/passkeys/",
+        "/auth/",
+        "/static/",
     )
     return path in allowed_exact or any(
         path.startswith(prefix) for prefix in allowed_prefixes
@@ -208,7 +208,7 @@ async def enforce_mfa_enrollment(
     if not await user_requires_mfa_enrollment(user_id, db):
         return
     path = request.url.path
-    if path.startswith("/webui"):
+    if not path.startswith(("/api/", "/setup", "/docs", "/openapi.json", "/redoc", "/health")):
         if _is_mfa_enrollment_path(path):
             return
         raise HTTPException(status_code=428, detail="mfa_enrollment_required")

--- a/backend/webui/routes/__init__.py
+++ b/backend/webui/routes/__init__.py
@@ -21,6 +21,8 @@ from backend.webui.routes import (
     agent_skills,
 )
 
+# WebUI routes are mounted at root (no prefix) so the dashboard is served at /.
+# The router prefix is kept as an explicit empty string to document this intent.
 webui_router = APIRouter(prefix="")
 
 webui_router.include_router(auth.router)

--- a/backend/webui/routes/__init__.py
+++ b/backend/webui/routes/__init__.py
@@ -1,6 +1,7 @@
 """WebUI 路由"""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from backend.webui.deps import mark_webui_request
 from backend.webui.routes import (
     auth,
     dashboard,
@@ -23,7 +24,10 @@ from backend.webui.routes import (
 
 # WebUI routes are mounted at root (no prefix) so the dashboard is served at /.
 # The router prefix is kept as an explicit empty string to document this intent.
-webui_router = APIRouter(prefix="")
+# Every request hitting a WebUI route carries ``request.state.is_webui = True``
+# via the ``mark_webui_request`` dependency, so error handlers can distinguish
+# WebUI pages from API/setup/docs routes without exclusion lists.
+webui_router = APIRouter(prefix="", dependencies=[Depends(mark_webui_request)])
 
 webui_router.include_router(auth.router)
 webui_router.include_router(dashboard.router)

--- a/backend/webui/routes/__init__.py
+++ b/backend/webui/routes/__init__.py
@@ -21,7 +21,7 @@ from backend.webui.routes import (
     agent_skills,
 )
 
-webui_router = APIRouter(prefix="/webui")
+webui_router = APIRouter(prefix="")
 
 webui_router.include_router(auth.router)
 webui_router.include_router(dashboard.router)

--- a/backend/webui/routes/agent_skills.py
+++ b/backend/webui/routes/agent_skills.py
@@ -76,7 +76,7 @@ async def upload_skill(
     lang = detect_language(user_prefs)
     if not skill_file.filename:
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_invalid_file",
             "error",
             lang=lang,
@@ -85,7 +85,7 @@ async def upload_skill(
     lower_name = skill_file.filename.lower()
     if not (lower_name.endswith(".md") or lower_name.endswith(".zip")):
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_invalid_file",
             "error",
             lang=lang,
@@ -109,14 +109,14 @@ async def upload_skill(
             {"slug": skill.slug, "name": skill.name},
         )
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_installed",
             lang=lang,
             slug=skill.slug,
         )
     except Exception as exc:
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_install_failed",
             "error",
             lang=lang,
@@ -149,14 +149,14 @@ async def install_skill_from_github(
             {"slug": skill.slug, "source_url": github_url},
         )
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_installed",
             lang=lang,
             slug=skill.slug,
         )
     except Exception as exc:
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_install_failed",
             "error",
             lang=lang,
@@ -187,13 +187,13 @@ async def toggle_skill(
             {"slug": skill.slug, "enabled": is_enabled},
         )
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_updated",
             lang=lang,
         )
     except Exception as exc:
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_update_failed",
             "error",
             lang=lang,
@@ -222,13 +222,13 @@ async def delete_skill(
             {"slug": skill.slug, "name": skill.name},
         )
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_deleted",
             lang=lang,
         )
     except Exception as exc:
         return toast_redirect(
-            "/webui/agent-skills/",
+            "/agent-skills/",
             "toast.agent_skill_delete_failed",
             "error",
             lang=lang,

--- a/backend/webui/routes/agent_team.py
+++ b/backend/webui/routes/agent_team.py
@@ -335,7 +335,7 @@ async def save_agent_team_config(
                 num_val = float(val)
             except ValueError:
                 return toast_redirect(
-                    "/webui/agent-team/",
+                    "/agent-team/",
                     "toast.numeric_required",
                     "error",
                     lang=detect_language(),
@@ -343,7 +343,7 @@ async def save_agent_team_config(
                 )
             if not (min_v <= num_val <= max_v):
                 return toast_redirect(
-                    "/webui/agent-team/",
+                    "/agent-team/",
                     "toast.value_range",
                     "error",
                     lang=detect_language(),
@@ -356,7 +356,7 @@ async def save_agent_team_config(
             valid_values = [opt["value"] for opt in DYNAMIC_CONFIG_SELECT_OPTIONS[key]]
             if val not in valid_values:
                 return toast_redirect(
-                    "/webui/agent-team/",
+                    "/agent-team/",
                     "toast.value_invalid",
                     "error",
                     lang=detect_language(),
@@ -385,7 +385,7 @@ async def save_agent_team_config(
 
     if not changed:
         return toast_redirect(
-            "/webui/agent-team/", "toast.config_saved_live", lang=detect_language()
+            "/agent-team/", "toast.config_saved_live", lang=detect_language()
         )
 
     await db.commit()
@@ -408,7 +408,7 @@ async def save_agent_team_config(
         log_changed,
     )
     return toast_redirect(
-        "/webui/agent-team/", "toast.config_saved_live", lang=detect_language()
+        "/agent-team/", "toast.config_saved_live", lang=detect_language()
     )
 
 

--- a/backend/webui/routes/auth.py
+++ b/backend/webui/routes/auth.py
@@ -209,7 +209,7 @@ async def login_page(request: Request):
     # 已登录则跳转仪表盘
     token = request.cookies.get("webui_token")
     if token and decode_access_token(token):
-        return toast_redirect("/webui/", "toast.auto_logged_in", lang=detect_language())
+        return toast_redirect("/", "toast.auto_logged_in", lang=detect_language())
 
     settings = get_settings()
     has_oauth = bool(settings.github_oauth_client_id)
@@ -251,7 +251,7 @@ async def github_login(request: Request):
 
     # 生成 state 防止 CSRF
     state = secrets.token_urlsafe(32)
-    await _save_oauth_state(state, "/webui/")
+    await _save_oauth_state(state, "/")
 
     params = {
         "client_id": settings.github_oauth_client_id,
@@ -389,7 +389,7 @@ async def github_callback(
     if has_mfa_method:
         mfa_token = create_mfa_pending_token(token_data)
         logger.info(f"GitHub OAuth 需要二次验证: {github_username} (role={user.role})")
-        response = RedirectResponse(url="/webui/auth/2fa", status_code=302)
+        response = RedirectResponse(url="/auth/2fa", status_code=302)
         _set_mfa_pending_cookie(response, mfa_token)
         response.delete_cookie("webui_token")
         return response
@@ -409,7 +409,7 @@ async def two_factor_page(request: Request):
     token = request.cookies.get(MFA_PENDING_COOKIE_NAME)
     payload = decode_access_token(token) if token else None
     if not is_mfa_pending_payload(payload):
-        return toast_redirect("/webui/auth/login", "toast.login_required", "error")
+        return toast_redirect("/auth/login", "toast.login_required", "error")
 
     user_id = payload.get("user_id")
     async with db_module.async_session() as session:
@@ -421,7 +421,7 @@ async def two_factor_page(request: Request):
         )
         user = result.scalar_one_or_none()
         if not user or not await user_has_any_mfa_method(session, user):
-            return toast_redirect("/webui/auth/login", "toast.login_required", "error")
+            return toast_redirect("/auth/login", "toast.login_required", "error")
         totp_enabled = bool(user.totp_enabled)
 
     return render_template(
@@ -449,7 +449,7 @@ async def verify_two_factor(
     token = request.cookies.get(MFA_PENDING_COOKIE_NAME)
     payload = decode_access_token(token) if token else None
     if not is_mfa_pending_payload(payload):
-        return toast_redirect("/webui/auth/login", "toast.login_required", "error")
+        return toast_redirect("/auth/login", "toast.login_required", "error")
 
     user_id = payload.get("user_id")
     async with db_module.async_session() as session:
@@ -461,7 +461,7 @@ async def verify_two_factor(
         )
         user = result.scalar_one_or_none()
         if not user or not await user_has_any_mfa_method(session, user):
-            return toast_redirect("/webui/auth/login", "toast.login_required", "error")
+            return toast_redirect("/auth/login", "toast.login_required", "error")
 
         # Check lockout before attempting verification
         try:
@@ -533,7 +533,7 @@ async def verify_two_factor(
         }
     )
     logger.info("WebUI 二次验证成功: user={}", payload.get("sub"))
-    response = RedirectResponse(url="/webui/", status_code=302)
+    response = RedirectResponse(url="/", status_code=302)
     _set_webui_token_cookie(response, jwt_token)
     response.delete_cookie(MFA_PENDING_COOKIE_NAME)
     return response
@@ -629,7 +629,7 @@ async def two_factor_passkey_verify(
         }
     )
     response = JSONResponse(
-        content={"success": True, "message": "ok", "data": {"redirect": "/webui/"}}
+        content={"success": True, "message": "ok", "data": {"redirect": "/"}}
     )
     _set_webui_token_cookie(response, jwt_token)
     response.delete_cookie(MFA_PENDING_COOKIE_NAME)
@@ -644,7 +644,7 @@ async def logout(request: Request, csrf_token: str = Form(...)):
 
     logger.info("WebUI 用户登出")
     response = toast_redirect(
-        "/webui/auth/login", "toast.logged_out", lang=detect_language()
+        "/auth/login", "toast.logged_out", lang=detect_language()
     )
     response.delete_cookie("webui_token")
     response.delete_cookie(MFA_PENDING_COOKIE_NAME)
@@ -751,7 +751,7 @@ async def passkey_verify_discover(request: Request, body: dict = Body(...)):
     jwt_token = create_access_token(token_payload)
     logger.info("Passkey 直接登录成功: user={}", token_payload["sub"])
     response = JSONResponse(
-        content={"success": True, "message": "ok", "data": {"redirect": "/webui/"}}
+        content={"success": True, "message": "ok", "data": {"redirect": "/"}}
     )
     _set_webui_token_cookie(response, jwt_token)
     response.delete_cookie(MFA_PENDING_COOKIE_NAME)

--- a/backend/webui/routes/billing.py
+++ b/backend/webui/routes/billing.py
@@ -87,7 +87,7 @@ async def redeem_code(
     code = code.strip().upper()
     if not code:
         return toast_redirect(
-            "/webui/billing/", "toast.code_required", "error", lang=detect_language()
+            "/billing/", "toast.code_required", "error", lang=detect_language()
         )
 
     svc = PaymentService(db)
@@ -96,7 +96,7 @@ async def redeem_code(
         await db.commit()
         logger.info(f"User {user['sub']} redeemed code {code}, order {order.order_no}")
         return toast_redirect(
-            "/webui/billing/",
+            "/billing/",
             "toast.redeem_success",
             lang=detect_language(),
             order_no=order.order_no,
@@ -104,7 +104,7 @@ async def redeem_code(
     except PaymentError as e:
         await db.rollback()
         return toast_redirect(
-            "/webui/billing/",
+            "/billing/",
             "toast.payment_error",
             "error",
             lang=detect_language(),
@@ -179,12 +179,12 @@ async def admin_create_plan(
         )
         await db.commit()
         return toast_redirect(
-            "/webui/billing/admin/plans", "toast.plan_created", lang=detect_language()
+            "/billing/admin/plans", "toast.plan_created", lang=detect_language()
         )
     except PaymentError as e:
         await db.rollback()
         return toast_redirect(
-            "/webui/billing/admin/plans",
+            "/billing/admin/plans",
             "toast.payment_error",
             "error",
             lang=detect_language(),
@@ -194,7 +194,7 @@ async def admin_create_plan(
         await db.rollback()
         logger.error(f"Failed to create plan: {e}")
         return toast_redirect(
-            "/webui/billing/admin/plans",
+            "/billing/admin/plans",
             "toast.save_failed",
             "error",
             lang=detect_language(),
@@ -214,7 +214,7 @@ async def admin_toggle_plan(
     plan = await svc.get_plan(plan_id)
     if not plan:
         return toast_redirect(
-            "/webui/billing/admin/plans",
+            "/billing/admin/plans",
             "toast.plan_not_found",
             "error",
             lang=detect_language(),
@@ -223,7 +223,7 @@ async def admin_toggle_plan(
     await db.commit()
     status = "enabled" if plan.is_active else "disabled"
     return toast_redirect(
-        "/webui/billing/admin/plans",
+        "/billing/admin/plans",
         "toast.plan_toggled",
         lang=detect_language(),
         status=status,
@@ -277,7 +277,7 @@ async def admin_generate_codes(
     """批量生成兑换码"""
     if count < 1 or count > 100:
         return toast_redirect(
-            "/webui/billing/admin/codes",
+            "/billing/admin/codes",
             "toast.code_count_range",
             "error",
             lang=detect_language(),
@@ -295,7 +295,7 @@ async def admin_generate_codes(
         await db.commit()
         logger.info(f"Admin {user['sub']} generated {count} codes for plan {plan_id}")
         return toast_redirect(
-            "/webui/billing/admin/codes",
+            "/billing/admin/codes",
             "toast.code_generated",
             lang=detect_language(),
             count=len(codes),
@@ -303,7 +303,7 @@ async def admin_generate_codes(
     except PaymentError as e:
         await db.rollback()
         return toast_redirect(
-            "/webui/billing/admin/codes",
+            "/billing/admin/codes",
             "toast.payment_error",
             "error",
             lang=detect_language(),
@@ -334,7 +334,7 @@ async def admin_grant(
         await db.commit()
         logger.info(f"Admin {user['sub']} granted plan {plan_id} to user {user_id}")
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.grant_success",
             lang=detect_language(),
             order_no=order.order_no,
@@ -342,7 +342,7 @@ async def admin_grant(
     except PaymentError as e:
         await db.rollback()
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.payment_error",
             "error",
             lang=detect_language(),

--- a/backend/webui/routes/config.py
+++ b/backend/webui/routes/config.py
@@ -374,7 +374,7 @@ async def save_strategies_section(
     except (ValueError, yaml.YAMLError) as e:
         logger.error(f"配置验证失败: {e}")
         return toast_redirect(
-            f"/webui/config/strategies?tab={section}",
+            f"/config/strategies?tab={section}",
             "toast.config_validation_failed",
             "error",
             lang=detect_language(),
@@ -383,7 +383,7 @@ async def save_strategies_section(
     except PermissionError as e:
         logger.error(f"文件权限不足: {e}")
         return toast_redirect(
-            f"/webui/config/strategies?tab={section}",
+            f"/config/strategies?tab={section}",
             "toast.file_permission_denied",
             "error",
             lang=detect_language(),
@@ -391,14 +391,14 @@ async def save_strategies_section(
     except Exception as e:
         logger.error(f"策略配置保存异常: {e}", exc_info=True)
         return toast_redirect(
-            f"/webui/config/strategies?tab={section}",
+            f"/config/strategies?tab={section}",
             "toast.save_failed",
             "error",
             lang=detect_language(),
         )
 
     return toast_redirect(
-        f"/webui/config/strategies?tab={section}",
+        f"/config/strategies?tab={section}",
         "toast.strategy_saved",
         lang=detect_language(),
         section=section,
@@ -481,7 +481,7 @@ async def save_labels_definitions(
     except ValueError as e:
         logger.warning(f"标签验证失败: {e}")
         return toast_redirect(
-            "/webui/config/labels",
+            "/config/labels",
             "toast.label_validation_failed",
             "error",
             lang=detect_language(),
@@ -490,11 +490,11 @@ async def save_labels_definitions(
     except Exception as e:
         logger.error(f"标签定义保存失败: {e}")
         return toast_redirect(
-            "/webui/config/labels", "toast.save_failed", "error", lang=detect_language()
+            "/config/labels", "toast.save_failed", "error", lang=detect_language()
         )
 
     return toast_redirect(
-        "/webui/config/labels",
+        "/config/labels",
         "toast.labels_saved",
         lang=detect_language(),
         count=len(labels),
@@ -538,7 +538,7 @@ async def save_recommendation_settings(
     except (ValueError, yaml.YAMLError) as e:
         logger.error(f"推荐设置验证失败: {e}")
         return toast_redirect(
-            "/webui/config/labels",
+            "/config/labels",
             "toast.label_settings_validation_failed",
             "error",
             lang=detect_language(),
@@ -547,11 +547,11 @@ async def save_recommendation_settings(
     except Exception as e:
         logger.error(f"标签推荐设置保存失败: {e}", exc_info=True)
         return toast_redirect(
-            "/webui/config/labels", "toast.save_failed", "error", lang=detect_language()
+            "/config/labels", "toast.save_failed", "error", lang=detect_language()
         )
 
     return toast_redirect(
-        "/webui/config/labels", "toast.label_settings_saved", lang=detect_language()
+        "/config/labels", "toast.label_settings_saved", lang=detect_language()
     )
 
 
@@ -609,7 +609,7 @@ async def save_conflict_rules(
     except ValueError as e:
         logger.warning(f"冲突规则验证失败: {e}")
         return toast_redirect(
-            "/webui/config/labels",
+            "/config/labels",
             "toast.conflict_rules_validation_failed",
             "error",
             lang=detect_language(),
@@ -618,11 +618,11 @@ async def save_conflict_rules(
     except Exception as e:
         logger.error(f"冲突规则保存失败: {e}", exc_info=True)
         return toast_redirect(
-            "/webui/config/labels", "toast.save_failed", "error", lang=detect_language()
+            "/config/labels", "toast.save_failed", "error", lang=detect_language()
         )
 
     return toast_redirect(
-        "/webui/config/labels",
+        "/config/labels",
         "toast.conflict_rules_saved",
         lang=detect_language(),
         count=len(conflict_rules),
@@ -874,7 +874,7 @@ async def save_general_config(
                     val_i = int(val)
                 except ValueError:
                     return toast_redirect(
-                        "/webui/config/general",
+                        "/config/general",
                         "toast.numeric_required",
                         "error",
                         lang=detect_language(),
@@ -884,7 +884,7 @@ async def save_general_config(
                 min_v, max_v = DYNAMIC_CONFIG_RANGES[key]
                 if not (min_v <= val_i <= max_v):
                     return toast_redirect(
-                        "/webui/config/general",
+                        "/config/general",
                         "toast.value_range",
                         "error",
                         lang=detect_language(),
@@ -896,7 +896,7 @@ async def save_general_config(
             elif key == "web_search_provider":
                 if val not in ("duckduckgo", "tavily"):
                     return toast_redirect(
-                        "/webui/config/general",
+                        "/config/general",
                         "toast.unsupported_search_provider",
                         "error",
                         lang=detect_language(),
@@ -956,7 +956,7 @@ async def save_general_config(
                         num_val = float(val)
                     except ValueError:
                         return toast_redirect(
-                            "/webui/config/general",
+                            "/config/general",
                             "toast.numeric_required",
                             "error",
                             lang=detect_language(),
@@ -964,7 +964,7 @@ async def save_general_config(
                         )
                     if not (min_v <= num_val <= max_v):
                         return toast_redirect(
-                            "/webui/config/general",
+                            "/config/general",
                             "toast.value_range",
                             "error",
                             lang=detect_language(),
@@ -979,7 +979,7 @@ async def save_general_config(
                     ]
                     if val not in valid_values:
                         return toast_redirect(
-                            "/webui/config/general",
+                            "/config/general",
                             "toast.value_invalid",
                             "error",
                             lang=detect_language(),
@@ -1017,7 +1017,7 @@ async def save_general_config(
 
         if not changed:
             return toast_redirect(
-                "/webui/config/general",
+                "/config/general",
                 "toast.config_saved_restart",
                 lang=detect_language(),
             )
@@ -1052,12 +1052,12 @@ async def save_general_config(
             db, user["user_id"], "config_save", "global", None, log_changed
         )
         return toast_redirect(
-            "/webui/config/general", "toast.config_saved_live", lang=detect_language()
+            "/config/general", "toast.config_saved_live", lang=detect_language()
         )
 
     except ValueError:
         return toast_redirect(
-            "/webui/config/general",
+            "/config/general",
             "toast.invalid_param",
             "error",
             lang=detect_language(),
@@ -1065,7 +1065,7 @@ async def save_general_config(
     except Exception as e:
         logger.error(f"全局配置保存失败: {e}", exc_info=True)
         return toast_redirect(
-            "/webui/config/general",
+            "/config/general",
             "toast.save_failed",
             "error",
             lang=detect_language(),

--- a/backend/webui/routes/dashboard.py
+++ b/backend/webui/routes/dashboard.py
@@ -182,7 +182,7 @@ async def dashboard_page(
     )
 
 
-@router.get("/api/webui/stats")
+@router.get("/api/stats")
 async def get_stats(
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
@@ -304,7 +304,7 @@ async def get_stats(
     return result
 
 
-@router.get("/api/webui/recent-reviews")
+@router.get("/api/recent-reviews")
 async def get_recent_reviews(
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
@@ -314,7 +314,7 @@ async def get_recent_reviews(
     return [_serialize_review(r) for r in reviews]
 
 
-@router.get("/api/webui/recent-reviews-html")
+@router.get("/api/recent-reviews-html")
 async def get_recent_reviews_html(
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -331,7 +331,7 @@ async def get_recent_reviews_html(
     )
 
 
-@router.get("/api/webui/chart-data")
+@router.get("/api/chart-data")
 async def get_chart_data(
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
@@ -476,7 +476,7 @@ async def get_chart_data(
     return result
 
 
-@router.post("/api/webui/cache/refresh")
+@router.post("/api/cache/refresh")
 async def refresh_cache(user: dict = Depends(require_auth)):
     """手动刷新仪表盘缓存（仅清除当前用户）"""
     uid = user["user_id"]

--- a/backend/webui/routes/security.py
+++ b/backend/webui/routes/security.py
@@ -77,7 +77,7 @@ async def enable_global_mfa_route(
         request=request,
     )
     await db.commit()
-    return toast_redirect("/webui/security/", "toast.security_global_mfa_enabled")
+    return toast_redirect("/security/", "toast.security_global_mfa_enabled")
 
 
 @router.post("/global-mfa/disable")
@@ -97,7 +97,7 @@ async def disable_global_mfa_route(
         request=request,
     )
     await db.commit()
-    return toast_redirect("/webui/security/", "toast.security_global_mfa_disabled")
+    return toast_redirect("/security/", "toast.security_global_mfa_disabled")
 
 
 @router.get("/users/{target_user_id}")
@@ -140,7 +140,7 @@ async def reset_totp_route(
     """Reset target user's TOTP and recovery codes."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     await reset_user_totp(db, target_user)
     await record_security_event(
         db,
@@ -153,7 +153,7 @@ async def reset_totp_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "totp_reset_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_totp_reset"
+        f"/security/users/{target_user_id}", "toast.security_totp_reset"
     )
 
 
@@ -168,7 +168,7 @@ async def require_mfa_route(
     """Require target user to enroll at least one MFA method."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     await set_user_mfa_required(db, target_user, True)
     await record_security_event(
         db,
@@ -181,7 +181,7 @@ async def require_mfa_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "mfa_required_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_mfa_required"
+        f"/security/users/{target_user_id}", "toast.security_mfa_required"
     )
 
 
@@ -196,7 +196,7 @@ async def unrequire_mfa_route(
     """Remove forced MFA enrollment requirement for target user."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     await set_user_mfa_required(db, target_user, False)
     await record_security_event(
         db,
@@ -209,7 +209,7 @@ async def unrequire_mfa_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "mfa_unrequired_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_mfa_unrequired"
+        f"/security/users/{target_user_id}", "toast.security_mfa_unrequired"
     )
 
 
@@ -224,7 +224,7 @@ async def delete_all_passkeys_route(
     """Delete all target user's passkeys."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     deleted_count = await delete_user_passkeys(db, target_user_id)
     await record_security_event(
         db,
@@ -238,7 +238,7 @@ async def delete_all_passkeys_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "passkey_deleted_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_passkeys_deleted"
+        f"/security/users/{target_user_id}", "toast.security_passkeys_deleted"
     )
 
 
@@ -254,7 +254,7 @@ async def delete_passkey_route(
     """Delete one target user's passkey."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     deleted_count = await delete_user_passkey(db, target_user_id, credential_id)
     await record_security_event(
         db,
@@ -268,7 +268,7 @@ async def delete_passkey_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "passkey_deleted_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_passkey_deleted"
+        f"/security/users/{target_user_id}", "toast.security_passkey_deleted"
     )
 
 
@@ -283,7 +283,7 @@ async def reset_mfa_route(
     """Reset all MFA methods for a target user."""
     target_user = await _get_target_user(db, target_user_id)
     if not target_user:
-        return toast_redirect("/webui/security/", "toast.user_not_found", "error")
+        return toast_redirect("/security/", "toast.user_not_found", "error")
     await reset_user_mfa(db, target_user)
     await record_security_event(
         db,
@@ -296,7 +296,7 @@ async def reset_mfa_route(
     await db.commit()
     await notify_mfa_event(db, target_user_id, "mfa_reset_by_admin")
     return toast_redirect(
-        f"/webui/security/users/{target_user_id}", "toast.security_mfa_reset"
+        f"/security/users/{target_user_id}", "toast.security_mfa_reset"
     )
 
 

--- a/backend/webui/routes/settings.py
+++ b/backend/webui/routes/settings.py
@@ -195,7 +195,7 @@ async def save_settings(
     # 验证参数范围
     if items_per_page not in (10, 20, 50, 100):
         return toast_redirect(
-            "/webui/settings/",
+            "/settings/",
             "toast.invalid_param",
             "error",
             lang=detect_language({"language": language}),
@@ -211,7 +211,7 @@ async def save_settings(
         )
     except ValueError:
         return toast_redirect(
-            "/webui/settings/",
+            "/settings/",
             "toast.invalid_param",
             "error",
             lang=detect_language({"language": language}),
@@ -260,7 +260,7 @@ async def save_settings(
         f"language={language}, output_language={normalized_output_language or 'inherit'}"
     )
     return toast_redirect(
-        "/webui/settings/",
+        "/settings/",
         "toast.settings_saved",
         lang=detect_language({"language": language}),
     )
@@ -280,7 +280,7 @@ async def start_two_factor_setup(
     result = await db.execute(select(TelegramUser).where(TelegramUser.id == user_id))
     db_user = result.scalar_one_or_none()
     if not db_user:
-        return toast_redirect("/webui/settings/", "toast.login_required", "error")
+        return toast_redirect("/settings/", "toast.login_required", "error")
 
     setup = create_totp_setup(db_user)
     await _save_totp_setup_secret(user_id, setup.secret)
@@ -308,16 +308,16 @@ async def enable_two_factor(
     secret = await _pop_totp_setup_secret(user_id)
     if not secret:
         return toast_redirect(
-            "/webui/settings/", "toast.two_factor_setup_expired", "error"
+            "/settings/", "toast.two_factor_setup_expired", "error"
         )
     used_step = verify_totp_secret(secret, code)
     if used_step is None:
-        return toast_redirect("/webui/settings/", "toast.two_factor_invalid", "error")
+        return toast_redirect("/settings/", "toast.two_factor_invalid", "error")
 
     result = await db.execute(select(TelegramUser).where(TelegramUser.id == user_id))
     db_user = result.scalar_one_or_none()
     if not db_user:
-        return toast_redirect("/webui/settings/", "toast.login_required", "error")
+        return toast_redirect("/settings/", "toast.login_required", "error")
 
     db_user.totp_enabled = True
     db_user.totp_secret_encrypted = encrypt_totp_secret(secret)
@@ -357,7 +357,7 @@ async def disable_two_factor_route(
     db_user = result.scalar_one_or_none()
     if not db_user or not db_user.totp_enabled:
         return toast_redirect(
-            "/webui/settings/", "toast.two_factor_not_enabled", "error"
+            "/settings/", "toast.two_factor_not_enabled", "error"
         )
 
     verified = False
@@ -373,12 +373,12 @@ async def disable_two_factor_route(
         verified = await consume_recovery_code(db, user_id, code)
     if not verified:
         await db.rollback()
-        return toast_redirect("/webui/settings/", "toast.two_factor_invalid", "error")
+        return toast_redirect("/settings/", "toast.two_factor_invalid", "error")
 
     await disable_totp(db, db_user)
     await db.commit()
     await notify_mfa_event(db, user_id, "totp_disabled")
-    return toast_redirect("/webui/settings/", "toast.two_factor_disabled")
+    return toast_redirect("/settings/", "toast.two_factor_disabled")
 
 
 @router.post("/2fa/recovery-codes/regenerate")
@@ -397,7 +397,7 @@ async def regenerate_recovery_codes(
     db_user = result.scalar_one_or_none()
     if not db_user or not db_user.totp_enabled:
         return toast_redirect(
-            "/webui/settings/", "toast.two_factor_not_enabled", "error"
+            "/settings/", "toast.two_factor_not_enabled", "error"
         )
 
     try:
@@ -405,7 +405,7 @@ async def regenerate_recovery_codes(
     except TwoFactorError:
         used_step = None
     if used_step is None:
-        return toast_redirect("/webui/settings/", "toast.two_factor_invalid", "error")
+        return toast_redirect("/settings/", "toast.two_factor_invalid", "error")
 
     db_user.totp_last_used_step = used_step
     recovery_codes = await replace_recovery_codes(db, user_id)
@@ -507,7 +507,7 @@ async def passkey_delete(
     )
     await db.commit()
     await notify_mfa_event(db, int(user["user_id"]), "passkey_deleted")
-    return toast_redirect("/webui/settings/", "toast.passkey_deleted")
+    return toast_redirect("/settings/", "toast.passkey_deleted")
 
 
 @router.get("/about")

--- a/backend/webui/routes/setup.py
+++ b/backend/webui/routes/setup.py
@@ -26,7 +26,7 @@ templates = get_templates()
 def _check_bootstrap():
     """检查是否处于 bootstrap 模式，已完成后拒绝访问"""
     if not is_bootstrap_mode():
-        return RedirectResponse(url="/webui/", status_code=302)
+        return RedirectResponse(url="/", status_code=302)
     return None
 
 

--- a/backend/webui/routes/users.py
+++ b/backend/webui/routes/users.py
@@ -128,13 +128,13 @@ async def add_user(
     # 角色验证
     if role not in ("user", "admin", "super_admin"):
         return toast_redirect(
-            "/webui/users/", "toast.invalid_role", "error", lang=detect_language()
+            "/users/", "toast.invalid_role", "error", lang=detect_language()
         )
 
     # Telegram ID 验证
     if telegram_id <= 0:
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.telegram_id_positive",
             "error",
             lang=detect_language(),
@@ -144,7 +144,7 @@ async def add_user(
     github_username = github_username.strip()
     if not github_username:
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.github_username_required",
             "error",
             lang=detect_language(),
@@ -161,7 +161,7 @@ async def add_user(
     ):
         if q < 0:
             return toast_redirect(
-                "/webui/users/",
+                "/users/",
                 "toast.quota_non_negative",
                 "error",
                 lang=detect_language(),
@@ -173,7 +173,7 @@ async def add_user(
     )
     if existing.scalar_one_or_none():
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.telegram_id_exists",
             "error",
             lang=detect_language(),
@@ -186,7 +186,7 @@ async def add_user(
     )
     if existing_gh.scalar_one_or_none():
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.github_username_used",
             "error",
             lang=detect_language(),
@@ -220,7 +220,7 @@ async def add_user(
         logger.error(f"用户创建失败（数据库冲突）: {e}")
         await db.rollback()
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.user_create_failed_duplicate",
             "error",
             lang=detect_language(),
@@ -229,7 +229,7 @@ async def add_user(
         logger.error(f"用户创建失败（未知错误）: {e}")
         await db.rollback()
         return toast_redirect(
-            "/webui/users/", "toast.user_create_failed", "error", lang=detect_language()
+            "/users/", "toast.user_create_failed", "error", lang=detect_language()
         )
 
     logger.info(
@@ -258,7 +258,7 @@ async def add_user(
         "toast.user_added_auto_super_admin" if auto_super_admin else "toast.user_added"
     )
     return toast_redirect(
-        "/webui/users/",
+        "/users/",
         msg_key,
         lang=detect_language(),
         github_username=github_username,
@@ -314,7 +314,7 @@ async def update_user_role(
     """修改用户角色"""
     if role not in ("user", "admin", "super_admin"):
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.invalid_role",
             "error",
             lang=detect_language(),
@@ -328,7 +328,7 @@ async def update_user_role(
     # 权限保护：只有超级管理员可授予或修改管理员级别角色
     if not can_update_user_role(user["role"], target_user.role, role):
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.permission_denied_role",
             "error",
             lang=detect_language(),
@@ -350,7 +350,7 @@ async def update_user_role(
         {"old_role": old_role, "new_role": role},
     )
     return toast_redirect(
-        f"/webui/users/{user_id}",
+        f"/users/{user_id}",
         "toast.user_role_changed",
         lang=detect_language(),
         role=role,
@@ -371,7 +371,7 @@ async def update_user_quota(
     """修改用户配额"""
     if daily_quota < 0 or weekly_quota < 0 or monthly_quota < 0:
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.quota_non_negative",
             "error",
             lang=detect_language(),
@@ -411,7 +411,7 @@ async def update_user_quota(
         },
     )
     return toast_redirect(
-        f"/webui/users/{user_id}", "toast.user_quota_updated", lang=detect_language()
+        f"/users/{user_id}", "toast.user_quota_updated", lang=detect_language()
     )
 
 
@@ -429,7 +429,7 @@ async def update_user_issue_quota(
     """修改用户 Issue 分析配额"""
     if issue_daily_quota < 0 or issue_weekly_quota < 0 or issue_monthly_quota < 0:
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.quota_non_negative",
             "error",
             lang=detect_language(),
@@ -467,7 +467,7 @@ async def update_user_issue_quota(
         },
     )
     return toast_redirect(
-        f"/webui/users/{user_id}", "toast.issue_quota_updated", lang=detect_language()
+        f"/users/{user_id}", "toast.issue_quota_updated", lang=detect_language()
     )
 
 
@@ -488,14 +488,14 @@ async def toggle_user_status(
     # 权限保护：不允许修改同级别或更高级别的用户，不允许禁用自己
     if user_id == user["user_id"]:
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.cannot_disable_self",
             "error",
             lang=detect_language(),
         )
     if not can_toggle_user_status(user["role"], target_user.role):
         return toast_redirect(
-            "/webui/users/",
+            "/users/",
             "toast.permission_denied_user",
             "error",
             lang=detect_language(),
@@ -517,7 +517,7 @@ async def toggle_user_status(
         {"is_active": target_user.is_active},
     )
     return toast_redirect(
-        "/webui/users/",
+        "/users/",
         "toast.user_status_changed",
         lang=detect_language(),
         username=target_user.github_username,
@@ -536,7 +536,7 @@ async def delete_user(
     """删除用户（仅超级管理员）"""
     if user_id == user["user_id"]:
         return toast_redirect(
-            "/webui/users/", "toast.cannot_delete_self", "error", lang=detect_language()
+            "/users/", "toast.cannot_delete_self", "error", lang=detect_language()
         )
 
     result = await db.execute(select(TelegramUser).where(TelegramUser.id == user_id))
@@ -555,7 +555,7 @@ async def delete_user(
         logger.error(f"用户删除失败: {e}")
         await db.rollback()
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.user_delete_failed",
             "error",
             lang=detect_language(),
@@ -577,7 +577,7 @@ async def delete_user(
         },
     )
     return toast_redirect(
-        "/webui/users/",
+        "/users/",
         "toast.user_deleted",
         lang=detect_language(),
         name=github or tg_id,
@@ -597,7 +597,7 @@ async def update_user_info(
     """修改用户基本信息（Telegram ID、GitHub 用户名）"""
     if telegram_id <= 0:
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.telegram_id_positive",
             "error",
             lang=detect_language(),
@@ -606,7 +606,7 @@ async def update_user_info(
     github_username = github_username.strip()
     if not github_username:
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.github_username_required",
             "error",
             lang=detect_language(),
@@ -625,7 +625,7 @@ async def update_user_info(
     )
     if existing.scalar_one_or_none():
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.telegram_id_used",
             "error",
             lang=detect_language(),
@@ -640,7 +640,7 @@ async def update_user_info(
     )
     if existing_gh.scalar_one_or_none():
         return toast_redirect(
-            f"/webui/users/{user_id}",
+            f"/users/{user_id}",
             "toast.github_username_conflict",
             "error",
             lang=detect_language(),
@@ -670,7 +670,7 @@ async def update_user_info(
         },
     )
     return toast_redirect(
-        f"/webui/users/{user_id}", "toast.user_info_updated", lang=detect_language()
+        f"/users/{user_id}", "toast.user_info_updated", lang=detect_language()
     )
 
 
@@ -725,7 +725,7 @@ async def reset_user_quota(
         {"old_used": old_used},
     )
     return toast_redirect(
-        f"/webui/users/{user_id}",
+        f"/users/{user_id}",
         "toast.quota_reset",
         lang=detect_language(),
         username=target_user.github_username,

--- a/backend/webui/templates/action_logs.html
+++ b/backend/webui/templates/action_logs.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- 日志列表（通过 HTMX 加载） -->
-    <div id="action-log-list-container" hx-get="/webui/logs/actions/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="action-log-list-container" hx-get="/logs/actions/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -26,7 +26,7 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadActionLogPage = function(n) { loadListPage('action-log-list-container', '/webui/logs/actions/list-fragment', n); };
-initFilterForm('action-log-filter-form', 'action-log-list-container', '/webui/logs/actions/list-fragment');
+var loadActionLogPage = function(n) { loadListPage('action-log-list-container', '/logs/actions/list-fragment', n); };
+initFilterForm('action-log-filter-form', 'action-log-list-container', '/logs/actions/list-fragment');
 </script>
 {% endblock %}

--- a/backend/webui/templates/agent_skills.html
+++ b/backend/webui/templates/agent_skills.html
@@ -25,7 +25,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5">
             <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ _('agent_skills.install_github') }}</h2>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('agent_skills.install_github_desc') }}</p>
-            <form method="post" action="/webui/agent-skills/install-github" class="mt-4 space-y-4">
+            <form method="post" action="/agent-skills/install-github" class="mt-4 space-y-4">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <input name="github_url" type="url" required placeholder="https://github.com/owner/repo/blob/main/path/SKILL.md" class="w-full rounded-xl border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm">
                 <button type="submit" class="inline-flex items-center justify-center px-5 py-2.5 rounded-xl bg-sakura-500 hover:bg-sakura-600 text-white text-sm font-semibold shadow-lg shadow-sakura-500/20">
@@ -37,7 +37,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5">
             <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ _('agent_skills.upload_skill') }}</h2>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('agent_skills.upload_skill_desc') }}</p>
-            <form method="post" action="/webui/agent-skills/upload" enctype="multipart/form-data" class="mt-4 space-y-4">
+            <form method="post" action="/agent-skills/upload" enctype="multipart/form-data" class="mt-4 space-y-4">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <input name="name" type="text" placeholder="{{ _('agent_skills.name_placeholder') }}" class="w-full rounded-xl border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm">
                 <input name="skill_file" type="file" accept=".md,.zip,text/markdown,text/plain,application/zip" required class="block w-full text-sm text-gray-600 dark:text-gray-300 file:mr-4 file:rounded-xl file:border-0 file:bg-sakura-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-sakura-700 hover:file:bg-sakura-100 dark:file:bg-sakura-900/30 dark:file:text-sakura-300">
@@ -54,11 +54,11 @@
                 <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ _('agent_skills.installed_skills') }}</h2>
                 <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ _('agent_skills.installed_skills_desc') }}</p>
             </div>
-            <button hx-get="/webui/agent-skills/list-fragment" hx-target="#agent-skills-list" hx-swap="innerHTML" class="px-4 py-2 bg-sakura-500 hover:bg-sakura-600 text-white rounded-xl text-sm font-semibold">
+            <button hx-get="/agent-skills/list-fragment" hx-target="#agent-skills-list" hx-swap="innerHTML" class="px-4 py-2 bg-sakura-500 hover:bg-sakura-600 text-white rounded-xl text-sm font-semibold">
                 {{ _('common.refresh') }}
             </button>
         </div>
-        <div id="agent-skills-list" hx-get="/webui/agent-skills/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+        <div id="agent-skills-list" hx-get="/agent-skills/list-fragment" hx-trigger="load" hx-swap="innerHTML">
             {% include "components/agent_skills_list_fragment.html" %}
         </div>
     </section>

--- a/backend/webui/templates/agent_team.html
+++ b/backend/webui/templates/agent_team.html
@@ -119,7 +119,7 @@
                     </div>
                 </div>
             </div>
-            <div id="agent-task-list" hx-get="/webui/agent-team/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+            <div id="agent-task-list" hx-get="/agent-team/list-fragment" hx-trigger="load" hx-swap="innerHTML">
                 <div class="text-center py-8 text-gray-400">{{ _('common.loading') }}</div>
             </div>
         </div>
@@ -137,7 +137,7 @@
             </div>
             <button @click="refreshWorkspaces()" class="px-4 py-2 bg-sakura-500 hover:bg-sakura-600 text-white rounded-xl text-sm font-semibold">{{ _('common.refresh') }}</button>
         </div>
-        <div id="agent-workspace-list" hx-get="/webui/agent-team/workspaces-fragment" hx-trigger="load" hx-swap="innerHTML">
+        <div id="agent-workspace-list" hx-get="/agent-team/workspaces-fragment" hx-trigger="load" hx-swap="innerHTML">
             <div class="text-center py-8 text-gray-400">{{ _('common.loading') }}</div>
         </div>
     </section>
@@ -168,7 +168,7 @@
             <h2 class="text-lg font-bold">{{ _('agent_team.dedicated_ai_config') }}</h2>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ _('agent_team.config_center_desc') }}</p>
         </div>
-        <form method="post" action="/webui/agent-team/config/save" class="space-y-4">
+        <form method="post" action="/agent-team/config/save" class="space-y-4">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             {% for group in config_groups %}
             <details class="rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden" {% if loop.first %}open{% endif %}>
@@ -225,7 +225,7 @@ function agentTeamPage() {
         },
         buildTaskUrl(page) {
             const params = new URLSearchParams({page: page || 1, status: this.filters.status, source_type: this.filters.source_type, q: this.filters.q || '', sort: this.filters.sort});
-            return '/webui/agent-team/list-fragment?' + params.toString();
+            return '/agent-team/list-fragment?' + params.toString();
         },
         loadAgentTaskPage(page) {
             const target = document.getElementById('agent-task-list');
@@ -250,7 +250,7 @@ function refreshWorkspaces() {
     const target = document.getElementById('agent-workspace-list');
     if (!target) return;
     target.innerHTML = getLoadingHTML();
-    fetch('/webui/agent-team/workspaces-fragment', {headers: {'HX-Request': 'true'}})
+    fetch('/agent-team/workspaces-fragment', {headers: {'HX-Request': 'true'}})
         .then(r => { if (!r.ok) throw new Error('failed'); return r.text(); })
         .then(html => { target.innerHTML = html; })
         .catch(() => { target.innerHTML = getErrorHTML('{{ _('agent_team.request_failed') }}'); });
@@ -258,7 +258,7 @@ function refreshWorkspaces() {
 function deleteWorkspace(repoOwner, repoName) {
     const message = '{{ _('agent_team.confirm_delete_workspace') }}\n\n{{ _('agent_team.delete_workspace_warning') }}';
     const runDelete = () => {
-        fetch('/webui/agent-team/workspaces/delete', {
+        fetch('/agent-team/workspaces/delete', {
             method: 'POST',
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
             body: new URLSearchParams({csrf_token: '{{ csrf_token }}', repo_owner: repoOwner, repo_name: repoName})
@@ -283,7 +283,7 @@ function loadTaskDetail(taskId) {
     const target = document.getElementById('agent-task-detail');
     if (!target) return;
     target.innerHTML = getLoadingHTML();
-    fetch(`/webui/agent-team/tasks/${taskId}/detail-fragment`, {headers: {'HX-Request': 'true'}})
+    fetch(`/agent-team/tasks/${taskId}/detail-fragment`, {headers: {'HX-Request': 'true'}})
         .then(r => { if (!r.ok) throw new Error('failed'); return r.text(); })
         .then(html => { target.innerHTML = html; })
         .catch(() => { target.innerHTML = getErrorHTML('{{ _('agent_team.request_failed') }}'); });
@@ -298,7 +298,7 @@ function previewCandidates() {
     const box = document.getElementById('candidate-results');
     const requirement = window.agentTeamState?.candidateFilterRequirement || '';
     box.innerHTML = getLoadingHTML();
-    fetch('/webui/agent-team/candidates', {
+    fetch('/agent-team/candidates', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: new URLSearchParams({csrf_token: '{{ csrf_token }}', ai_filter_requirement: requirement})
@@ -350,7 +350,7 @@ function createAgentTask(btn, sourceType, sourceId, requirement = '') {
     btn.disabled = true;
     btn.classList.add('opacity-60', 'cursor-not-allowed');
     btn.textContent = '...';
-    fetch('/webui/agent-team/tasks/create', {
+    fetch('/agent-team/tasks/create', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: new URLSearchParams({csrf_token: '{{ csrf_token }}', source_type: sourceType, source_id: sourceId, ai_filter_requirement: requirement})

--- a/backend/webui/templates/base.html
+++ b/backend/webui/templates/base.html
@@ -342,7 +342,7 @@
           document.getElementById('hljs-light').disabled = val === 'dark';
           document.getElementById('hljs-dark').disabled = val !== 'dark';
           localStorage.setItem('theme', val);
-          fetch('/webui/auth/api/theme', {
+          fetch('/auth/api/theme', {
               method: 'POST',
               headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': '{{ csrf_token }}' },
               body: 'theme=' + val

--- a/backend/webui/templates/billing/admin_codes.html
+++ b/backend/webui/templates/billing/admin_codes.html
@@ -74,7 +74,7 @@
             <button onclick="this.closest('#generate-modal').classList.add('hidden')"
                     class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
         </div>
-        <form action="/webui/billing/admin/codes/generate" method="POST" class="px-6 py-4 space-y-4">
+        <form action="/billing/admin/codes/generate" method="POST" class="px-6 py-4 space-y-4">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
             <div>

--- a/backend/webui/templates/billing/admin_plans.html
+++ b/backend/webui/templates/billing/admin_plans.html
@@ -52,7 +52,7 @@
                         </span>
                     </td>
                     <td class="px-6 py-4">
-                        <form action="/webui/billing/admin/plans/{{ plan.id }}/toggle" method="POST" class="inline">
+                        <form action="/billing/admin/plans/{{ plan.id }}/toggle" method="POST" class="inline">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit"
                                     class="text-sm {{ 'text-red-600 hover:text-red-800' if plan.is_active else 'text-green-600 hover:text-green-800' }}">
@@ -83,7 +83,7 @@
             <button onclick="this.closest('#create-plan-modal').classList.add('hidden')"
                     class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
         </div>
-        <form action="/webui/billing/admin/plans" method="POST" class="px-6 py-4 space-y-4">
+        <form action="/billing/admin/plans" method="POST" class="px-6 py-4 space-y-4">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
             <div class="grid grid-cols-2 gap-4">

--- a/backend/webui/templates/billing/index.html
+++ b/backend/webui/templates/billing/index.html
@@ -63,7 +63,7 @@
     <!-- 兑换码 -->
     <div class="mb-8 bg-white dark:bg-gray-800 rounded-lg shadow p-6">
         <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{{ _('billing.redeem_title') }}</h2>
-        <form action="/webui/billing/redeem" method="POST" class="flex gap-3">
+        <form action="/billing/redeem" method="POST" class="flex gap-3">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="text" name="code" required
                    class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg

--- a/backend/webui/templates/components/add_user_modal.html
+++ b/backend/webui/templates/components/add_user_modal.html
@@ -46,7 +46,7 @@
             </div>
 
             <!-- 表单 -->
-            <form method="POST" action="/webui/users/add">
+            <form method="POST" action="/users/add">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
                 <!-- 基本信息 -->

--- a/backend/webui/templates/components/agent_skills_list_fragment.html
+++ b/backend/webui/templates/components/agent_skills_list_fragment.html
@@ -38,14 +38,14 @@
                 <td class="px-4 py-4 text-sm text-gray-500 dark:text-gray-400">{{ skill.updated_at }}</td>
                 <td class="px-4 py-4">
                     <div class="flex justify-end gap-2">
-                        <form method="post" action="/webui/agent-skills/{{ skill.id }}/toggle">
+                        <form method="post" action="/agent-skills/{{ skill.id }}/toggle">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <input type="hidden" name="enabled" value="{% if skill.enabled %}0{% else %}1{% endif %}">
                             <button type="submit" class="px-3 py-1.5 rounded-lg text-xs font-semibold border border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700">
                                 {% if skill.enabled %}{{ _('agent_skills.disable') }}{% else %}{{ _('agent_skills.enable') }}{% endif %}
                             </button>
                         </form>
-                        <form method="post" action="/webui/agent-skills/{{ skill.id }}/delete" onsubmit="return confirm('{{ _('agent_skills.confirm_delete') }}');">
+                        <form method="post" action="/agent-skills/{{ skill.id }}/delete" onsubmit="return confirm('{{ _('agent_skills.confirm_delete') }}');">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="px-3 py-1.5 rounded-lg text-xs font-semibold bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30">
                                 {{ _('common.delete') }}

--- a/backend/webui/templates/components/agent_team_task_list_fragment.html
+++ b/backend/webui/templates/components/agent_team_task_list_fragment.html
@@ -101,7 +101,7 @@
 
 <script>
 function retryTask(taskId) {
-    fetch(`/webui/agent-team/tasks/${taskId}/retry`, {
+    fetch(`/agent-team/tasks/${taskId}/retry`, {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: new URLSearchParams({csrf_token: '{{ csrf_token }}'})
@@ -111,7 +111,7 @@ function retryTask(taskId) {
     }).catch(() => window.dispatchEvent(new CustomEvent('show-toast', {detail: {message: '{{ _('agent_team.request_failed') }}', type: 'error'}})));
 }
 function cancelTask(taskId) {
-    fetch(`/webui/agent-team/tasks/${taskId}/cancel`, {
+    fetch(`/agent-team/tasks/${taskId}/cancel`, {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: new URLSearchParams({csrf_token: '{{ csrf_token }}'})
@@ -130,7 +130,7 @@ function deleteTask(taskId) {
     }) : Promise.resolve(window.confirm('{{ _('agent_team.confirm_delete') }}'));
     confirmPromise.then(function(confirmed) {
         if (!confirmed) return;
-        fetch(`/webui/agent-team/tasks/${taskId}/delete`, {
+        fetch(`/agent-team/tasks/${taskId}/delete`, {
             method: 'POST',
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
             body: new URLSearchParams({csrf_token: '{{ csrf_token }}'})

--- a/backend/webui/templates/components/dashboard_charts_inline.html
+++ b/backend/webui/templates/components/dashboard_charts_inline.html
@@ -34,7 +34,7 @@ async function initDashboardCharts() {
         }
     }
 
-    fetch('/webui/api/webui/chart-data')
+    fetch('/api/chart-data')
         .then(function(r) { return r.json(); })
         .then(function(data) {
             var colors = _getThemeColors();

--- a/backend/webui/templates/components/issue_list_fragment.html
+++ b/backend/webui/templates/components/issue_list_fragment.html
@@ -6,7 +6,7 @@
     {% if analyses %}
     <div class="divide-y divide-gray-200 dark:divide-gray-700">
         {% for a in analyses %}
-        <a href="/webui/issues/{{ a.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+        <a href="/issues/{{ a.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
             <!-- 状态 -->
             <div class="flex-shrink-0">
                 {% if a.status == 'completed' %}

--- a/backend/webui/templates/components/log_detail_fragment.html
+++ b/backend/webui/templates/components/log_detail_fragment.html
@@ -62,7 +62,7 @@
             </div>
             {% endfor %}
             {% if comments|length > 5 %}
-            <a href="/webui/pr/{{ review.id }}" class="text-sm text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.view_all') }} {{ comments|length }} {{ _('pr.inline_comments') }}</a>
+            <a href="/pr/{{ review.id }}" class="text-sm text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.view_all') }} {{ comments|length }} {{ _('pr.inline_comments') }}</a>
             {% endif %}
         </div>
     </div>

--- a/backend/webui/templates/components/log_list_fragment.html
+++ b/backend/webui/templates/components/log_list_fragment.html
@@ -7,7 +7,7 @@
         {% for r in reviews %}
         <div id="log-row-{{ r.id }}">
             <div class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer"
-                 hx-get="/webui/logs/{{ r.id }}/detail-fragment"
+                 hx-get="/logs/{{ r.id }}/detail-fragment"
                  hx-target="#log-detail-{{ r.id }}"
                  hx-swap="innerHTML"
                  hx-on::before-request="document.getElementById('log-detail-{{ r.id }}').classList.remove('hidden')"

--- a/backend/webui/templates/components/navbar.html
+++ b/backend/webui/templates/components/navbar.html
@@ -8,7 +8,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
             </svg>
         </button>
-        <a href="/webui/" class="flex items-center gap-2 group">
+        <a href="/" class="flex items-center gap-2 group">
             <span class="text-2xl transition-transform duration-300 group-hover:scale-110">🌸</span>
             <span class="font-bold text-lg hidden sm:inline bg-gradient-to-r from-sakura-600 to-sakura-800 dark:from-sakura-400 dark:to-sakura-300 bg-clip-text text-transparent">Sakura AI Reviewer</span>
         </a>
@@ -50,7 +50,7 @@
         </div>
 
         <!-- 登出 -->
-        <form method="POST" action="/webui/auth/logout" class="ml-1"
+        <form method="POST" action="/auth/logout" class="ml-1"
               data-confirm="{{ _('auth.logout_confirm') }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <button type="submit" class="p-2 rounded-xl hover:bg-sakura-50 dark:hover:bg-sakura-900/20 transition-colors" title="{{ _('auth.logout') }}" aria-label="{{ _('auth.logout') }}">

--- a/backend/webui/templates/components/pr_list_fragment.html
+++ b/backend/webui/templates/components/pr_list_fragment.html
@@ -6,7 +6,7 @@
     {% if reviews %}
     <div class="divide-y divide-gray-200 dark:divide-gray-700">
         {% for r in reviews %}
-        <a href="/webui/pr/{{ r.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+        <a href="/pr/{{ r.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
             <!-- 状态 -->
             <div class="flex-shrink-0">
                 {% if r.status == "completed" and r.decision == "approve" %}

--- a/backend/webui/templates/components/queue_list_fragment.html
+++ b/backend/webui/templates/components/queue_list_fragment.html
@@ -53,7 +53,7 @@
                 {% for r in reviews %}
                 <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
                     <td class="px-4 py-3">
-                        <a href="/webui/pr/{{ r.id }}" class="text-pink-600 dark:text-pink-400 hover:underline">
+                        <a href="/pr/{{ r.id }}" class="text-pink-600 dark:text-pink-400 hover:underline">
                             #{{ r.pr_id }} {{ (r.title or '') | truncate(30) }}
                         </a>
                     </td>

--- a/backend/webui/templates/components/recent_reviews.html
+++ b/backend/webui/templates/components/recent_reviews.html
@@ -4,11 +4,11 @@
     <div class="glass rounded-2xl border border-sakura-200/50 dark:border-sakura-800/30 shadow-sm overflow-hidden">
         <div class="px-5 py-4 border-b border-sakura-200/50 dark:border-sakura-800/30 flex items-center justify-between">
             <h2 class="text-lg font-semibold">{{ _('dashboard.recent_reviews') }}</h2>
-            <a href="/webui/pr/" class="text-sm text-sakura-600 dark:text-sakura-400 hover:text-sakura-700 dark:hover:text-sakura-300 transition-colors">{{ _('common.view_all') }} →</a>
+            <a href="/pr/" class="text-sm text-sakura-600 dark:text-sakura-400 hover:text-sakura-700 dark:hover:text-sakura-300 transition-colors">{{ _('common.view_all') }} →</a>
         </div>
         <div class="divide-y divide-sakura-100/50 dark:divide-sakura-800/20">
             {% for r in reviews %}
-            <a href="/webui/pr/{{ r.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-sakura-50/50 dark:hover:bg-sakura-900/10 transition-colors">
+            <a href="/pr/{{ r.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-sakura-50/50 dark:hover:bg-sakura-900/10 transition-colors">
                 <!-- 状态图标 -->
                 <div class="flex-shrink-0">
                     {% if r.status == "completed" and r.decision == "approve" %}

--- a/backend/webui/templates/components/repo_list_fragment.html
+++ b/backend/webui/templates/components/repo_list_fragment.html
@@ -35,11 +35,11 @@
 
             <!-- 统计 -->
             <div class="flex items-center gap-4 flex-shrink-0 text-xs">
-                <a href="/webui/pr/?search={{ repo.full_name }}"
+                <a href="/pr/?search={{ repo.full_name }}"
                    class="text-gray-500 dark:text-gray-400 hover:text-pink-500 dark:hover:text-pink-400 transition-colors">
                     PR: {{ repo.pr_count }}
                 </a>
-                <a href="/webui/issues/?repo_name={{ repo.full_name }}"
+                <a href="/issues/?repo_name={{ repo.full_name }}"
                    class="text-gray-500 dark:text-gray-400 hover:text-pink-500 dark:hover:text-pink-400 transition-colors">
                     Issue: {{ repo.issue_count }}
                 </a>

--- a/backend/webui/templates/components/scan_list_fragment.html
+++ b/backend/webui/templates/components/scan_list_fragment.html
@@ -2,7 +2,7 @@
 
 <!-- 筛选表单 -->
 <form id="scan-filter-form" class="flex flex-wrap gap-2 mb-4"
-      hx-get="/webui/scans/list-fragment" hx-target="#scan-list-container" hx-swap="innerHTML" hx-trigger="submit">
+      hx-get="/scans/list-fragment" hx-target="#scan-list-container" hx-swap="innerHTML" hx-trigger="submit">
     <input type="text" name="search" value="{{ search }}" placeholder="{{ _('common.search') }}..."
            class="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-pink-500 focus:border-transparent">
     <select name="status" class="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-pink-500">
@@ -24,7 +24,7 @@
     {% if scans %}
     <div class="divide-y divide-gray-200 dark:divide-gray-700">
         {% for s in scans %}
-        <a href="/webui/scans/{{ s.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+        <a href="/scans/{{ s.id }}" class="flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
             <!-- 状态 -->
             <div class="flex-shrink-0">
                 {% if s.status == 'completed' %}

--- a/backend/webui/templates/components/sidebar.html
+++ b/backend/webui/templates/components/sidebar.html
@@ -2,7 +2,7 @@
 <aside id="sidebar"
          class="fixed top-16 left-0 bottom-0 w-64 glass border-r border-sakura-200/50 dark:border-sakura-800/30 z-40 transform -translate-x-full lg:translate-x-0 transition-transform duration-300 ease-in-out overflow-y-auto overscroll-contain">
      <nav class="p-4 pb-6 space-y-1">
-        <a href="/webui/"
+        <a href="/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'dashboard' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -11,7 +11,7 @@
             {{ _('nav.dashboard') }}
         </a>
 
-        <a href="/webui/pr/"
+        <a href="/pr/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'pr' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -20,7 +20,7 @@
             {{ _('nav.pr_reviews') }}
         </a>
 
-        <a href="/webui/issues/"
+        <a href="/issues/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'issues' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -29,7 +29,7 @@
             {{ _('nav.issue_analysis') }}
         </a>
 
-        <a href="/webui/logs/"
+        <a href="/logs/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'logs' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -39,7 +39,7 @@
         </a>
 
         {% if current_user and (current_user.role == 'admin' or current_user.role == 'super_admin') %}
-        <a href="/webui/scans/"
+        <a href="/scans/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'scans' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -50,7 +50,7 @@
         {% endif %}
 
         {% if current_user and current_user.role == 'super_admin' %}
-        <a href="/webui/agent-team/"
+        <a href="/agent-team/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'agent_team' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -59,7 +59,7 @@
             </svg>
             {{ _('nav.agent_team') }}
         </a>
-        <a href="/webui/agent-skills/"
+        <a href="/agent-skills/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'agent_skills' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -70,7 +70,7 @@
         {% endif %}
 
         {% if current_user and (current_user.role == 'admin' or current_user.role == 'super_admin') %}
-        <a href="/webui/logs/actions/"
+        <a href="/logs/actions/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'action_logs' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -79,7 +79,7 @@
             {{ _('nav.action_logs') }}
         </a>
 
-        <a href="/webui/queue/"
+        <a href="/queue/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'queue' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -93,7 +93,7 @@
         <!-- 分隔线 -->
         <div class="border-t border-sakura-200/50 dark:border-sakura-800/30 my-3"></div>
 
-        <a href="/webui/users/"
+        <a href="/users/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'users' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -103,7 +103,7 @@
         </a>
 
         {% if current_user.role == 'super_admin' %}
-        <a href="/webui/security/"
+        <a href="/security/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'security' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -113,7 +113,7 @@
         </a>
         {% endif %}
 
-        <a href="/webui/repos/"
+        <a href="/repos/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'repos' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -127,7 +127,7 @@
         <div class="border-t border-sakura-200/50 dark:border-sakura-800/30 my-3"></div>
 
         {% if current_user and current_user.role == 'super_admin' %}
-        <a href="/webui/config/strategies"
+        <a href="/config/strategies"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'config_strategies' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -135,7 +135,7 @@
             </svg>
             {{ _('nav.review_strategies') }}
         </a>
-        <a href="/webui/config/labels"
+        <a href="/config/labels"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'config_labels' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -143,7 +143,7 @@
             </svg>
             {{ _('nav.label_config') }}
         </a>
-        <a href="/webui/config/general"
+        <a href="/config/general"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'config_general' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -158,7 +158,7 @@
         <!-- 分隔线 -->
         <div class="border-t border-sakura-200/50 dark:border-sakura-800/30 my-3"></div>
 
-        <a href="/webui/billing/"
+        <a href="/billing/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'billing' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -168,7 +168,7 @@
         </a>
 
         {% if current_user and current_user.role == 'super_admin' %}
-        <a href="/webui/billing/admin/plans"
+        <a href="/billing/admin/plans"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'billing_admin' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -176,7 +176,7 @@
             </svg>
             {{ _('nav.plan_management') }}
         </a>
-        <a href="/webui/billing/admin/codes"
+        <a href="/billing/admin/codes"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'billing_admin' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -190,7 +190,7 @@
         <!-- 分隔线 -->
         <div class="border-t border-sakura-200/50 dark:border-sakura-800/30 my-3"></div>
 
-        <a href="/webui/settings/"
+        <a href="/settings/"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'settings' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -200,7 +200,7 @@
             {{ _('nav.personal_settings') }}
         </a>
 
-        <a href="/webui/settings/about"
+        <a href="/settings/about"
            class="sidebar-link flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200
                   {% if active_page == 'about' %}bg-gradient-to-r from-sakura-500 to-sakura-600 text-white shadow-md shadow-sakura-500/25{% else %}text-gray-700 dark:text-gray-300 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 hover:text-sakura-700 dark:hover:text-sakura-400{% endif %}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/backend/webui/templates/components/sse_client.html
+++ b/backend/webui/templates/components/sse_client.html
@@ -14,7 +14,7 @@
             return;
         }
 
-        eventSource = new EventSource('/webui/sse/events');
+        eventSource = new EventSource('/sse/events');
 
         // 审查状态变更
         eventSource.addEventListener('review:status_changed', function(e) {

--- a/backend/webui/templates/components/user_list_fragment.html
+++ b/backend/webui/templates/components/user_list_fragment.html
@@ -46,7 +46,7 @@
                 {% for u in users %}
                 <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
                     <td class="py-3 px-5">
-                        <a href="/webui/users/{{ u.id }}" class="flex items-center gap-3 hover:text-pink-600 dark:hover:text-pink-400 transition-colors">
+                        <a href="/users/{{ u.id }}" class="flex items-center gap-3 hover:text-pink-600 dark:hover:text-pink-400 transition-colors">
                             {% if u.github_username %}
                             <img src="https://github.com/{{ u.github_username }}.png"
                                  alt="{{ u.github_username }}"

--- a/backend/webui/templates/config_general.html
+++ b/backend/webui/templates/config_general.html
@@ -40,7 +40,7 @@
     </div>
 
     <!-- 配置表单 -->
-    <form method="POST" action="/webui/config/general/save" id="configForm">
+    <form method="POST" action="/config/general/save" id="configForm">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
         <!-- ===== 基础配置 Tab ===== -->

--- a/backend/webui/templates/config_labels.html
+++ b/backend/webui/templates/config_labels.html
@@ -14,7 +14,7 @@
     <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
         <h2 class="text-lg font-semibold mb-4">AI 标签推荐设置</h2>
 
-        <form method="POST" action="/webui/config/labels/save-settings">
+        <form method="POST" action="/config/labels/save-settings">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
             <div class="space-y-4">
@@ -85,7 +85,7 @@
             </button>
         </div>
 
-        <form method="POST" action="/webui/config/labels/save-conflict-rules" id="conflict-form">
+        <form method="POST" action="/config/labels/save-conflict-rules" id="conflict-form">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
             <div class="overflow-x-auto">
@@ -163,7 +163,7 @@
             </button>
         </div>
 
-        <form method="POST" action="/webui/config/labels/save-labels" id="labels-form">
+        <form method="POST" action="/config/labels/save-labels" id="labels-form">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 
             <div class="overflow-x-auto">

--- a/backend/webui/templates/config_strategies.html
+++ b/backend/webui/templates/config_strategies.html
@@ -58,7 +58,7 @@
 
             <!-- ======== Tab 1: 审查策略 ======== -->
             <div x-show="activeTab === 'strategies'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="strategies">
 
@@ -124,7 +124,7 @@
 
             <!-- ======== Tab 2: 文件过滤 ======== -->
             <div x-show="activeTab === 'filters'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="file_filters">
 
@@ -159,7 +159,7 @@
 
             <!-- ======== Tab 3: 批处理 ======== -->
             <div x-show="activeTab === 'batch'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="batch">
 
@@ -190,7 +190,7 @@
 
             <!-- ======== Tab 4: 上下文增强 ======== -->
             <div x-show="activeTab === 'context'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="context_enhancement">
 
@@ -349,7 +349,7 @@
 
             <!-- ======== Tab 5: 审查政策 ======== -->
             <div x-show="activeTab === 'policy'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="review_policy">
 
@@ -452,7 +452,7 @@
 
             <!-- ======== Tab: 依赖图 ========= -->
             <div x-show="activeTab === 'depgraph'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="depgraph">
 
@@ -491,7 +491,7 @@
 
             <!-- ======== Tab: Issue 分析 ======== -->
             <div x-show="activeTab === 'issue_analysis'" x-cloak>
-                <form method="POST" action="/webui/config/strategies/save">
+                <form method="POST" action="/config/strategies/save">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="section" value="issue_analysis">
 

--- a/backend/webui/templates/dashboard.html
+++ b/backend/webui/templates/dashboard.html
@@ -52,7 +52,7 @@
     <!-- 最近审查 -->
     <div>
         <h2 class="text-lg font-semibold mb-3">{{ _('dashboard.recent_reviews') }}</h2>
-        <div id="recent-reviews-container" hx-get="/webui/api/webui/recent-reviews-html" hx-trigger="load" hx-swap="innerHTML">
+        <div id="recent-reviews-container" hx-get="/api/recent-reviews-html" hx-trigger="load" hx-swap="innerHTML">
             <div class="text-center py-8 text-gray-400">
                 <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -70,7 +70,7 @@
 <script>
 function dashboardInit() {
     // 加载统计数据
-    fetch('/webui/api/webui/stats')
+    fetch('/api/stats')
         .then(r => r.json())
         .then(data => {
             document.getElementById('stat-total').textContent = data.total;
@@ -99,7 +99,7 @@ document.addEventListener('sse:review-status', function() {
     var container = document.getElementById('recent-reviews-container');
     if (container) {
         container.innerHTML = getLoadingHTML();
-        fetch('/webui/api/webui/recent-reviews-html', { headers: { 'HX-Request': 'true' } })
+        fetch('/api/recent-reviews-html', { headers: { 'HX-Request': 'true' } })
             .then(function(r) { return r.text(); })
             .then(function(html) { container.innerHTML = html; })
             .catch(function() { container.innerHTML = getErrorHTML(); });

--- a/backend/webui/templates/error.html
+++ b/backend/webui/templates/error.html
@@ -7,7 +7,7 @@
         <div class="text-8xl font-bold bg-gradient-to-r from-sakura-400 to-sakura-600 bg-clip-text text-transparent mb-4">{{ status_code }}</div>
         <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-2">{{ title }}</h1>
         <p class="text-gray-500 dark:text-gray-400 mb-6">{{ message }}</p>
-        <a href="/webui/" class="inline-flex items-center px-5 py-2.5 bg-gradient-to-r from-sakura-500 to-sakura-600 hover:from-sakura-600 hover:to-sakura-700 text-white rounded-xl transition-all shadow-md shadow-sakura-500/25">
+        <a href="/" class="inline-flex items-center px-5 py-2.5 bg-gradient-to-r from-sakura-500 to-sakura-600 hover:from-sakura-600 hover:to-sakura-700 text-white rounded-xl transition-all shadow-md shadow-sakura-500/25">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
             </svg>

--- a/backend/webui/templates/issue_detail.html
+++ b/backend/webui/templates/issue_detail.html
@@ -6,7 +6,7 @@
 <div class="space-y-6">
     <!-- 面包屑 -->
     <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-        <a href="/webui/issues/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('issue.title') }}</a>
+        <a href="/issues/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('issue.title') }}</a>
         <span>/</span>
         <span class="text-gray-900 dark:text-gray-100">#{{ analysis.issue_number }}</span>
     </div>
@@ -169,7 +169,7 @@
 {{ super() }}
 <script>
 function reanalyze(id) {
-    fetch('/webui/issues/' + id + '/reanalyze', {
+    fetch('/issues/' + id + '/reanalyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({})

--- a/backend/webui/templates/issues.html
+++ b/backend/webui/templates/issues.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- 统计卡片 -->
-    <div id="issue-stats-container" hx-get="/webui/issues/stats" hx-trigger="load" hx-swap="innerHTML">
+    <div id="issue-stats-container" hx-get="/issues/stats" hx-trigger="load" hx-swap="innerHTML">
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
                 <div class="animate-pulse h-4 bg-gray-200 dark:bg-gray-700 rounded w-20 mb-2"></div>
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Issue 列表（通过 HTMX 加载） -->
-    <div id="issue-list-container" hx-get="/webui/issues/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="issue-list-container" hx-get="/issues/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -36,7 +36,7 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadPage = function(n) { loadListPage('issue-list-container', '/webui/issues/list-fragment', n); };
-initFilterForm('issue-filter-form', 'issue-list-container', '/webui/issues/list-fragment');
+var loadPage = function(n) { loadListPage('issue-list-container', '/issues/list-fragment', n); };
+initFilterForm('issue-filter-form', 'issue-list-container', '/issues/list-fragment');
 </script>
 {% endblock %}

--- a/backend/webui/templates/login.html
+++ b/backend/webui/templates/login.html
@@ -54,7 +54,7 @@
 
             {% if has_oauth %}
             <!-- GitHub OAuth 登录按钮 -->
-            <a href="/webui/auth/github"
+            <a href="/auth/github"
                class="flex items-center justify-center gap-3 w-full py-3 px-4 bg-gradient-to-r from-gray-800 to-gray-900 dark:from-white dark:to-gray-100 hover:from-gray-700 hover:to-gray-800 dark:hover:from-gray-200 dark:hover:to-gray-100 text-white dark:text-gray-900 font-medium rounded-xl transition-all shadow-lg shadow-gray-800/25 dark:shadow-white/10">
                 <!-- GitHub Logo SVG -->
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -158,7 +158,7 @@
             btn.style.opacity = '0.6';
             try {
                 // 1. 获取 discoverable options
-                const optResp = await fetch('/webui/auth/passkey/discover', {
+                const optResp = await fetch('/auth/passkey/discover', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                 });
@@ -198,7 +198,7 @@
                 };
 
                 // 5. 验证
-                const verifyResp = await fetch('/webui/auth/passkey/verify-discover', {
+                const verifyResp = await fetch('/auth/passkey/verify-discover', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ challenge_id: challengeId, credential }),

--- a/backend/webui/templates/logs.html
+++ b/backend/webui/templates/logs.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- 日志列表（通过 HTMX 加载） -->
-    <div id="log-list-container" hx-get="/webui/logs/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="log-list-container" hx-get="/logs/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -26,7 +26,7 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadLogPage = function(n) { loadListPage('log-list-container', '/webui/logs/list-fragment', n); };
-initFilterForm('log-filter-form', 'log-list-container', '/webui/logs/list-fragment');
+var loadLogPage = function(n) { loadListPage('log-list-container', '/logs/list-fragment', n); };
+initFilterForm('log-filter-form', 'log-list-container', '/logs/list-fragment');
 </script>
 {% endblock %}

--- a/backend/webui/templates/pr_detail.html
+++ b/backend/webui/templates/pr_detail.html
@@ -6,9 +6,9 @@
 <div class="space-y-6">
     <!-- 面包屑导航 -->
     <nav class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-        <a href="/webui/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.dashboard') }}</a>
+        <a href="/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.dashboard') }}</a>
         <span>/</span>
-        <a href="/webui/pr/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.pr_reviews') }}</a>
+        <a href="/pr/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.pr_reviews') }}</a>
         <span>/</span>
         <span class="text-gray-900 dark:text-white">{{ review.repo_owner }}/{{ review.repo_name }} #{{ review.pr_id }}</span>
     </nav>
@@ -94,7 +94,7 @@
         </div>
 
         <!-- 操作按钮 -->
-        <a href="/webui/pr/{{ review.id }}/files" class="inline-flex items-center gap-1.5 px-4 py-2 bg-pink-500 hover:bg-pink-600 text-white rounded-lg text-sm font-medium transition-colors">
+        <a href="/pr/{{ review.id }}/files" class="inline-flex items-center gap-1.5 px-4 py-2 bg-pink-500 hover:bg-pink-600 text-white rounded-lg text-sm font-medium transition-colors">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
             </svg>
@@ -248,7 +248,7 @@
 
     <!-- 返回按钮 -->
     <div>
-        <a href="/webui/pr/" class="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400">
+        <a href="/pr/" class="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
             </svg>

--- a/backend/webui/templates/pr_files.html
+++ b/backend/webui/templates/pr_files.html
@@ -6,11 +6,11 @@
 <div class="space-y-4">
     <!-- 面包屑导航 -->
     <nav class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-        <a href="/webui/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.dashboard') }}</a>
+        <a href="/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.dashboard') }}</a>
         <span>/</span>
-        <a href="/webui/pr/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.pr_reviews') }}</a>
+        <a href="/pr/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('nav.pr_reviews') }}</a>
         <span>/</span>
-        <a href="/webui/pr/{{ review.id }}" class="hover:text-pink-600 dark:hover:text-pink-400">{{ review.repo_owner }}/{{ review.repo_name }} #{{ review.pr_id }}</a>
+        <a href="/pr/{{ review.id }}" class="hover:text-pink-600 dark:hover:text-pink-400">{{ review.repo_owner }}/{{ review.repo_name }} #{{ review.pr_id }}</a>
         <span>/</span>
         <span class="text-gray-900 dark:text-white">{{ _('pr.files') }}</span>
     </nav>
@@ -32,7 +32,7 @@
                     <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300">{{ _('pr.files') }}</h2>
                 </div>
                 <div id="file-list-container" class="max-h-[calc(100vh-280px)] overflow-y-auto"
-                     hx-get="/webui/pr/{{ review.id }}/files/file-fragment" hx-trigger="load" hx-swap="innerHTML">
+                     hx-get="/pr/{{ review.id }}/files/file-fragment" hx-trigger="load" hx-swap="innerHTML">
                     <div class="text-center py-8 text-gray-400">
                         <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -59,7 +59,7 @@
 
     <!-- 返回按钮 -->
     <div>
-        <a href="/webui/pr/{{ review.id }}" class="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400">
+        <a href="/pr/{{ review.id }}" class="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
             </svg>
@@ -86,7 +86,7 @@ function loadFileComments(filePath, btn) {
     panel.innerHTML = '<div class="text-center py-8 text-gray-400"><svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg><p class="mt-2">' + _t('loading') + '</p></div>';
 
     const params = new URLSearchParams({ file_path: filePath });
-    fetch('/webui/pr/' + REVIEW_ID + '/files/comment-fragment?' + params.toString(), {
+    fetch('/pr/' + REVIEW_ID + '/files/comment-fragment?' + params.toString(), {
         headers: { 'HX-Request': 'true' }
     })
     .then(r => r.text())

--- a/backend/webui/templates/pr_list.html
+++ b/backend/webui/templates/pr_list.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- PR 列表（通过 HTMX 加载） -->
-    <div id="pr-list-container" hx-get="/webui/pr/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="pr-list-container" hx-get="/pr/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -32,9 +32,9 @@ function exportCSV() {
     for (var pair of new FormData(form).entries()) {
         if (pair[1]) params.set(pair[0], pair[1]);
     }
-    window.location.href = '/webui/pr/export-csv?' + params.toString();
+    window.location.href = '/pr/export-csv?' + params.toString();
 }
-var loadPage = function(n) { loadListPage('pr-list-container', '/webui/pr/list-fragment', n); };
-initFilterForm('pr-filter-form', 'pr-list-container', '/webui/pr/list-fragment');
+var loadPage = function(n) { loadListPage('pr-list-container', '/pr/list-fragment', n); };
+initFilterForm('pr-filter-form', 'pr-list-container', '/pr/list-fragment');
 </script>
 {% endblock %}

--- a/backend/webui/templates/queue.html
+++ b/backend/webui/templates/queue.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- 统计卡片 -->
-    <div id="queue-stats-container" hx-get="/webui/queue/stats-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="queue-stats-container" hx-get="/queue/stats-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
             {% for i in range(5) %}
             <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-4 animate-pulse">
@@ -22,7 +22,7 @@
     </div>
 
     <!-- 队列列表 -->
-    <div id="queue-list-container" hx-get="/webui/queue/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="queue-list-container" hx-get="/queue/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -37,14 +37,14 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadQueuePage = function(n) { loadListPage('queue-list-container', '/webui/queue/list-fragment', n); };
-initFilterForm('queue-filter-form', 'queue-list-container', '/webui/queue/list-fragment');
+var loadQueuePage = function(n) { loadListPage('queue-list-container', '/queue/list-fragment', n); };
+initFilterForm('queue-filter-form', 'queue-list-container', '/queue/list-fragment');
 
 // SSE: 审查状态变更时自动刷新
 document.addEventListener('sse:review-status', function() {
     var statsContainer = document.getElementById('queue-stats-container');
     if (statsContainer) {
-        fetch('/webui/queue/stats-fragment', { headers: { 'HX-Request': 'true' } })
+        fetch('/queue/stats-fragment', { headers: { 'HX-Request': 'true' } })
             .then(function(r) { return r.text(); })
             .then(function(html) { statsContainer.innerHTML = html; })
             .catch(function() {});
@@ -52,7 +52,7 @@ document.addEventListener('sse:review-status', function() {
     var listContainer = document.getElementById('queue-list-container');
     if (listContainer) {
         listContainer.innerHTML = getLoadingHTML();
-        fetch('/webui/queue/list-fragment', { headers: { 'HX-Request': 'true' } })
+        fetch('/queue/list-fragment', { headers: { 'HX-Request': 'true' } })
             .then(function(r) { return r.text(); })
             .then(function(html) { listContainer.innerHTML = html; })
             .catch(function() { listContainer.innerHTML = getErrorHTML(); });

--- a/backend/webui/templates/register.html
+++ b/backend/webui/templates/register.html
@@ -88,7 +88,7 @@
             <!-- 注册完成后提示 -->
             <div class="mt-6 pt-4 border-t border-gray-100 dark:border-gray-700">
                 <p class="text-center text-xs text-gray-400 dark:text-gray-500">
-                    {{ _('register.after_register') }}<a href="/webui/auth/login" class="text-blue-500 hover:text-blue-600 dark:text-blue-400">{{ _('common.back') }}</a> {{ _('auth.login') }}{{ _('common.period') }}
+                    {{ _('register.after_register') }}<a href="/auth/login" class="text-blue-500 hover:text-blue-600 dark:text-blue-400">{{ _('common.back') }}</a> {{ _('auth.login') }}{{ _('common.period') }}
                 </p>
             </div>
         </div>

--- a/backend/webui/templates/repos.html
+++ b/backend/webui/templates/repos.html
@@ -10,7 +10,7 @@
             <h1 class="text-2xl font-bold">{{ _('repo.title') }}</h1>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('repo.installed_at') }}</p>
         </div>
-        <button onclick="loadListPage('repo-list-container', '/webui/repos/list-fragment', 1)"
+        <button onclick="loadListPage('repo-list-container', '/repos/list-fragment', 1)"
                 class="px-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
             <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
@@ -46,7 +46,7 @@
 <script>
 // 刷新仓库列表
 function refreshRepoList() {
-    loadListPage('repo-list-container', '/webui/repos/list-fragment', 1);
+    loadListPage('repo-list-container', '/repos/list-fragment', 1);
 }
 
 // 触发索引（文档或代码）
@@ -58,7 +58,7 @@ function triggerIndex(btn, repoName, indexType, csrfToken) {
     btn.textContent = '索引中...';
 
     var encodedName = encodeURIComponent(repoName).replace(/%2F/g, '/');
-    fetch('/webui/repos/' + encodedName + '/index-' + indexType, {
+    fetch('/repos/' + encodedName + '/index-' + indexType, {
         method: 'POST',
         headers: { 'X-CSRF-Token': csrfToken }
     })
@@ -136,7 +136,7 @@ function triggerScan(btn, repoName, csrfToken) {
     btn.textContent = '扫描中...';
 
     var encodedName = encodeURIComponent(repoName).replace(/%2F/g, '/');
-    fetch('/webui/repos/' + encodedName + '/scan', {
+    fetch('/repos/' + encodedName + '/scan', {
         method: 'POST',
         headers: { 'X-CSRF-Token': csrfToken }
     })

--- a/backend/webui/templates/scan_detail.html
+++ b/backend/webui/templates/scan_detail.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="space-y-6">
     <!-- 返回链接 -->
-    <a href="/webui/scans/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+    <a href="/scans/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
         </svg>

--- a/backend/webui/templates/scans.html
+++ b/backend/webui/templates/scans.html
@@ -20,7 +20,7 @@
     </div>
 
     <!-- 统计卡片 -->
-    <div id="scan-stats-container" hx-get="/webui/scans/stats" hx-trigger="load" hx-swap="innerHTML">
+    <div id="scan-stats-container" hx-get="/scans/stats" hx-trigger="load" hx-swap="innerHTML">
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
                 <div class="animate-pulse h-4 bg-gray-200 dark:bg-gray-700 rounded w-20 mb-2"></div>
@@ -30,7 +30,7 @@
     </div>
 
     <!-- 扫描列表（通过 HTMX 加载） -->
-    <div id="scan-list-container" hx-get="/webui/scans/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="scan-list-container" hx-get="/scans/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -45,12 +45,12 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadPage = function(n) { loadListPage('scan-list-container', '/webui/scans/list-fragment', n); };
-initFilterForm('scan-filter-form', 'scan-list-container', '/webui/scans/list-fragment');
+var loadPage = function(n) { loadListPage('scan-list-container', '/scans/list-fragment', n); };
+initFilterForm('scan-filter-form', 'scan-list-container', '/scans/list-fragment');
 
 function triggerScan() {
     if (!confirm('{{ _('scan.confirm_trigger') }}')) return;
-    fetch('/webui/scans/trigger', {
+    fetch('/scans/trigger', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-CSRF-Token': '{{ csrf_token }}'}
     })

--- a/backend/webui/templates/security.html
+++ b/backend/webui/templates/security.html
@@ -25,12 +25,12 @@
             </div>
             <div class="flex gap-3">
                 {% if global_mfa_required %}
-                <form method="POST" action="/webui/security/global-mfa/disable">
+                <form method="POST" action="/security/global-mfa/disable">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="px-4 py-2 bg-gray-700 text-white rounded-lg text-sm font-medium hover:bg-gray-800">{{ _('security.disable_global_mfa') }}</button>
                 </form>
                 {% else %}
-                <form method="POST" action="/webui/security/global-mfa/enable">
+                <form method="POST" action="/security/global-mfa/enable">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="px-4 py-2 bg-pink-500 text-white rounded-lg text-sm font-medium hover:bg-pink-600">{{ _('security.enable_global_mfa') }}</button>
                 </form>
@@ -80,7 +80,7 @@
                         </td>
                         <td class="px-6 py-4 text-sm text-gray-500">{{ item.last_security_event_at or '-' }}</td>
                         <td class="px-6 py-4 text-right text-sm">
-                            <a href="/webui/security/users/{{ item.user.id }}" class="text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.more') }}</a>
+                            <a href="/security/users/{{ item.user.id }}" class="text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.more') }}</a>
                         </td>
                     </tr>
                     {% else %}

--- a/backend/webui/templates/security_user_detail.html
+++ b/backend/webui/templates/security_user_detail.html
@@ -9,7 +9,7 @@
             <h1 class="text-2xl font-bold">{{ _('security.user_detail') }}</h1>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ target_user.github_username or target_user.telegram_id }}</p>
         </div>
-        <a href="/webui/security/" class="text-sm text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.back') }}</a>
+        <a href="/security/" class="text-sm text-pink-600 dark:text-pink-400 hover:underline">{{ _('common.back') }}</a>
     </div>
 
     <div class="grid gap-4 md:grid-cols-5">
@@ -40,12 +40,12 @@
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('security.mfa_requirement_desc') }}</p>
         <div class="mt-4 flex flex-wrap gap-3">
             {% if target_user.mfa_required %}
-            <form method="POST" action="/webui/security/users/{{ target_user.id }}/mfa/unrequire">
+            <form method="POST" action="/security/users/{{ target_user.id }}/mfa/unrequire">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-gray-700 text-white rounded-lg text-sm font-medium hover:bg-gray-800">{{ _('security.unrequire_mfa') }}</button>
             </form>
             {% else %}
-            <form method="POST" action="/webui/security/users/{{ target_user.id }}/mfa/require">
+            <form method="POST" action="/security/users/{{ target_user.id }}/mfa/require">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-pink-500 text-white rounded-lg text-sm font-medium hover:bg-pink-600">{{ _('security.require_mfa') }}</button>
             </form>
@@ -57,15 +57,15 @@
         <h2 class="text-base font-semibold text-red-700 dark:text-red-300">{{ _('security.danger_zone') }}</h2>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('security.danger_zone_desc') }}</p>
         <div class="mt-4 flex flex-wrap gap-3">
-            <form method="POST" action="/webui/security/users/{{ target_user.id }}/totp/reset" onsubmit="return confirm('{{ _('security.confirm_reset_totp') }}')">
+            <form method="POST" action="/security/users/{{ target_user.id }}/totp/reset" onsubmit="return confirm('{{ _('security.confirm_reset_totp') }}')">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600">{{ _('security.reset_totp') }}</button>
             </form>
-            <form method="POST" action="/webui/security/users/{{ target_user.id }}/passkeys/delete-all" onsubmit="return confirm('{{ _('security.confirm_delete_all_passkeys') }}')">
+            <form method="POST" action="/security/users/{{ target_user.id }}/passkeys/delete-all" onsubmit="return confirm('{{ _('security.confirm_delete_all_passkeys') }}')">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600">{{ _('security.delete_all_passkeys') }}</button>
             </form>
-            <form method="POST" action="/webui/security/users/{{ target_user.id }}/mfa/reset" onsubmit="return confirm('{{ _('security.confirm_reset_all_mfa') }}')">
+            <form method="POST" action="/security/users/{{ target_user.id }}/mfa/reset" onsubmit="return confirm('{{ _('security.confirm_reset_all_mfa') }}')">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-red-500 text-white rounded-lg text-sm font-medium hover:bg-red-600">{{ _('security.reset_all_mfa') }}</button>
             </form>
@@ -81,7 +81,7 @@
                     <p class="text-sm font-medium">{{ passkey.device_name or _('settings.passkey_default_name') }}</p>
                     <p class="text-xs text-gray-500">{{ _('common.created_at') }}: {{ passkey.created_at }}{% if passkey.last_used_at %} · {{ _('settings.last_used_at') }}: {{ passkey.last_used_at }}{% endif %}</p>
                 </div>
-                <form method="POST" action="/webui/security/users/{{ target_user.id }}/passkeys/{{ passkey.id }}/delete" onsubmit="return confirm('{{ _('security.confirm_delete_passkey') }}')">
+                <form method="POST" action="/security/users/{{ target_user.id }}/passkeys/{{ passkey.id }}/delete" onsubmit="return confirm('{{ _('security.confirm_delete_passkey') }}')">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="px-3 py-1.5 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg">{{ _('common.delete') }}</button>
                 </form>

--- a/backend/webui/templates/settings.html
+++ b/backend/webui/templates/settings.html
@@ -93,7 +93,7 @@
             </div>
 
             {% if not two_factor_enabled and not totp_setup %}
-            <form method="POST" action="/webui/settings/2fa/setup" class="mt-4">
+            <form method="POST" action="/settings/2fa/setup" class="mt-4">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="px-4 py-2 bg-pink-500 text-white rounded-lg text-sm font-medium hover:bg-pink-600 transition-colors">
                     {{ _('settings.enable_two_factor') }}
@@ -111,7 +111,7 @@
                             </ol>
                             <img src="{{ totp_setup.qr_code_data_uri }}" alt="{{ _('settings.totp_qr_alt') }}" class="mt-4 w-48 h-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-white p-2">
                             <p class="mt-3 text-xs text-gray-500 dark:text-gray-400 break-all">{{ _('settings.manual_secret') }}: <code>{{ totp_setup.secret }}</code></p>
-                            <form method="POST" action="/webui/settings/2fa/enable" class="mt-4 flex flex-col sm:flex-row gap-3">
+                            <form method="POST" action="/settings/2fa/enable" class="mt-4 flex flex-col sm:flex-row gap-3">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                                 <input name="code" type="text" inputmode="numeric" autocomplete="one-time-code" required placeholder="123456"
                                        class="px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-pink-500 focus:border-transparent outline-none">
@@ -136,7 +136,7 @@
 
                         {% if two_factor_enabled %}
                         <div class="mt-5 grid gap-4 md:grid-cols-2">
-                            <form method="POST" action="/webui/settings/2fa/recovery-codes/regenerate" class="p-4 rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+                            <form method="POST" action="/settings/2fa/recovery-codes/regenerate" class="p-4 rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                                 <h4 class="text-sm font-semibold">{{ _('settings.regenerate_recovery_codes') }}</h4>
                                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('settings.regenerate_recovery_codes_desc') }}</p>
@@ -147,7 +147,7 @@
                                 </button>
                             </form>
 
-                            <form method="POST" action="/webui/settings/2fa/disable" class="p-4 rounded-xl bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800">
+                            <form method="POST" action="/settings/2fa/disable" class="p-4 rounded-xl bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                                 <h4 class="text-sm font-semibold text-red-700 dark:text-red-300">{{ _('settings.disable_two_factor') }}</h4>
                                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('settings.disable_two_factor_desc') }}</p>
@@ -184,7 +184,7 @@
                                 {% if passkey.last_used_at %} · {{ _('settings.last_used_at') }}: {{ passkey.last_used_at }}{% endif %}
                             </p>
                         </div>
-                        <form method="POST" action="/webui/settings/passkeys/{{ passkey.id }}/delete">
+                        <form method="POST" action="/settings/passkeys/{{ passkey.id }}/delete">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="px-3 py-1.5 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors">
                                 {{ _('common.delete') }}
@@ -229,7 +229,7 @@ document.getElementById('register-passkey-btn').addEventListener('click', async 
     }
     try {
         const csrfToken = '{{ csrf_token }}';
-        const optionsResp = await fetch('/webui/settings/passkeys/register/options', {
+        const optionsResp = await fetch('/settings/passkeys/register/options', {
             method: 'POST',
             headers: { 'X-CSRF-Token': csrfToken },
         });
@@ -244,7 +244,7 @@ document.getElementById('register-passkey-btn').addEventListener('click', async 
             publicKey.excludeCredentials = publicKey.excludeCredentials.map((item) => ({ ...item, id: base64urlToBuffer(item.id) }));
         }
         const credential = await navigator.credentials.create({ publicKey });
-        const verifyResp = await fetch('/webui/settings/passkeys/register/verify', {
+        const verifyResp = await fetch('/settings/passkeys/register/verify', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
             body: JSON.stringify({

--- a/backend/webui/templates/setup_wizard.html
+++ b/backend/webui/templates/setup_wizard.html
@@ -482,7 +482,7 @@
                         </p>
                         <div class="flex gap-2">
                             <input type="text" x-model="form.github_oauth_redirect_uri"
-                                   placeholder="https://your-domain.com/webui/auth/callback"
+                                   placeholder="https://your-domain.com/auth/callback"
                                    class="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-pink-500 focus:border-transparent outline-none">
                             <button @click="generateOAuthCallback()"
                                     :disabled="!form.app_domain"
@@ -622,7 +622,7 @@ function setupWizard() {
             let domain = this.form.app_domain.trim().replace(/^https?:\/\//, '');
             if (!domain) return;
             const proto = domain.startsWith('localhost') ? 'http' : 'https';
-            this.form.github_oauth_redirect_uri = `${proto}://${domain}/webui/auth/callback`;
+            this.form.github_oauth_redirect_uri = `${proto}://${domain}/auth/callback`;
         },
 
         onProviderChange() {
@@ -654,7 +654,7 @@ function setupWizard() {
                 const resp = await fetch('/setup/api/state');
                 const data = await resp.json();
                 if (data.state === 'completed') {
-                    window.location.href = '/webui/';
+                    window.location.href = '/';
                     return;
                 }
                 if (data.current_step > 0) {
@@ -784,7 +784,7 @@ function setupWizard() {
                 try {
                     const resp = await fetch('/health');
                     if (resp.ok) {
-                        window.location.href = '/webui/auth/login';
+                        window.location.href = '/auth/login';
                         return;
                     }
                 } catch (e) {

--- a/backend/webui/templates/two_factor_verify.html
+++ b/backend/webui/templates/two_factor_verify.html
@@ -120,7 +120,7 @@
         }
         try {
             const csrfToken = '{{ csrf_token }}';
-            const optionsResp = await fetch('/webui/auth/2fa/passkey/options', {
+            const optionsResp = await fetch('/auth/2fa/passkey/options', {
                 method: 'POST',
                 headers: { 'X-CSRF-Token': csrfToken },
             });
@@ -134,7 +134,7 @@
                 publicKey.allowCredentials = publicKey.allowCredentials.map((item) => ({ ...item, id: base64urlToBuffer(item.id) }));
             }
             const assertion = await navigator.credentials.get({ publicKey });
-            const verifyResp = await fetch('/webui/auth/2fa/passkey/verify', {
+            const verifyResp = await fetch('/auth/2fa/passkey/verify', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
                 body: JSON.stringify({ challenge_id: data.challenge_id, credential: publicKeyCredentialToJSON(assertion) }),
@@ -142,7 +142,7 @@
             const verifyJson = await verifyResp.json();
             if (verifyResp.status === 429) throw new Error(localizePasskeyMessage(verifyJson.message, '{{ _("toast.rate_limit_exceeded") }}'));
             if (!verifyJson.success) throw new Error(localizePasskeyMessage(verifyJson.message, 'Passkey verify failed'));
-            window.location.href = verifyJson.data.redirect || '/webui/';
+            window.location.href = verifyJson.data.redirect || '/';
         } catch (error) {
             errorEl.textContent = error.message || '{{ _("auth.passkey_failed") }}';
             errorEl.classList.remove('hidden');

--- a/backend/webui/templates/user_detail.html
+++ b/backend/webui/templates/user_detail.html
@@ -7,7 +7,7 @@
     <!-- 面包屑 -->
     <div>
         <nav class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-            <a href="/webui/users/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('user.title') }}</a>
+            <a href="/users/" class="hover:text-pink-600 dark:hover:text-pink-400">{{ _('user.title') }}</a>
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
             <span class="text-gray-900 dark:text-gray-100">{{ target_user.github_username or target_user.telegram_id }}</span>
         </nav>
@@ -79,7 +79,7 @@
                     <span>{{ target_user.github_username or '-' }}</span>
                 </div>
             </div>
-            <form id="info-edit-form" method="POST" action="/webui/users/{{ target_user.id }}/info" class="hidden space-y-3"
+            <form id="info-edit-form" method="POST" action="/users/{{ target_user.id }}/info" class="hidden space-y-3"
                   data-confirm="{{ _('user.confirm_edit_info') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <div>
@@ -103,7 +103,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 space-y-5">
             <div>
                 <h3 class="text-base font-medium mb-3">{{ _('common.status') }}</h3>
-                <form method="POST" action="/webui/users/{{ target_user.id }}/toggle"
+                <form method="POST" action="/users/{{ target_user.id }}/toggle"
                       data-confirm="{{ _('user.confirm_disable') if target_user.is_active else _('user.confirm_enable') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="w-full px-4 py-2 rounded-lg text-sm font-medium transition-colors
@@ -118,7 +118,7 @@
             </div>
             <div class="border-t border-gray-200 dark:border-gray-700 pt-5">
                 <h3 class="text-base font-medium mb-3">{{ _('user.role') }}</h3>
-                <form method="POST" action="/webui/users/{{ target_user.id }}/role"
+                <form method="POST" action="/users/{{ target_user.id }}/role"
                       data-confirm="{{ _('user.confirm_role_change') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <select name="role" class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm mb-3 focus:ring-2 focus:ring-pink-500 focus:border-transparent outline-none">
@@ -140,7 +140,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-xl border border-red-200 dark:border-red-900/50 shadow-sm p-6">
             <h3 class="text-base font-medium mb-2 text-red-600 dark:text-red-400">{{ _('common.delete') }}</h3>
             <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">{{ _('user.delete_warning') }}</p>
-            <form method="POST" action="/webui/users/{{ target_user.id }}/delete"
+            <form method="POST" action="/users/{{ target_user.id }}/delete"
                   data-confirm="{{ _('user.confirm_delete_user', name=target_user.github_username or target_user.telegram_id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="w-full px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg text-sm font-medium transition-colors">
@@ -159,7 +159,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-base font-medium">PR {{ _('user.quota') }}</h3>
-                <form method="POST" action="/webui/users/{{ target_user.id }}/reset-quota" class="inline"
+                <form method="POST" action="/users/{{ target_user.id }}/reset-quota" class="inline"
                       data-confirm="{{ _('user.confirm_reset_quota', name=target_user.github_username or target_user.telegram_id) }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="text-xs px-3 py-1 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400 hover:border-pink-300 dark:hover:border-pink-700 transition-colors">
@@ -206,7 +206,7 @@
             <!-- 修改配额 -->
             <div class="mt-5 pt-5 border-t border-gray-200 dark:border-gray-700">
                 <h4 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">{{ _('user.quota') }}</h4>
-                <form method="POST" action="/webui/users/{{ target_user.id }}/quota"
+                <form method="POST" action="/users/{{ target_user.id }}/quota"
                       data-confirm="{{ _('common.are_you_sure') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="grid grid-cols-3 gap-3">
@@ -275,7 +275,7 @@
             <!-- 修改配额 -->
             <div class="mt-5 pt-5 border-t border-gray-200 dark:border-gray-700">
                 <h4 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">{{ _('user.quota') }}</h4>
-                <form method="POST" action="/webui/users/{{ target_user.id }}/issue-quota"
+                <form method="POST" action="/users/{{ target_user.id }}/issue-quota"
                       data-confirm="{{ _('common.are_you_sure') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <div class="grid grid-cols-3 gap-3">

--- a/backend/webui/templates/users.html
+++ b/backend/webui/templates/users.html
@@ -17,7 +17,7 @@
     </div>
 
     <!-- 用户列表（通过 HTMX 加载） -->
-    <div id="user-list-container" hx-get="/webui/users/list-fragment" hx-trigger="load" hx-swap="innerHTML">
+    <div id="user-list-container" hx-get="/users/list-fragment" hx-trigger="load" hx-swap="innerHTML">
         <div class="text-center py-8 text-gray-400">
             <svg class="w-8 h-8 mx-auto animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -32,7 +32,7 @@
 {% block extra_scripts %}
 {{ super() }}
 <script>
-var loadUserPage = function(n) { loadListPage('user-list-container', '/webui/users/list-fragment', n); };
-initFilterForm('user-filter-form', 'user-list-container', '/webui/users/list-fragment');
+var loadUserPage = function(n) { loadListPage('user-list-container', '/users/list-fragment', n); };
+initFilterForm('user-filter-form', 'user-list-container', '/users/list-fragment');
 </script>
 {% endblock %}


### PR DESCRIPTION
- Update demo URLs in README and README_EN by removing `/webui` suffix from live demo badge and access links
- Change OAuth callback URL setup instructions from `/webui/auth/callback` to `/auth/callback`
- Modify `github_authorize` in auth.py to save OAuth state with redirect path `/` instead of `/webui/`
- Add `_is_webui_path` helper to main.py for identifying WebUI requests using exclusion logic
- Update rate-limit exception handler to use `_is_webui_path` and change default redirect from `/webui/` to `/`
- Update HTTP exception handler (401/428) for WebUI paths using `_is_webui_path`, redirect to `/auth/login` and `/settings/` (without `/webui` prefix)
- Remove root endpoint `@app.get("/")` from main.py (previously returned service info)
- Trim `/webui` prefix from allowed exact paths in `_is_mfa_enrollment_path` inside webui/deps.py

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在上一版重构基础上进一步优化，彻底移除了 WebUI 路由中的 `/webui` 前缀，统一简化后端路径与前端模板引用，并优化了路径检测逻辑。净变更 +338/-318，属于纯重构，未新增功能或修复 Bug。

### 主要改动
- **路由前缀移除**：所有 WebUI 相关接口（认证、用户、配置、计费、安全等）的基础路径从 `/webui/xxx` 简化为 `/xxx`
- **模板链接更新**：同步更新 30+ 个 HTML 模板中的链接地址，覆盖侧边栏、导航栏及各功能页面
- **路径检测重构**：将 `_is_webui_path` 重命名为 `is_webui_path`，并改为基于请求状态（request state）而非路径字符串进行 WebUI 检测，提升准确性与可维护性
- **依赖与主程序调整**：更新 `backend/main.py`、`backend/webui/deps.py` 及路由初始化模块中的路径处理逻辑

### 影响范围
- **后端**：`main.py`、`deps.py`、`scan_report_service.py` 及所有 WebUI 路由模块
- **前端**：仪表盘、登录、用户管理、计费、任务队列、Agent 团队、Issue/PR 管理等页面的模板文件

此次重构简化了 URL 结构，并增强了 WebUI 检测机制的健壮性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/main.py"]
    N2["backend/services/scan_report_service.py"]
    N3["backend/webui/deps.py"]
    N4["backend/webui/routes/__init__.py"]
    N1 --> N3
    N1 --> N4
    N2 --> N3
    N4 --> N3
```

<!-- sakura-ai-depgraph-end -->