### PR TITLE
chore(release): Bump version from 2.10.0 to 2.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-2.10.0-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.10.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-2.10.0-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
+[![Version](https://img.shields.io/badge/Version-2.10.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI-Reviewer/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-yellow.svg)](LICENSE)

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,3 @@
 """Sakura AI Reviewer Backend"""
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -562,7 +562,7 @@ async def insert_default_configs_async():
         raise RuntimeError("异步会话工厂未初始化,请先调用 init_async_db()")
 
     default_configs = [
-        AppConfig(key_name="app_version", key_value="2.10.0", description="应用版本号"),
+        AppConfig(key_name="app_version", key_value="2.10.1", description="应用版本号"),
         AppConfig(
             key_name="max_concurrent_reviews",
             key_value="5",
@@ -683,7 +683,7 @@ def init_database(database_url: str):
 
             default_configs = [
                 AppConfig(
-                    key_name="app_version", key_value="2.10.0", description="应用版本号"
+                    key_name="app_version", key_value="2.10.1", description="应用版本号"
                 ),
                 AppConfig(
                     key_name="max_concurrent_reviews",

--- a/docker/mysql-init/init.sql
+++ b/docker/mysql-init/init.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS review_queue (
 
 -- 插入默认配置
 INSERT IGNORE INTO app_config (key_name, key_value, description) VALUES
-('app_version', '2.10.0', '应用版本号'),
+('app_version', '2.10.1', '应用版本号'),
 ('max_concurrent_reviews', '5', '最大并发审查数量'),
 ('review_timeout_seconds', '300', '审查超时时间（秒）'),
 ('enable_auto_review', 'true', '是否启用自动审查'),

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -2544,7 +2544,7 @@ Issue 分析详情。
   "success": true,
   "message": "ok",
   "data": {
-    "version": "2.10.0",
+    "version": "2.10.1",
     "build_date": "2026-05-11"
   }
 }


### PR DESCRIPTION
- Update version badge in README.md from 2.10.0 to 2.10.1
- Update version badge in README_EN.md from 2.10.0 to 2.10.1
- Update __version__ in backend/__init__.py from 2.10.0 to 2.10.1
- Update app_version default config in backend/models/database.py from 2.10.0 to 2.10.1
- Update app_version default config in docker/mysql-init/init.sql from 2.10.0 to 2.10.1
- Update version in docs/api-v1-reference.md from 2.10.0 to 2.10.1

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
这是一个发布版本升级的 PR，将版本号从 2.10.0 更新至 2.10.1。变更涉及 3 个文件，共 7 行代码增减，属于常规版本维护，无重大功能变更。

### 主要改动列表
- **版本号更新**：在 `backend/__init__.py` 中更新版本号。
- **数据库模型调整**：在 `backend/models/database.py` 中微调了模型定义（可能涉及字段或约束优化）。
- **初始化脚本修改**：在 `docker/mysql-init/init.sql` 中调整了数据库初始化语句。

### 影响范围
- **后端服务**：版本号变更影响所有后端 API 的版本标识。
- **数据库**：初始化脚本和模型调整可能影响数据库表结构或数据初始化流程。
- **部署流程**：版本升级需同步更新 Docker 镜像和部署配置。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/__init__.py"]
    N2["backend/models/database.py"]
```

<!-- sakura-ai-depgraph-end -->