### PR TITLE
Fix duplicate .sakura/ prefix in memory handling

### DIFF
--- a/backend/services/sakura_memory_service.py
+++ b/backend/services/sakura_memory_service.py
@@ -974,7 +974,8 @@ class SakuraMemoryService:
                 max_iterations=max_iterations,
             )
             for k, v in sakura_changes.items():
-                files[f".sakura/{k}"] = v
+                clean = k.removeprefix(".sakura/").lstrip("/")
+                files[f".sakura/{clean}"] = v
 
             # 串行处理 memory.md
             memory_changes = await agent.consolidate_file(
@@ -990,7 +991,8 @@ class SakuraMemoryService:
                 max_iterations=max_iterations,
             )
             for k, v in memory_changes.items():
-                files[f".sakura/{k}"] = v
+                clean = k.removeprefix(".sakura/").lstrip("/")
+                files[f".sakura/{clean}"] = v
 
             # 字符限制告警
             for path, content in files.items():
@@ -1130,8 +1132,11 @@ class SakuraMemoryService:
             logger.warning("[extract] 知识提取无结果: {}", repo_full_name)
             return False
 
-        # 合并子目录前缀
-        files = {f".sakura/{k}": v for k, v in extracted.items()}
+        # 合并子目录前缀（AI 可能已带 .sakura/ 前缀，需去重）
+        files = {}
+        for k, v in extracted.items():
+            clean = k.removeprefix(".sakura/").lstrip("/")
+            files[f".sakura/{clean}"] = v
 
         commit_msg = "chore(sakura): extract structured knowledge from reflections"
         await self.write_service.commit_files(repo, files, commit_msg)

--- a/backend/services/sakura_memory_service.py
+++ b/backend/services/sakura_memory_service.py
@@ -235,6 +235,18 @@ class SakuraMemoryService:
     - get_sakura_context: 读取上下文注入审查 prompt
     """
 
+    @staticmethod
+    def _normalize_sakura_path(key: str) -> str:
+        """Normalize a path key to .sakura/ relative form.
+
+        Strips any leading ``.sakura/`` prefix (the AI may include it),
+        then ``lstrip("/")`` removes stray leading slashes left after
+        ``removeprefix``.  The result is always prefixed with ``.sakura/``.
+        ``lstrip("/")`` is intentional here — unlike stripping a fixed
+        prefix, we are guarding against variable-length leading slashes.
+        """
+        return f".sakura/{key.removeprefix('.sakura/').lstrip('/')}"
+
     def __init__(self):
         """初始化服务 / Initialize service"""
         self.write_service = get_github_write_service()
@@ -974,8 +986,7 @@ class SakuraMemoryService:
                 max_iterations=max_iterations,
             )
             for k, v in sakura_changes.items():
-                clean = k.removeprefix(".sakura/").lstrip("/")
-                files[f".sakura/{clean}"] = v
+                files[self._normalize_sakura_path(k)] = v
 
             # 串行处理 memory.md
             memory_changes = await agent.consolidate_file(
@@ -991,8 +1002,7 @@ class SakuraMemoryService:
                 max_iterations=max_iterations,
             )
             for k, v in memory_changes.items():
-                clean = k.removeprefix(".sakura/").lstrip("/")
-                files[f".sakura/{clean}"] = v
+                files[self._normalize_sakura_path(k)] = v
 
             # 字符限制告警
             for path, content in files.items():
@@ -1135,8 +1145,7 @@ class SakuraMemoryService:
         # 合并子目录前缀（AI 可能已带 .sakura/ 前缀，需去重）
         files = {}
         for k, v in extracted.items():
-            clean = k.removeprefix(".sakura/").lstrip("/")
-            files[f".sakura/{clean}"] = v
+            files[self._normalize_sakura_path(k)] = v
 
         commit_msg = "chore(sakura): extract structured knowledge from reflections"
         await self.write_service.commit_files(repo, files, commit_msg)


### PR DESCRIPTION
Remove duplicate `.sakura/` prefixes when processing extracted knowledge in both `consolidate_memory` and `extract_knowledge` functions. This improves the handling of file paths and ensures consistency.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 修复了内存处理中重复的 `.sakura/` 前缀问题，并重构了路径标准化逻辑。仅修改了一个文件，代码变更量为 +18/-4。这是一个 Bug 修复与代码优化，旨在避免路径或标识符的重复前缀导致的错误，并提升代码可维护性。

### 主要改动列表
- **Bug 修复**：在 `backend/services/sakura_memory_service.py` 中，调整了内存处理逻辑，移除了重复添加 `.sakura/` 前缀的代码，确保路径或键名正确生成。
- **代码重构**：提取了路径标准化逻辑到独立函数，增强了代码复用性和可读性。
- **代码优化**：新增了 18 行代码（包括路径标准化函数和调用），同时删除了 4 行冗余代码，提升了代码健壮性。

### 影响范围
- **功能影响**：仅影响后端服务中的内存管理模块，修复后可避免因前缀重复导致的内存访问或存储错误，并改善路径处理的一致性。
- **风险评估**：低风险，变更集中且针对性强，无新增依赖或接口改动。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    N1["backend/services/sakura_memory_service.py"]
```

<!-- sakura-ai-depgraph-end -->