### PR TITLE
fix(config): Sanitize app_domain and update URL generation logic

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -16,14 +16,16 @@ from backend.core.ai_providers import get_provider_select_options
 DEFAULT_FETCH_URL_ALLOWED_CONTENT_TYPES = "text/html,application/xhtml+xml,text/plain"
 
 
-def sanitize_domain(domain: str) -> str:
+def sanitize_domain(domain: Optional[str]) -> str:
     """Strip protocol prefix and trailing slashes from a domain string."""
     domain = (domain or "").strip()
     for prefix in ("https://", "http://"):
         if domain.startswith(prefix):
             domain = domain.removeprefix(prefix)
             break
-    return domain.removesuffix("/")
+    while domain.endswith("/"):
+        domain = domain.removesuffix("/")
+    return domain
 
 
 class Settings(BaseSettings):

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -16,6 +16,16 @@ from backend.core.ai_providers import get_provider_select_options
 DEFAULT_FETCH_URL_ALLOWED_CONTENT_TYPES = "text/html,application/xhtml+xml,text/plain"
 
 
+def sanitize_domain(domain: str) -> str:
+    """Strip protocol prefix and trailing slashes from a domain string."""
+    domain = (domain or "").strip()
+    for prefix in ("https://", "http://"):
+        if domain.startswith(prefix):
+            domain = domain.removeprefix(prefix)
+            break
+    return domain.removesuffix("/")
+
+
 class Settings(BaseSettings):
     """应用配置"""
 
@@ -325,12 +335,7 @@ class Settings(BaseSettings):
     @property
     def sanitized_app_domain(self) -> str:
         """Return app_domain with protocol prefix and trailing slashes stripped."""
-        domain = (self.app_domain or "").strip()
-        for prefix in ("https://", "http://"):
-            if domain.startswith(prefix):
-                domain = domain[len(prefix) :]
-                break
-        return domain.rstrip("/")
+        return sanitize_domain(self.app_domain)
 
     @property
     def webhook_url(self) -> str:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -323,9 +323,19 @@ class Settings(BaseSettings):
         return self.sakura_env.lower() in {"dev", "development", "local"}
 
     @property
+    def sanitized_app_domain(self) -> str:
+        """Return app_domain with protocol prefix and trailing slashes stripped."""
+        domain = (self.app_domain or "").strip()
+        for prefix in ("https://", "http://"):
+            if domain.startswith(prefix):
+                domain = domain[len(prefix) :]
+                break
+        return domain.rstrip("/")
+
+    @property
     def webhook_url(self) -> str:
         """获取完整的Webhook URL"""
-        return f"https://{self.app_domain}{self.webhook_path}"
+        return f"https://{self.sanitized_app_domain}{self.webhook_path}"
 
     @property
     def github_oauth_auth_url(self) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,7 +40,7 @@ settings = get_settings()
 
 def _get_allowed_origins(app_settings: Settings) -> list[str]:
     """构造 CORS origin 列表。开发模式下放行本地调试地址。"""
-    origins = {f"https://{app_settings.app_domain}"}
+    origins = {f"https://{app_settings.sanitized_app_domain}"}
     if app_settings.is_development:
         port = app_settings.app_port
         origins.update(

--- a/backend/services/scan_report_service.py
+++ b/backend/services/scan_report_service.py
@@ -175,16 +175,16 @@ class ScanReportService:
                 duration = f"{int(delta // 3600)}h{int((delta % 3600) // 60)}m"
 
         lines = [
-            "🛡️ *Sakura AI 仓库扫描完成*",
+            "*Sakura AI 仓库扫描完成*",
             "",
-            f"📦 仓库: `{scan.repo_name}`",
+            f"仓库: `{scan.repo_name}`",
         ]
 
         if scan.commit_sha:
-            lines.append(f"🔧 Commit: `{scan.commit_sha[:7]}`")
+            lines.append(f"Commit: `{scan.commit_sha[:7]}`")
         if duration:
-            lines.append(f"⏱ 扫描耗时: {duration}")
-        lines.append(f"📊 扫描文件: {scan.code_file_count or 0}")
+            lines.append(f"扫描耗时: {duration}")
+        lines.append(f"扫描文件: {scan.code_file_count or 0}")
         lines.append("")
 
         # 健康评分
@@ -194,32 +194,38 @@ class ScanReportService:
         # 问题统计
         total = scan.total_findings or 0
         if total > 0:
-            lines.append("📋 *问题统计*")
+            lines.append("*问题统计*")
             if scan.critical_count or 0:
-                lines.append(f"  🔴 Critical: {scan.critical_count}")
+                lines.append(f" 🔴 Critical: {scan.critical_count}")
             if scan.major_count or 0:
-                lines.append(f"  🟡 Major: {scan.major_count}")
+                lines.append(f" 🟡 Major: {scan.major_count}")
             if scan.minor_count or 0:
-                lines.append(f"  🟠 Minor: {scan.minor_count}")
+                lines.append(f" 🟠 Minor: {scan.minor_count}")
             if scan.suggestion_count or 0:
-                lines.append(f"  💡 Suggestion: {scan.suggestion_count}")
+                lines.append(f" 💡 Suggestion: {scan.suggestion_count}")
             lines.append("")
 
             # Token 消耗
             total_tokens = (scan.prompt_tokens or 0) + (scan.completion_tokens or 0)
             if total_tokens > 0:
-                lines.append(f"🪙 Token 消耗: {total_tokens:,}")
+                lines.append(f"Token 消耗: {total_tokens:,}")
                 lines.append("")
         else:
             lines.append("✅ 未发现问题，代码质量良好")
             lines.append("")
 
-        # 链接：始终提供 WebUI 链接；如有 Issue 链接则同时展示
+        # 链接：如有 Issue 链接则展示；始终提供 WebUI 链接（若 app_domain 已配置）
         webui_url = get_webui_url(f"/scans/{scan.id}")
+        logger.debug(f"WebUI URL for scan {scan.id}: {webui_url!r}")
         link_url = issue_url or scan.report_issue_url
         if link_url:
-            lines.append(f"[📎 查看详细报告]({link_url})")
-        lines.append(f"[🌐 WebUI 查看详情]({webui_url})")
+            lines.append(f"[查看详细报告]({link_url})")
+        if webui_url:
+            lines.append(f"[WebUI 查看详情]({webui_url})")
+        else:
+            logger.warning(
+                f"app_domain 未配置，跳过 WebUI 链接 (scan_id={scan.id})"
+            )
 
         return "\n".join(lines)
 

--- a/backend/services/system_config_service.py
+++ b/backend/services/system_config_service.py
@@ -16,6 +16,7 @@ from backend.core.config import (
     get_settings,
     invalidate_dynamic_config_cache,
     get_all_dynamic_config_keys,
+    sanitize_domain,
 )
 
 # 敏感键（在页面显示时脱敏）
@@ -147,12 +148,7 @@ class SystemConfigService:
 
             # Auto-sanitize app_domain: strip protocol prefix and trailing slashes
             if key == "app_domain" and val:
-                val = val.strip()
-                for prefix in ("https://", "http://"):
-                    if val.startswith(prefix):
-                        val = val[len(prefix) :]
-                        break
-                val = val.rstrip("/")
+                val = sanitize_domain(val)
 
             result = await db.execute(
                 select(AppConfig).where(AppConfig.key_name == key)

--- a/backend/services/system_config_service.py
+++ b/backend/services/system_config_service.py
@@ -145,6 +145,15 @@ class SystemConfigService:
         for key, val in updates.items():
             is_sensitive = key in SYSTEM_SENSITIVE_KEYS
 
+            # Auto-sanitize app_domain: strip protocol prefix and trailing slashes
+            if key == "app_domain" and val:
+                val = val.strip()
+                for prefix in ("https://", "http://"):
+                    if val.startswith(prefix):
+                        val = val[len(prefix) :]
+                        break
+                val = val.rstrip("/")
+
             result = await db.execute(
                 select(AppConfig).where(AppConfig.key_name == key)
             )

--- a/backend/telegram/notifications.py
+++ b/backend/telegram/notifications.py
@@ -276,11 +276,14 @@ class NotificationSender:
             if issue_url:
                 text += f"\n[查看详细报告]({issue_url})"
             if scan_id is not None:
+                # 延迟导入：避免 telegram 模块与 webui 模块之间产生循环依赖
                 from backend.webui.deps import get_webui_url
 
                 webui_url = get_webui_url(f"/scans/{scan_id}")
                 if webui_url:
                     text += f"\n[WebUI 查看详情]({webui_url})"
+                else:
+                    logger.warning(f"app_domain 未配置，跳过 WebUI 链接 (scan_id={scan_id})")
 
             if not chat_ids:
                 logger.debug(f"无通知目标，跳过扫描完成通知: {repo_name}")

--- a/backend/telegram/notifications.py
+++ b/backend/telegram/notifications.py
@@ -264,33 +264,33 @@ class NotificationSender:
             )
 
             text = (
-                f"🛡️ *Sakura AI 仓库扫描完成*\n\n"
-                f"📦 仓库: {safe_repo_name}\n"
+                f"*Sakura AI 仓库扫描完成*\n\n"
+                f"仓库: {safe_repo_name}\n"
                 f"{health_emoji} 健康评分: *{health_score}/100*\n"
                 f"🔴 Critical: {critical_count}\n"
                 f"🟡 Major: {major_count}\n"
-                f"📝 总计发现: {total_findings} 个问题\n"
+                f"总计发现: {total_findings} 个问题\n"
             )
 
-            # 链接：如有 Issue 链接则展示；始终提供 WebUI 链接回退
+            # 链接：如有 Issue 链接则展示；始终提供 WebUI 链接回退（若 app_domain 已配置）
             if issue_url:
                 text += f"\n[查看详细报告]({issue_url})"
             if scan_id is not None:
-                # 延迟导入：避免 telegram 模块与 webui 模块之间产生循环依赖
                 from backend.webui.deps import get_webui_url
 
                 webui_url = get_webui_url(f"/scans/{scan_id}")
-                text += f"\n[🌐 WebUI 查看详情]({webui_url})"
+                if webui_url:
+                    text += f"\n[WebUI 查看详情]({webui_url})"
 
             if not chat_ids:
                 logger.debug(f"无通知目标，跳过扫描完成通知: {repo_name}")
                 return
 
             await self.send_to_targets(text, chat_ids, disable_web_page_preview=True)
-            logger.info(f"✅ 发送扫描完成通知: {repo_name} → {len(chat_ids)} 人")
+            logger.info(f"发送扫描完成通知: {repo_name} → {len(chat_ids)} 人")
 
         except Exception as e:
-            logger.error(f"❌ 发送扫描完成通知失败: {e}")
+            logger.error(f"发送扫描完成通知失败: {e}")
 
     async def send_critical_issue_alert(
         self,
@@ -321,9 +321,9 @@ class NotificationSender:
                 f"📝 标题: {safe_title}\n"
             )
 
-            text += f"\n📋 *AI 摘要*\n{safe_summary}\n"
+            text += f"\n*AI 摘要*\n{safe_summary}\n"
 
-            text += f"\n🔍 *可行性评估*\n{safe_feasibility}\n"
+            text += f"\n*可行性评估*\n{safe_feasibility}\n"
 
             if suggested_labels:
                 labels_str = ", ".join(

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from fastapi import Request, HTTPException, Depends, Form, Header
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from loguru import logger
 from sqlalchemy import Select
 from sqlalchemy.ext.asyncio import AsyncSession
 from itsdangerous import URLSafeTimedSerializer, BadSignature
@@ -175,8 +176,6 @@ def get_webui_url(path: str = "") -> str:
     """
     domain = get_settings().sanitized_app_domain
     if not domain:
-        from loguru import logger
-
         logger.warning(f"app_domain is empty, cannot build WebUI URL for path={path!r}")
         return ""
     if path and not path.startswith("/"):

--- a/backend/webui/deps.py
+++ b/backend/webui/deps.py
@@ -171,8 +171,16 @@ def get_webui_url(path: str = "") -> str:
     """Build an absolute WebUI URL for external consumption (Telegram, GitHub, etc.).
 
     ``path`` should start with ``/`` (e.g. ``"/scans/42"``).
+    Returns empty string if ``app_domain`` is not configured.
     """
-    domain = get_settings().app_domain
+    domain = get_settings().sanitized_app_domain
+    if not domain:
+        from loguru import logger
+
+        logger.warning(f"app_domain is empty, cannot build WebUI URL for path={path!r}")
+        return ""
+    if path and not path.startswith("/"):
+        path = "/" + path
     return f"https://{domain}{path}"
 
 

--- a/tests/test_config_basic_settings.py
+++ b/tests/test_config_basic_settings.py
@@ -151,3 +151,9 @@ class TestSanitizeDomain:
 
     def test_whitespace_and_prefix_and_slash(self):
         assert sanitize_domain("  https://example.com/  ") == "example.com"
+
+    def test_multiple_trailing_slashes(self):
+        assert sanitize_domain("example.com//") == "example.com"
+
+    def test_https_prefix_and_multiple_trailing_slashes(self):
+        assert sanitize_domain("https://example.com///") == "example.com"

--- a/tests/test_config_basic_settings.py
+++ b/tests/test_config_basic_settings.py
@@ -6,6 +6,7 @@ from backend.core.config import (
     Settings,
     get_all_db_config_keys,
     get_settings,
+    sanitize_domain,
     update_settings_field,
 )
 
@@ -116,3 +117,37 @@ def test_web_search_configs_have_range_limits_and_fetch_url_configs_do_not():
     }
 
     assert unrestricted_fetch_url_keys.isdisjoint(DYNAMIC_CONFIG_RANGES)
+
+
+class TestSanitizeDomain:
+    """Cover sanitize_domain edge cases."""
+
+    def test_plain_domain(self):
+        assert sanitize_domain("example.com") == "example.com"
+
+    def test_empty_string(self):
+        assert sanitize_domain("") == ""
+
+    def test_none_input(self):
+        assert sanitize_domain(None) == ""
+
+    def test_strip_whitespace(self):
+        assert sanitize_domain("  example.com  ") == "example.com"
+
+    def test_remove_https_prefix(self):
+        assert sanitize_domain("https://example.com") == "example.com"
+
+    def test_remove_http_prefix(self):
+        assert sanitize_domain("http://example.com") == "example.com"
+
+    def test_remove_trailing_slash(self):
+        assert sanitize_domain("example.com/") == "example.com"
+
+    def test_https_prefix_and_trailing_slash(self):
+        assert sanitize_domain("https://example.com/") == "example.com"
+
+    def test_http_prefix_and_trailing_slash(self):
+        assert sanitize_domain("http://example.com/") == "example.com"
+
+    def test_whitespace_and_prefix_and_slash(self):
+        assert sanitize_domain("  https://example.com/  ") == "example.com"


### PR DESCRIPTION
- Add `sanitized_app_domain` property in `backend/core/config.py` to strip protocol prefix and trailing slashes
- Update `webhook_url` property to use `sanitized_app_domain` instead of raw `app_domain`
- Modify CORS origin construction in `backend/main.py` to use `sanitized_app_domain`
- Implement auto-sanitization of `app_domain` in `backend/services/system_config_service.py` during config updates
- Update `get_webui_url` function in `backend/webui/deps.py` to handle missing `app_domain` and return empty string
- Remove emoji icons from scan report messages in `backend/services/scan_report_service.py` and `backend/telegram/notifications.py`
- Add conditional WebUI link generation in scan reports and notifications, with warning log when `app_domain` is not configured
- Update notification log messages to remove emoji prefixes

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览  
本次 PR 在原有修复基础上，进一步完善了 `app_domain` 的清理逻辑，新增对 `None` 输入和多个尾部斜杠的处理，并更新了 URL 生成逻辑。共修改 7 个文件，代码变更 +105/-26，重点增强了配置安全性、健壮性及测试覆盖。

### 主要改动列表  
- **配置清理逻辑增强**：在 `backend/core/config.py` 中，优化 `sanitize_domain` 函数，新增对 `None` 输入和多个尾部斜杠的处理，提升域名清理的健壮性。  
- **URL 生成逻辑更新**：在 `backend/telegram/notifications.py` 中调整 URL 构造方法，确保使用清理后的 `app_domain`，避免无效 URL。  
- **系统配置服务扩展**：在 `backend/services/system_config_service.py` 中调整配置项支持，优化域名管理。  
- **依赖注入调整**：在 `backend/webui/deps.py` 中更新依赖项，适配新的配置验证逻辑。  
- **测试覆盖增强**：在 `tests/test_config_basic_settings.py` 中新增测试用例，验证 `sanitize_domain` 函数对 `None` 和尾部斜杠的处理，确保清理逻辑正确。

### 影响范围  
- **安全提升**：防止因 `app_domain` 配置不当（如 `None` 或无效格式）导致的安全风险（如 URL 注入）。  
- **功能影响**：所有依赖 `app_domain` 的 URL 生成（如 Telegram 通知）将更可靠，避免因域名格式问题导致的错误。  
- **测试覆盖**：新增测试确保域名清理逻辑的稳定性，降低未来回归风险。  
- **兼容性**：无破坏性变更，但建议测试配置更新后的 URL 生成功能。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/core/config.py"]
    N2["tests/test_config_basic_settings.py"]
    N2 --> N1
```

<!-- sakura-ai-depgraph-end -->