### PR TITLE
docs(api): Update API v1 reference documentation with v1.3 details an...

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Sakura-AI-Reviewer/
 | [PR 功能指南](docs/PR_FEATURES_GUIDE.md)                   | PR 变更总结与依赖图配置说明        |
 | [配额系统指南](docs/QUOTA_SYSTEM_GUIDE.md)                 | PR/Issue 配额统计与自动重置机制    |
 | [安全与 MFA 指南](docs/SECURITY_MFA_GUIDE.md)              | TOTP、恢复码、Passkeys/WebAuthn 与安全中心 |
-| [API v1 参考文档](docs/api-v1-reference.md)             | RESTful API 接口文档（移动端对接） |
+| [API v1 参考文档](docs/api-v1-reference.md)             | RESTful API v1.3 接口文档（移动端 OAuth、MFA、SSE、Billing） |
 | [WebUI 设计文档](docs/plans/2026-03-27-webui-design.md) | WebUI 设计规范              |
 | [项目记忆系统使用指南](docs/SAKURA_MEMORY_GUIDE.md) | .sakura/ 目录结构、生命周期、配置说明 |
 | [项目记忆系统设计](docs/plans/2026-04-20-sakura-memory-design.md) | .sakura/ 记忆系统架构与配置 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -419,7 +419,7 @@ Sakura-AI-Reviewer/
 | [PR Features Guide](docs/PR_FEATURES_GUIDE.md)                 | PR change summary and dependency graph configuration |
 | [Quota System Guide](docs/QUOTA_SYSTEM_GUIDE.md)               | PR/Issue quota usage tracking and auto-reset mechanism |
 | [Security & MFA Guide](docs/SECURITY_MFA_GUIDE.md)             | TOTP, recovery codes, Passkeys/WebAuthn, and Security Center |
-| [API v1 Reference](docs/api-v1-reference.md)                   | RESTful API documentation (mobile integration)  |
+| [API v1 Reference](docs/api-v1-reference.md)                   | RESTful API v1.3 docs (mobile OAuth, MFA, SSE, Billing) |
 | [WebUI Design Document](docs/plans/2026-03-27-webui-design.md) | WebUI design specification                      |
 | [Project Memory Guide](docs/SAKURA_MEMORY_GUIDE.md) | .sakura/ directory structure, lifecycle, configuration (Chinese) |
 | [Project Memory System Design](docs/plans/2026-04-20-sakura-memory-design.md) | .sakura/ memory system architecture & config |

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -86,6 +86,7 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 401 | 未提供认证凭证 / 凭证无效或已过期 |
 | 403 | 权限不足（角色不满足要求） |
 | 428 | 需要先完成 MFA 注册（全局或单用户强制 MFA） |
+| 429 | 请求过于频繁或 MFA 连续失败后被临时锁定 |
 | 404 | 资源不存在 |
 | 409 | 资源冲突（如正在索引中） |
 | 500 | 服务器内部错误 |
@@ -101,6 +102,8 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 移动端 OAuth `GET /auth/github/mobile` | 10 次/分钟 |
 | OAuth 回调 `POST /auth/callback` | 5 次/分钟 |
 | 二次验证 `POST /auth/2fa/verify` | 5 次/分钟 |
+| Passkey 二次验证 `POST /auth/2fa/passkey/options` | 默认 10 次/分钟，可通过 `passkeys_authentication_rate_limit` 配置 |
+| Passkey 二次验证 `POST /auth/2fa/passkey/verify` | 默认 10 次/分钟，可通过 `passkeys_authentication_rate_limit` 配置 |
 | 登出 `POST /auth/logout` | 10 次/分钟 |
 | Setup 连接测试 `POST /setup/test-connection` | 10 次/分钟 |
 | Setup 模型列表 `POST /setup/ai-providers/{provider}/models` | 10 次/分钟 |
@@ -193,19 +196,14 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 76 | GET | `/billing/orders` | auth | 获取订单历史 |
 | 77 | POST | `/billing/admin/plans` | super_admin | 创建套餐 |
 | 78 | PUT | `/billing/admin/plans/{plan_id}` | super_admin | 编辑套餐 |
-| 79 | DELETE | `/billing/admin/plans/{plan_id}` | super_admin | 删除套餐 |
+| 79 | DELETE | `/billing/admin/plans/{plan_id}` | super_admin | 删除套餐（默认软删除，可选硬删除） |
 | 80 | POST | `/billing/admin/codes/generate` | super_admin | 批量生成兑换码 |
 | 81 | PUT | `/billing/admin/codes/{code_id}` | super_admin | 编辑兑换码 |
 | 82 | DELETE | `/billing/admin/codes/{code_id}` | super_admin | 删除兑换码 |
 | 83 | POST | `/billing/admin/grant` | super_admin | 手动为用户充值 |
-| 84 | POST | `/billing/admin/plans/batch-toggle` | super_admin | 批量启用/禁用套餐 |
-| 85 | POST | `/billing/admin/plans/batch-delete` | super_admin | 批量删除套餐 |
-| 86 | POST | `/billing/admin/codes/batch-enable` | super_admin | 批量启用兑换码 |
-| 87 | POST | `/billing/admin/codes/batch-disable` | super_admin | 批量禁用兑换码 |
-| 88 | POST | `/billing/admin/codes/batch-delete` | super_admin | 批量删除兑换码 |
-| 89 | POST | `/auth/2fa/passkey/options` | 免认证 | 创建 API Passkey 认证 options |
-| 90 | POST | `/auth/2fa/passkey/verify` | 免认证 | 验证 API Passkey 认证 |
-| 91 | GET | `/events` | auth | SSE 事件流 |
+| 84 | POST | `/auth/2fa/passkey/options` | 免认证 | 创建 API Passkey 认证 options |
+| 85 | POST | `/auth/2fa/passkey/verify` | 免认证 | 验证 API Passkey 认证 |
+| 86 | GET | `/events` | auth | SSE 事件流 |
 
 ---
 
@@ -374,7 +372,7 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 }
 ```
 
-客户端收到该响应后，应提示用户输入 TOTP 验证码或恢复码，并调用 `POST /auth/2fa/verify` 换取正式 Token。WebUI 支持 Passkey 作为二次验证方式；API v1 当前提供 TOTP/恢复码验证路径。
+客户端收到该响应后，应根据 `methods` 字段选择验证方式：TOTP/恢复码调用 `POST /auth/2fa/verify`，Passkey 调用 `POST /auth/2fa/passkey/options` 后再提交 `POST /auth/2fa/passkey/verify` 换取正式 Token。
 
 > **Android 接入建议**：获取 `access_token` 后存储到本地安全存储（如 EncryptedSharedPreferences），后续所有请求通过 `Authorization: Bearer <access_token>` 携带。
 
@@ -431,9 +429,9 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 
 | HTTP 状态码 | 说明 |
 |-------------|------|
-| 400 | 用户未启用二次验证、验证码/恢复码无效，或仅配置了 Passkey 而 API 侧未提供 Passkey 验证路径 |
+| 400 | 用户未启用二次验证、验证码/恢复码无效，或当前用户需使用 Passkey 完成验证 |
 | 401 | `mfa_token` 无效或已过期 |
-| 423 | 账户因连续 MFA 验证失败被临时锁定 |
+| 429 | 账户因连续 MFA 验证失败被临时锁定 |
 
 #### POST /auth/2fa/passkey/options
 
@@ -451,7 +449,10 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data.options` | object | WebAuthn Authentication Options（PublicKeyCredentialRequestOptions JSON）|
+| `data.challenge_id` | string | 服务端保存的 challenge ID，提交验证时需原样带回 |
+| `data.public_key` | object | WebAuthn Authentication Options（PublicKeyCredentialRequestOptions JSON） |
+| `data.rp_id` | string | Relying Party ID |
+| `data.origin` | string | 服务端用于校验的 Origin |
 
 **响应示例**：
 
@@ -460,12 +461,16 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
   "success": true,
   "message": "ok",
   "data": {
-    "options": {
-      "challenge": "base64-encoded-challenge",
+    "challenge_id": "base64url-challenge-id",
+    "public_key": {
+      "challenge": "base64url-challenge",
       "rpId": "example.com",
-      "allowCredentials": [...],
-      "timeout": 60000
-    }
+      "allowCredentials": [],
+      "timeout": 300000,
+      "userVerification": "required"
+    },
+    "rp_id": "example.com",
+    "origin": "https://example.com"
   }
 }
 ```
@@ -483,6 +488,7 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `mfa_token` | string | 是 | OAuth 回调返回的临时二次验证 Token |
+| `challenge_id` | string | 是 | `POST /auth/2fa/passkey/options` 返回的 challenge ID |
 | `credential` | object | 是 | WebAuthn 认证结果（navigator.credentials.get() 返回值 JSON 序列化）|
 
 **响应字段**：同 `POST /auth/callback` 成功签发 Token 时的响应。
@@ -493,7 +499,7 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 |-------------|------|
 | 400 | Passkey 认证失败或凭证无效 |
 | 401 | `mfa_token` 无效或已过期 |
-| 423 | 账户因连续 MFA 验证失败被临时锁定 |
+| 429 | 账户因连续 MFA 验证失败被临时锁定 |
 
 ---
 
@@ -617,8 +623,10 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | `redis_url` | string | 条件 | Redis 连接 URL（type=redis） |
 | `app_id` | string | 条件 | GitHub App ID（type=github） |
 | `private_key` | string | 条件 | GitHub 私钥（type=github） |
-| `api_key` | string | 条件 | OpenAI API Key（type=openai） |
-| `api_base` | string | 条件 | OpenAI API Base URL（type=openai） |
+| `provider` | string | 否 | AI 厂商 ID（type=openai，默认 `custom`） |
+| `api_key` | string | 条件 | OpenAI 兼容 API Key（type=openai） |
+| `api_base` | string | 条件 | OpenAI 兼容 API Base URL（type=openai） |
+| `model` | string | 否 | 用于辅助查询上下文窗口的模型名（type=openai） |
 | `bot_token` | string | 条件 | Telegram Bot Token（type=telegram） |
 
 **请求示例**：
@@ -655,7 +663,7 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data.providers` | array | AI Provider 元数据列表，包含 `id`、`label`、`base_url`、`default_model`、是否支持模型列表等信息 |
+| `data.providers` | array | AI Provider 元数据列表，包含 `id`、`label`、`base_url`、`default_model`、是否支持模型列表和上下文窗口等信息 |
 
 **响应示例**：
 
@@ -776,9 +784,11 @@ Setup 阶段按 AI 厂商获取模型列表，并尽可能提取上下文窗口�
 | `GITHUB_APP_ID` | string | GitHub App ID |
 | `GITHUB_PRIVATE_KEY` | string | GitHub App 私钥 |
 | `GITHUB_WEBHOOK_SECRET` | string | GitHub Webhook 密钥 |
-| `OPENAI_API_KEY` | string | OpenAI API Key |
-| `OPENAI_API_BASE` | string | OpenAI API Base URL |
-| `OPENAI_MODEL` | string | OpenAI 模型名 |
+| `AI_PROVIDER` | string | AI 厂商 ID |
+| `OPENAI_API_KEY` | string | OpenAI 兼容 API Key |
+| `OPENAI_API_BASE` | string | OpenAI 兼容 API Base URL |
+| `OPENAI_MODEL` | string | OpenAI 兼容模型名 |
+| `SUMMARY_PROVIDER` | string | Summary 使用的 AI 厂商 ID |
 | `TELEGRAM_BOT_TOKEN` | string | Telegram Bot Token |
 | `APP_DOMAIN` | string | 应用域名 |
 | `APP_PORT` | string | 应用端口 |
@@ -797,6 +807,8 @@ Setup 阶段按 AI 厂商获取模型列表，并尽可能提取上下文窗口�
 | `RERANK_BASE_URL` | string | Rerank Base URL |
 | `RERANK_MODEL` | string | Rerank 模型名 |
 | `RERANK_PROVIDER` | string | Rerank 提供商 |
+
+> **说明**：当前 Setup 状态步骤按 `database`、`github`、`ai`、`rag`、`admin` 分组展示，服务端实际必填检查来自 `field_groups` 返回值。
 
 **响应示例**：
 
@@ -1850,7 +1862,18 @@ Issue 分析详情。
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data.configs` | object | 键值对（键为配置名，值为配置值，敏感值已脱敏） |
+| `data.configs` | object | 键值对（键为配置名，值为配置值，敏感值已脱敏；包括数据库中保存的动态配置） |
+
+常见可配置键包括：
+
+| 配置键 | 说明 |
+|--------|------|
+| `openai_api_key` / `openai_api_base` / `openai_model` | OpenAI 兼容主模型配置 |
+| `output_language` | AI 输出语言配置 |
+| `init_user_daily_quota` / `init_user_weekly_quota` / `init_user_monthly_quota` | 自注册用户基础 PR 配额 |
+| `init_user_issue_daily_quota` / `init_user_issue_weekly_quota` / `init_user_issue_monthly_quota` | 自注册用户基础 Issue 配额 |
+| `init_admin_agent_daily_quota` / `init_admin_agent_weekly_quota` / `init_admin_agent_monthly_quota` | Setup 初始管理员 Agent 配额 |
+| `init_user_agent_daily_quota` / `init_user_agent_weekly_quota` / `init_user_agent_monthly_quota` | 自注册用户基础 Agent 配额 |
 
 **响应示例**：
 
@@ -2911,7 +2934,7 @@ Billing 端点仅在付费配额系统启用时可用；未启用时会返回拒
 
 #### DELETE /billing/admin/plans/{plan_id}
 
-删除套餐（软删除）。
+删除套餐。默认软删除；传入 `hard=true` 时从数据库硬删除。
 
 **认证级别**：super_admin
 
@@ -2921,43 +2944,22 @@ Billing 端点仅在付费配额系统启用时可用；未启用时会返回拒
 |------|------|------|
 | `plan_id` | int | 套餐 ID |
 
+**查询参数**：
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `hard` | bool | `false` | 是否硬删除 |
+
 **响应示例**：
 
 ```json
 {
   "success": true,
-  "message": "套餐已删除"
+  "id": 1,
+  "name": "Pro 月度包",
+  "hard_delete": false
 }
 ```
-
----
-
-#### POST /billing/admin/plans/batch-toggle
-
-批量启用或禁用套餐。
-
-**认证级别**：super_admin
-
-**请求体**：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `plan_ids` | int[] | 是 | 套餐 ID 列表 |
-| `enabled` | bool | 是 | `true` 启用，`false` 禁用 |
-
----
-
-#### POST /billing/admin/plans/batch-delete
-
-批量删除套餐。
-
-**认证级别**：super_admin
-
-**请求体**：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `plan_ids` | int[] | 是 | 套餐 ID 列表 |
 
 ---
 
@@ -2977,9 +2979,10 @@ Billing 端点仅在付费配额系统启用时可用；未启用时会返回拒
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `status` | string | 否 | 兑换码状态 |
+| `status` | string | 否 | 兑换码状态：`active` / `disabled` |
 | `expires_at` | string \| null | 否 | 过期时间 |
 | `max_uses` | int | 否 | 最大使用次数 |
+| `plan_id` | int | 否 | 绑定的新套餐 ID |
 
 ---
 
@@ -2995,47 +2998,15 @@ Billing 端点仅在付费配额系统启用时可用；未启用时会返回拒
 |------|------|------|
 | `code_id` | int | 兑换码 ID |
 
----
+**响应示例**：
 
-#### POST /billing/admin/codes/batch-enable
-
-批量启用兑换码。
-
-**认证级别**：super_admin
-
-**请求体**：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `code_ids` | int[] | 是 | 兑换码 ID 列表 |
-
----
-
-#### POST /billing/admin/codes/batch-disable
-
-批量禁用兑换码。
-
-**认证级别**：super_admin
-
-**请求体**：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `code_ids` | int[] | 是 | 兑换码 ID 列表 |
-
----
-
-#### POST /billing/admin/codes/batch-delete
-
-批量删除兑换码。
-
-**认证级别**：super_admin
-
-**请求体**：
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `code_ids` | int[] | 是 | 兑换码 ID 列表 |
+```json
+{
+  "success": true,
+  "id": 1,
+  "code": "SAKURA-ABCD"
+}
+```
 
 ---
 
@@ -3148,9 +3119,14 @@ data: {"scan_id": 101, "progress": 50, ...}
   -> 获取 access_token，或在用户启用 MFA 时获取 mfa_token
 
 5. 如返回 message="mfa_required":
-  POST /api/v1/auth/2fa/verify
-  Body: {"mfa_token": "xxx", "code": "123456"}
-  -> 获取正式 access_token
+   - TOTP/恢复码：POST /api/v1/auth/2fa/verify
+     Body: {"mfa_token": "xxx", "code": "123456"}
+   - Passkey：POST /api/v1/auth/2fa/passkey/options
+     Body: {"mfa_token": "xxx"}
+     -> 使用 public_key 发起 WebAuthn 认证
+     POST /api/v1/auth/2fa/passkey/verify
+     Body: {"mfa_token": "xxx", "challenge_id": "xxx", "credential": {...}}
+   -> 获取正式 access_token
 
 6. 后续请求: Authorization: Bearer <access_token>
 ```
@@ -3181,4 +3157,4 @@ val sseSource = EventSource.Factory.create(request, eventListener)
 
 ---
 
-> 文档版本：v1.2 | 最后更新：2026-05-09 | 端点总数：80
+> 文档版本：v1.3 | 最后更新：2026-05-21 | 端点总数：86


### PR DESCRIPTION
- Update README.md and README_EN.md to reflect RESTful API v1.3 documentation with OAuth, MFA, SSE, and Billing details
- Add HTTP 429 status code description for rate limiting and MFA lockout in docs/api-v1-reference.md
- Add rate limit entries for Passkey authentication endpoints (`POST /auth/2fa/passkey/options` and `POST /auth/2fa/passkey/verify`)
- Update endpoint table to renumber Passkey and SSE endpoints and clarify soft/hard deletion for套餐 deletion
- Enhance Passkey authentication flow documentation with new response fields (`challenge_id`, `public_key`, `rp_id`, `origin`) and request field (`challenge_id`)
- Update MFA verification error descriptions to use HTTP 429 for account lockout
- Expand AI Provider configuration fields to include `provider`, `api