### PR TITLE
feat(webhook): Support scan report issues in agent command handling

### DIFF
--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -1467,11 +1467,14 @@ async def handle_agent_command(payload: Dict[str, Any]) -> JSONResponse:
                 content={"status": "denied", "reason": "insufficient permission"}
             )
 
-        # 前置校验：检查是否有已完成的 Issue 分析记录
-        # 延迟导入：避免 webhook ↔ database 循环依赖
+        # 前置校验：检查是否有已完成的 Issue 分析记录，或是否为扫描自动创建的报告 Issue
+        # 延迟导入：避免 webhook ↔ database/scan_models 循环依赖
         from sqlalchemy import select, and_, desc
         from backend.models.database import IssueAnalysis, IssueAnalysisStatus
+        from backend.models.scan_models import RepoScan, ScanFinding
 
+        scan_report = None
+        scan_findings = []
         async with get_async_session() as session:
             existing_analysis = await session.scalar(
                 select(IssueAnalysis)
@@ -1486,17 +1489,37 @@ async def handle_agent_command(payload: Dict[str, Any]) -> JSONResponse:
                 .order_by(desc(IssueAnalysis.completed_at))
                 .limit(1)
             )
+            if not existing_analysis:
+                scan_report = await session.scalar(
+                    select(RepoScan)
+                    .where(
+                        and_(
+                            RepoScan.repo_owner == repo_owner,
+                            RepoScan.repo_name.in_({repo_name, repo_full_name}),
+                            RepoScan.report_issue_number == issue_number,
+                        )
+                    )
+                    .order_by(desc(RepoScan.completed_at), desc(RepoScan.created_at))
+                    .limit(1)
+                )
+                if scan_report:
+                    result = await session.execute(
+                        select(ScanFinding)
+                        .where(ScanFinding.scan_id == scan_report.id)
+                        .order_by(ScanFinding.severity, desc(ScanFinding.confidence))
+                    )
+                    scan_findings = list(result.scalars().all())
 
-        if not existing_analysis:
-            logger.info("/agent 无分析记录: {}#{}", repo_full_name, issue_number)
+        if not existing_analysis and not scan_report:
+            logger.info("/agent 无分析记录或扫描报告: {}#{}", repo_full_name, issue_number)
             await _post_issue_comment(
                 github_app, repo_owner, repo_name, repo_full_name, issue_number,
-                "❌ 此 Issue 尚未完成 AI 分析，请先使用 `/analyze` 命令分析此 Issue。",
+                "❌ 此 Issue 尚未完成 AI 分析，也未匹配到 Sakura 仓库扫描报告。请先使用 `/analyze` 命令分析此 Issue。",
             )
             return JSONResponse(
                 content={
                     "status": "skipped",
-                    "reason": "no completed analysis",
+                    "reason": "no completed analysis or scan report",
                 }
             )
 
@@ -1523,9 +1546,33 @@ async def handle_agent_command(payload: Dict[str, Any]) -> JSONResponse:
                 issue_analysis_context=analysis_ctx,
                 issue_comments=issue_comments,
             )
-            agent_task_context = build_agent_task_summary(
-                existing_analysis.summary or "", issue_context_md
-            )
+            task_summary = existing_analysis.summary if existing_analysis else ""
+            if scan_report:
+                # 延迟导入：避免 webhook ↔ scan_report_service/agent_team_models 循环依赖
+                from backend.services.scan_report_service import ScanReportService
+                from backend.models.agent_team_models import AgentTeamSourceType
+
+                scan_markdown = ScanReportService().generate_issue_body(
+                    scan_report, scan_findings
+                )
+                task_summary = scan_markdown
+                severity_order = {"critical": 0, "major": 1, "minor": 2, "suggestion": 3}
+                highest = min(
+                    (severity_order.get(f.severity, 4) for f in scan_findings),
+                    default=3,
+                )
+                priority = "critical" if highest == 0 else "high" if highest == 1 else "medium"
+                overrides.update(
+                    {
+                        "source_type": AgentTeamSourceType.SCAN_REPORT_ISSUE.value,
+                        "source_id": scan_report.id,
+                        "source_issue_number": issue_number,
+                        "title": f"处理扫描报告 Issue #{issue_number}",
+                        "priority": priority,
+                        "candidate_score": 90 if highest == 0 else 80 if highest == 1 else 60,
+                    }
+                )
+            agent_task_context = build_agent_task_summary(task_summary or "", issue_context_md)
             if agent_task_context:
                 overrides["summary"] = agent_task_context
 

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -20,6 +20,8 @@ from backend.core.config import get_settings, get_dynamic_config
 
 settings = get_settings()
 
+SCAN_SEVERITY_ORDER = {"critical": 0, "major": 1, "minor": 2, "suggestion": 3}
+
 
 def get_async_session():
     """获取异步会话"""
@@ -1556,9 +1558,8 @@ async def handle_agent_command(payload: Dict[str, Any]) -> JSONResponse:
                     scan_report, scan_findings
                 )
                 task_summary = scan_markdown
-                severity_order = {"critical": 0, "major": 1, "minor": 2, "suggestion": 3}
                 highest = min(
-                    (severity_order.get(f.severity, 4) for f in scan_findings),
+                    (SCAN_SEVERITY_ORDER.get(f.severity, 4) for f in scan_findings),
                     default=3,
                 )
                 priority = "critical" if highest == 0 else "high" if highest == 1 else "medium"

--- a/tests/test_agent_command.py
+++ b/tests/test_agent_command.py
@@ -60,9 +60,52 @@ class _FakeTask:
     id = 99
 
 
+class _FakeScan:
+    id = 77
+    repo_name = "owner/repo"
+    repo_owner = "owner"
+    report_issue_number = 42
+    created_at = None
+    commit_sha = "abcdef123456"
+    code_file_count = 10
+    overall_health_score = 55
+    critical_count = 1
+    major_count = 0
+    minor_count = 0
+    suggestion_count = 0
+    total_findings = 1
+
+
+class _FakeFinding:
+    id = 88
+    scan_id = 77
+    severity = "critical"
+    category = "security"
+    title = "Critical scan finding"
+    description = "Dangerous issue"
+    suggestion = "Fix it"
+    file_path = "src/app.py"
+    line_start = 10
+    line_end = 12
+    confidence = 95
+
+
+class _FakeResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._items
+
+
 class _FakeSession:
-    def __init__(self, scalar_result=None):
+    def __init__(self, scalar_result=None, scalar_results=None, execute_result=None):
         self._scalar_result = scalar_result
+        self._scalar_results = list(scalar_results or [])
+        self._execute_result = execute_result
 
     async def __aenter__(self):
         return self
@@ -71,10 +114,13 @@ class _FakeSession:
         pass
 
     async def scalar(self, stmt):
+        if self._scalar_results:
+            return self._scalar_results.pop(0)
         return self._scalar_result
 
     async def execute(self, *a, **kw):
-        pass
+        if self._execute_result is not None:
+            return self._execute_result
 
     async def commit(self):
         pass
@@ -218,6 +264,49 @@ async def test_agent_command_skipped_when_no_analysis(monkeypatch):
 
     assert response.status_code == 200
     assert b"no completed analysis" in response.body
+
+
+@pytest.mark.asyncio
+async def test_agent_command_creates_task_from_scan_report_issue(monkeypatch):
+    payload = _base_payload()
+    captured = {}
+
+    class CapturingCandidateService:
+        async def create_task_from_manual_issue(
+            self, db, repo_full_name, issue_number, started_by,
+            ai_config_snapshot=None, base_branch=None, overrides=None,
+        ):
+            captured["overrides"] = overrides
+            return _FakeTask()
+
+    _make_base_mocks(monkeypatch)
+    calls = {"count": 0}
+
+    def _session_factory():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeSession(
+                scalar_results=[None, _FakeScan()],
+                execute_result=_FakeResult([_FakeFinding()]),
+            )
+        return _FakeSession(scalar_result=_FakeAnalysis())
+
+    monkeypatch.setattr(webhook, "get_async_session", _session_factory)
+    monkeypatch.setattr(
+        "backend.services.agent_team.candidate_service.AgentTeamCandidateService",
+        CapturingCandidateService,
+    )
+
+    response = await webhook.handle_agent_command(payload)
+
+    assert response.status_code == 200
+    assert b"accepted" in response.body
+    overrides = captured["overrides"]
+    assert overrides["source_type"] == "scan_report_issue"
+    assert overrides["source_id"] == 77
+    assert overrides["priority"] == "critical"
+    assert "Sakura AI 仓库扫描报告" in overrides["summary"]
+    assert "Critical scan finding" in overrides["summary"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_command.py
+++ b/tests/test_agent_command.py
@@ -263,7 +263,7 @@ async def test_agent_command_skipped_when_no_analysis(monkeypatch):
     response = await webhook.handle_agent_command(payload)
 
     assert response.status_code == 200
-    assert b"no completed analysis" in response.body
+    assert b"no completed analysis or scan report" in response.body
 
 
 @pytest.mark.asyncio
@@ -304,7 +304,9 @@ async def test_agent_command_creates_task_from_scan_report_issue(monkeypatch):
     overrides = captured["overrides"]
     assert overrides["source_type"] == "scan_report_issue"
     assert overrides["source_id"] == 77
+    assert overrides["source_issue_number"] == 42
     assert overrides["priority"] == "critical"
+    assert overrides["candidate_score"] == 90
     assert "Sakura AI 仓库扫描报告" in overrides["summary"]
     assert "Critical scan finding" in overrides["summary"]
 


### PR DESCRIPTION
- Add import for RepoScan and ScanFinding models in webhook handler
- Query scan report and findings when no completed analysis exists
- Update log message and response to indicate missing analysis or scan report
- Generate task summary from scan report markdown when scan report is found
- Override task properties (source_type, source_id, priority, etc.) for scan report issues
- Add test case for creating task from scan report issue with fake scan and finding data
- Update test session mock to support scalar results and execute results for scan queries

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在原有 Webhook 功能基础上，进一步优化了扫描报告问题的处理逻辑，并提取了扫描严重性顺序常量。共修改 2 个文件，新增 151 行代码，删除 12 行，变更集中于后端 API 和测试模块。

### 主要改动列表
- **新增功能**：在 `backend/api/webhook.py` 中扩展 Webhook 处理逻辑，支持扫描报告问题的解析与代理命令响应（+3/-2）。
- **重构优化**：提取扫描严重性顺序到模块级常量，提升代码可维护性（参考 Commit 490f4c6）。
- **测试增强**：在 `tests/test_agent_command.py` 中补充测试用例，覆盖扫描报告问题处理场景（+3/-1）。

### 影响范围
- **功能影响**：增强 Webhook 与代理命令的集成，支持扫描报告问题的自动化处理，提升系统响应效率。
- **代码影响**：主要涉及后端 API 和测试模块，无破坏性变更，新增功能向后兼容。
- **测试影响**：新增测试用例确保功能稳定性，建议部署前运行完整测试套件。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/api/webhook.py"]
    N2["tests/test_agent_command.py"]
    N2 --> N1
```

<!-- sakura-ai-depgraph-end -->