### PR TITLE
fix(db): require SQLAlchemy aiomysql pre-ping fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ openai==1.10.0
 httpx==0.27.0
 
 # 数据库
-sqlalchemy==2.0.25
+sqlalchemy>=2.0.26,<2.1
 aiomysql==0.2.0
 asyncpg==0.29.0  # PostgreSQL 异步驱动（备用）
 alembic==1.13.1

--- a/tests/test_database_dependency_versions.py
+++ b/tests/test_database_dependency_versions.py
@@ -1,0 +1,60 @@
+"""Database dependency compatibility regression tests."""
+
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SQLALCHEMY_AIOMYSQL_PRE_PING_FIX_VERSION = Version("2.0.26")
+
+
+def _load_requirement(package_name: str) -> Requirement:
+    """从 requirements.txt 读取指定依赖。"""
+    normalized_name = package_name.lower()
+    for raw_line in (REPO_ROOT / "requirements.txt").read_text(
+        encoding="utf-8"
+    ).splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        requirement = Requirement(line)
+        if requirement.name.lower() == normalized_name:
+            return requirement
+
+    raise AssertionError(f"Missing dependency requirement: {package_name}")
+
+
+def _configured_minimum_version(requirement: Requirement) -> Version:
+    """返回依赖声明中的最低可安装版本。"""
+    exact_versions = [
+        Version(specifier.version)
+        for specifier in requirement.specifier
+        if specifier.operator == "=="
+    ]
+    if exact_versions:
+        return min(exact_versions)
+
+    lower_bounds = [
+        Version(specifier.version)
+        for specifier in requirement.specifier
+        if specifier.operator in {">=", "~="}
+    ]
+    if not lower_bounds:
+        raise AssertionError(
+            f"{requirement.name} must declare a lower bound for reproducible installs"
+        )
+
+    return max(lower_bounds)
+
+
+def test_sqlalchemy_version_keeps_aiomysql_pool_pre_ping_fix():
+    """SQLAlchemy 2.0.25 会触发 aiomysql pool_pre_ping 兼容问题。"""
+    sqlalchemy_requirement = _load_requirement("sqlalchemy")
+
+    assert (
+        _configured_minimum_version(sqlalchemy_requirement)
+        >= SQLALCHEMY_AIOMYSQL_PRE_PING_FIX_VERSION
+    )


### PR DESCRIPTION
## Summary
- require SQLAlchemy >=2.0.26,<2.1 to avoid the aiomysql pool_pre_ping ping signature bug
- add a dependency regression test so SQLAlchemy cannot be pinned back to the incompatible 2.0.25 version
- keep pool_pre_ping enabled instead of falling back to stale-connection-prone behavior

## Tests
- python -m pytest tests/test_database_dependency_versions.py tests/test_config_basic_settings.py -q
- python -m ruff check tests/test_database_dependency_versions.py
- git diff --check

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 修复了数据库依赖版本问题，新增测试以验证 SQLAlchemy 与 aiomysql 的预连接（pre-ping）修复。变更集中在测试文件，共 2 个文件，代码增删 +61/-1。

### 主要改动列表
- **新增测试文件**：`tests/test_database_dependency_versions.py`（+60 行），用于检查 SQLAlchemy 和 aiomysql 的版本兼容性，确保预连接修复生效。
- **其他文件**：未明确列出，但 PR 标题暗示可能涉及数据库配置或依赖声明的微调（代码变更总计 +61/-1）。

### 影响范围
- **功能影响**：提升数据库连接的稳定性和兼容性，避免因版本不匹配导致的预连接失败。
- **测试影响**：新增测试覆盖依赖版本验证，增强 CI/CD 的可靠性。
- **适用场景**：使用 SQLAlchemy 和 aiomysql 的异步数据库应用。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_database_dependency_versions.py"]
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-issue-links-start -->

Resolves #353

<!-- sakura-ai-issue-links-end -->