### PR TITLE
fix(db): require SQLAlchemy aiomysql pre-ping fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ openai==1.10.0
 httpx==0.27.0
 
 # 数据库
-sqlalchemy==2.0.25
+sqlalchemy>=2.0.26,<2.1
 aiomysql==0.2.0
 asyncpg==0.29.0  # PostgreSQL 异步驱动（备用）
 alembic==1.13.1

--- a/tests/test_agent_team_cancel_and_prompts.py
+++ b/tests/test_agent_team_cancel_and_prompts.py
@@ -246,7 +246,8 @@ def test_is_task_cancel_requested_returns_false_for_unknown():
 # ── Git workspace: Python project detection ──────────────────
 
 
-def test_install_workspace_dependencies_skips_non_python(tmp_path):
+@pytest.mark.asyncio
+async def test_install_workspace_dependencies_skips_non_python(tmp_path):
     """Non-Python projects should not create .venv or call pip."""
     from unittest.mock import AsyncMock, MagicMock
 
@@ -254,16 +255,14 @@ def test_install_workspace_dependencies_skips_non_python(tmp_path):
     executor = MagicMock()
     executor.run = AsyncMock()
 
-    import asyncio
-    asyncio.get_event_loop().run_until_complete(
-        service._install_workspace_dependencies(executor, tmp_path)
-    )
+    await service._install_workspace_dependencies(executor, tmp_path)
 
     assert not (tmp_path / ".venv").exists()
     executor.run.assert_not_awaited()
 
 
-def test_install_workspace_dependencies_creates_venv_for_python(tmp_path):
+@pytest.mark.asyncio
+async def test_install_workspace_dependencies_creates_venv_for_python(tmp_path):
     """Python projects with pyproject.toml should trigger venv creation."""
     (tmp_path / "pyproject.toml").write_text("[project]\nname='test'\n")
 
@@ -273,13 +272,13 @@ def test_install_workspace_dependencies_creates_venv_for_python(tmp_path):
     executor = MagicMock()
     executor.run = AsyncMock()
 
-    import asyncio
+    with patch(
+        "backend.services.agent_team.git_workspace_service.get_dynamic_config",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await service._install_workspace_dependencies(executor, tmp_path)
 
-    async def _run():
-        with patch("backend.services.agent_team.git_workspace_service.get_dynamic_config", new_callable=AsyncMock, return_value=None):
-            await service._install_workspace_dependencies(executor, tmp_path)
-        assert executor.run.call_count >= 1
-        calls_str = " ".join(str(c) for c in executor.run.call_args_list)
-        assert "venv" in calls_str
-
-    asyncio.get_event_loop().run_until_complete(_run())
+    assert executor.run.call_count >= 1
+    calls_str = " ".join(str(c) for c in executor.run.call_args_list)
+    assert "venv" in calls_str

--- a/tests/test_database_dependency_versions.py
+++ b/tests/test_database_dependency_versions.py
@@ -1,0 +1,60 @@
+"""Database dependency compatibility regression tests."""
+
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SQLALCHEMY_AIOMYSQL_PRE_PING_FIX_VERSION = Version("2.0.26")
+
+
+def _load_requirement(package_name: str) -> Requirement:
+    """从 requirements.txt 读取指定依赖。"""
+    normalized_name = package_name.lower()
+    for raw_line in (REPO_ROOT / "requirements.txt").read_text(
+        encoding="utf-8"
+    ).splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        requirement = Requirement(line)
+        if requirement.name.lower() == normalized_name:
+            return requirement
+
+    raise AssertionError(f"Missing dependency requirement: {package_name}")
+
+
+def _configured_minimum_version(requirement: Requirement) -> Version:
+    """返回依赖声明中的最低可安装版本。"""
+    exact_versions = [
+        Version(specifier.version)
+        for specifier in requirement.specifier
+        if specifier.operator == "=="
+    ]
+    if exact_versions:
+        return min(exact_versions)
+
+    lower_bounds = [
+        Version(specifier.version)
+        for specifier in requirement.specifier
+        if specifier.operator in {">=", "~="}
+    ]
+    if not lower_bounds:
+        raise AssertionError(
+            f"{requirement.name} must declare a lower bound for reproducible installs"
+        )
+
+    return max(lower_bounds)
+
+
+def test_sqlalchemy_version_keeps_aiomysql_pool_pre_ping_fix():
+    """SQLAlchemy 2.0.25 会触发 aiomysql pool_pre_ping 兼容问题。"""
+    sqlalchemy_requirement = _load_requirement("sqlalchemy")
+
+    assert (
+        _configured_minimum_version(sqlalchemy_requirement)
+        >= SQLALCHEMY_AIOMYSQL_PRE_PING_FIX_VERSION
+    )


### PR DESCRIPTION
## Summary
- require SQLAlchemy >=2.0.26,<2.1 to avoid the aiomysql pool_pre_ping ping signature bug
- add a dependency regression test so SQLAlchemy cannot be pinned back to the incompatible 2.0.25 version
- keep pool_pre_ping enabled instead of falling back to stale-connection-prone behavior

## Tests
- python -m pytest tests/test_database_dependency_versions.py tests/test_config_basic_settings.py -q
- python -m ruff check tests/test_database_dependency_versions.py
- git diff --check

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在原有数据库依赖版本修复基础上，进一步优化了测试代码，避免了全局事件循环查找问题。变更主要集中在测试文件，未修改核心代码，确保了 SQLAlchemy 和 aiomysql 预连接（pre-ping）功能的兼容性验证。

### 主要改动列表
- **测试优化**：修改 `tests/test_agent_team_cancel_and_prompts.py`（+14/-15），调整测试逻辑以避免全局事件循环查找，提升测试稳定性。
- **新增测试**：保留并整合了 `tests/test_database_dependency_versions.py`（+60 行），用于验证 SQLAlchemy 和 aiomysql 的版本兼容性及预连接修复。
- **代码变更**：总计 +75/-16，无重大重构或 Bug 修复，聚焦测试改进。

### 影响范围
- **测试层面**：增强了数据库依赖版本验证和测试代码的健壮性，确保预连接功能在特定版本下稳定工作。
- **功能影响**：无直接影响生产代码，但通过测试优化提升了数据库连接的可靠性预期。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_agent_team_cancel_and_prompts.py"]
```

<!-- sakura-ai-depgraph-end -->