### PR TITLE
fix: Enhance Redis Pub/Sub listener robustness and update dependency

### DIFF
--- a/backend/services/sakura_agent_base.py
+++ b/backend/services/sakura_agent_base.py
@@ -162,11 +162,11 @@ class SakuraAgentBase:
                 logger.error(
                     "{} LLM 调用失败 (iteration {}): {}", self.log_prefix, i, e
                 )
-                break
+                return
 
             if not response or not response.choices:
                 logger.warning("{} LLM 返回空响应 (iteration {})", self.log_prefix, i)
-                break
+                return
 
             choice = response.choices[0]
             msg = choice.message

--- a/backend/services/sakura_consolidation_agent.py
+++ b/backend/services/sakura_consolidation_agent.py
@@ -214,8 +214,15 @@ class SakuraConsolidationAgent(SakuraAgentBase):
             max_iterations,
         )
 
+        initial_user_message = (
+            f"请开始合并 {target_file}：先按系统指令读取必要文件，"
+            f"再只更新 {target_file}，完成后简要总结。"
+        )
         await self._run_agent_conversation(
-            system_prompt, effective_model, max_iterations
+            system_prompt,
+            effective_model,
+            max_iterations,
+            initial_user_message=initial_user_message,
         )
 
         changes = self._collect_changes()

--- a/backend/webui/sse.py
+++ b/backend/webui/sse.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from typing import Dict, List, Any
 from loguru import logger
+import redis.exceptions
 
 
 class SSEManager:
@@ -101,15 +102,21 @@ async def start_redis_listener(_attempt: int = 1):
         # 成功连接后重置重试计数
         _attempt = 1
 
-        async for message in pubsub.listen():
-            if message["type"] == "pmessage":
-                try:
-                    event = json.loads(message["data"])
-                    channel = event.get("channel", "webui:events")
-                    # 转发给本地 SSE 订阅者（避免重复广播到 Redis）
-                    await sse_manager.publish(channel, event)
-                except (json.JSONDecodeError, KeyError) as e:
-                    logger.warning(f"解析 SSE 事件失败: {e}")
+        # 外层循环：捕获 socket 空闲超时后重新进入 listen()，不重建连接
+        while True:
+            try:
+                async for message in pubsub.listen():
+                    if message["type"] == "pmessage":
+                        try:
+                            event = json.loads(message["data"])
+                            channel = event.get("channel", "webui:events")
+                            # 转发给本地 SSE 订阅者（避免重复广播到 Redis）
+                            await sse_manager.publish(channel, event)
+                        except (json.JSONDecodeError, KeyError) as e:
+                            logger.warning(f"解析 SSE 事件失败: {e}")
+            except (redis.exceptions.TimeoutError, TimeoutError, OSError):
+                # Socket 空闲读超时 — 服务端订阅仍有效，直接重新进入 listen
+                continue
     except asyncio.CancelledError:
         logger.info("Redis Pub/Sub 监听已停止")
         raise

--- a/backend/webui/sse.py
+++ b/backend/webui/sse.py
@@ -2,9 +2,10 @@
 
 import asyncio
 import json
-from typing import Dict, List, Any
+from typing import Any, Dict, List
+
+import redis.exceptions  # 仅异常类型引用，不触发连接初始化
 from loguru import logger
-import redis.exceptions
 
 
 class SSEManager:
@@ -102,7 +103,7 @@ async def start_redis_listener(_attempt: int = 1):
         # 成功连接后重置重试计数
         _attempt = 1
 
-        # 外层循环：捕获 socket 空闲超时后重新进入 listen()，不重建连接
+        # 外层循环：Redis 空闲读超时只重新进入 listen()；真实连接异常交给外层重连
         while True:
             try:
                 async for message in pubsub.listen():
@@ -114,8 +115,8 @@ async def start_redis_listener(_attempt: int = 1):
                             await sse_manager.publish(channel, event)
                         except (json.JSONDecodeError, KeyError) as e:
                             logger.warning(f"解析 SSE 事件失败: {e}")
-            except (redis.exceptions.TimeoutError, TimeoutError, OSError):
-                # Socket 空闲读超时 — 服务端订阅仍有效，直接重新进入 listen
+            except (redis.exceptions.TimeoutError, TimeoutError) as e:
+                logger.debug(f"Redis listen 空闲读超时，继续等待消息: {e}")
                 continue
     except asyncio.CancelledError:
         logger.info("Redis Pub/Sub 监听已停止")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ httpx>=0.27.0
 
 # 数据库
 sqlalchemy>=2.0.28,<2.1
-aiomysql>=0.3.0
+asyncmy>=0.2.9
 asyncpg>=0.29.0  # PostgreSQL 异步驱动（备用）
 alembic>=1.13.1
 

--- a/tests/test_sakura_agent_conversation.py
+++ b/tests/test_sakura_agent_conversation.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.services import sakura_agent_base as agent_base_module
+from backend.services.sakura_agent_base import SakuraAgentBase
+from backend.services.sakura_consolidation_agent import SakuraConsolidationAgent
+
+
+@pytest.mark.asyncio
+async def test_consolidation_agent_starts_conversation_with_user_task_message():
+    captured = {}
+
+    class Client:
+        async def call_with_retry(self, **kwargs):
+            captured["messages"] = kwargs["messages"]
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="done", tool_calls=None),
+                    )
+                ]
+            )
+
+    agent = SakuraConsolidationAgent()
+    agent._api_client = Client()
+    agent._default_model = "test-model"
+
+    changes = await agent.consolidate_file(
+        repo=object(),
+        repo_full_name="owner/repo",
+        sakura_ref="main",
+        target_file="SAKURA.md",
+        new_reflection_files=["2026-05-31_PR372_adca028.md"],
+        total_reflections=383,
+        max_chars=5000,
+        languages="Python: 1",
+        model="test-model",
+        max_iterations=1,
+    )
+
+    assert changes == {}
+    messages = captured["messages"]
+    assert [message["role"] for message in messages[:2]] == ["system", "user"]
+    assert "SAKURA.md" in messages[1]["content"]
+    assert "开始" in messages[1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_agent_conversation_does_not_report_max_iterations_after_llm_error(
+    monkeypatch,
+):
+    logs = {"errors": [], "warnings": []}
+
+    class Logger:
+        def error(self, message, *args, **kwargs):
+            logs["errors"].append(message.format(*args))
+
+        def warning(self, message, *args, **kwargs):
+            logs["warnings"].append(message.format(*args))
+
+        def info(self, message, *args, **kwargs):
+            pass
+
+    class Client:
+        async def call_with_retry(self, **kwargs):
+            raise RuntimeError("upstream request failed")
+
+    class Agent(SakuraAgentBase):
+        log_prefix = "[test-agent]"
+
+        def _ensure_client(self):
+            return None
+
+        def _get_tools(self):
+            return []
+
+    monkeypatch.setattr(agent_base_module, "logger", Logger())
+    agent = Agent()
+    agent._api_client = Client()
+
+    await agent._run_agent_conversation(
+        system_prompt="system instructions",
+        model="test-model",
+        max_iterations=50,
+        initial_user_message="start",
+    )
+
+    assert any("LLM 调用失败 (iteration 0)" in error for error in logs["errors"])
+    assert not any("达到最大迭代次数" in warning for warning in logs["warnings"])


### PR DESCRIPTION
Improves the `SSEManager`'s Redis subscription loop in `sse.py` by wrapping the message listening logic in a `while True` loop. This allows the listener to automatically retry connecting or re-entering the listen state upon encountering common network issues like timeouts (`TimeoutError`, `redis.exceptions.TimeoutError`, `OSError`), without needing to rebuild the Redis connection entirely.

Also updates the dependency from `aiomysql` to `asyncmy` in `requirements.txt`.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

## 变更概览
本次 PR 在原有 Redis Pub/Sub SSE 监听健壮性增强基础上，进一步重构 Sakura Agent 对话流程，并补充单元测试，提升实时消息推送与 Agent 会话处理的稳定性、可维护性。

## 主要改动列表
- **增强 Redis Pub/Sub 监听健壮性**
  - 优化 SSE 场景下 Redis Pub/Sub listener loop 的消息监听、退出与异常处理。
  - 改善 Redis 连接、订阅或读取异常时的容错能力，降低推送链路中断风险。
- **重构 Agent 对话流程**
  - 调整 `sakura_agent_base.py` 与 `sakura_consolidation_agent.py` 中的会话处理逻辑。
  - 优化 Agent conversation flow，使对话状态流转更清晰、稳定。
- **补充测试覆盖**
  - 新增 `tests/test_sakura_agent_conversation.py`，覆盖 Agent 会话流程相关逻辑。
- **依赖与代码整理**
  - 更新相关依赖，并整理部分实现细节以配合稳定性改进。

## 影响范围
- 影响 SSE 实时推送、Redis Pub/Sub 通信链路。
- 影响 Sakura Agent 的会话处理与整合流程。
- 新增测试有助于降低后续对话流程改动的回归风险。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/services/sakura_agent_base.py"]
    N2["backend/services/sakura_consolidation_agent.py"]
    N3["tests/test_sakura_agent_conversation.py"]
    N2 --> N1
    N3 --> N1
    N3 --> N2
```

<!-- sakura-ai-depgraph-end -->