### PR TITLE
Refactor webhook handlers and improve `cancel_expired_order` idempotency

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,17 +1,5 @@
-# CodeGraph data files
-# These are local to each machine and should not be committed
-
-# Database
-*.db
-*.db-wal
-*.db-shm
-
-# Cache
-cache/
-
-# Logs
-*.log
-
-# Hook markers
-.dirty
-*.pid
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -1792,11 +1792,12 @@ async def handle_stripe_webhook(
                     )
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
-                    order = await svc.cancel_expired_order(event.order_no)
-                    await db.commit()
+                    if event.order_no:
+                        await svc.cancel_expired_order(event.order_no)
+                        await db.commit()
                     logger.info(
                         "Stripe webhook: order expired/cancelled {}",
-                        order.order_no,
+                        event.order_no,
                     )
                     return JSONResponse(
                         content={"status": "processed", "event": "payment_expired"}
@@ -1898,12 +1899,12 @@ async def handle_paddle_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        order = await svc.cancel_expired_order(event.order_no)
+                        await svc.cancel_expired_order(event.order_no)
                         await db.commit()
-                        logger.info(
-                            "Paddle webhook: order expired/cancelled {}",
-                            order.order_no,
-                        )
+                    logger.info(
+                        "Paddle webhook: order expired/cancelled {}",
+                        event.order_no,
+                    )
                     return JSONResponse(
                         content={"status": "processed", "event": "payment_expired"}
                     )
@@ -2004,12 +2005,12 @@ async def handle_alipay_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        order = await svc.cancel_expired_order(event.order_no)
+                        await svc.cancel_expired_order(event.order_no)
                         await db.commit()
-                        logger.info(
-                            "Alipay webhook: order closed {}",
-                            order.order_no,
-                        )
+                    logger.info(
+                        "Alipay webhook: order closed {}",
+                        event.order_no,
+                    )
                     return PlainTextResponse("success")
 
                 else:
@@ -2076,12 +2077,12 @@ async def handle_nowpayments_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        order = await svc.cancel_expired_order(event.order_no)
+                        await svc.cancel_expired_order(event.order_no)
                         await db.commit()
-                        logger.info(
-                            "NOWPayments webhook: order expired {}",
-                            order.order_no,
-                        )
+                    logger.info(
+                        "NOWPayments webhook: order expired {}",
+                        event.order_no,
+                    )
                     return JSONResponse(
                         content={"status": "processed", "event": "payment_expired"}
                     )

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -1793,8 +1793,9 @@ async def handle_stripe_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        await svc.cancel_expired_order(event.order_no)
-                        await db.commit()
+                        result = await svc.cancel_expired_order(event.order_no)
+                        if result:
+                            await db.commit()
                     logger.info(
                         "Stripe webhook: order expired/cancelled {}",
                         event.order_no,
@@ -1899,8 +1900,9 @@ async def handle_paddle_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        await svc.cancel_expired_order(event.order_no)
-                        await db.commit()
+                        result = await svc.cancel_expired_order(event.order_no)
+                        if result:
+                            await db.commit()
                     logger.info(
                         "Paddle webhook: order expired/cancelled {}",
                         event.order_no,
@@ -2005,8 +2007,9 @@ async def handle_alipay_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        await svc.cancel_expired_order(event.order_no)
-                        await db.commit()
+                        result = await svc.cancel_expired_order(event.order_no)
+                        if result:
+                            await db.commit()
                     logger.info(
                         "Alipay webhook: order closed {}",
                         event.order_no,
@@ -2077,8 +2080,9 @@ async def handle_nowpayments_webhook(
 
                 elif event.event_type == WebhookEventType.PAYMENT_EXPIRED:
                     if event.order_no:
-                        await svc.cancel_expired_order(event.order_no)
-                        await db.commit()
+                        result = await svc.cancel_expired_order(event.order_no)
+                        if result:
+                            await db.commit()
                     logger.info(
                         "NOWPayments webhook: order expired {}",
                         event.order_no,

--- a/backend/services/code_index_service.py
+++ b/backend/services/code_index_service.py
@@ -70,7 +70,7 @@ class CodeIndexService:
         Returns:
             索引结果统计
         """
-        logger.info(f"开始索引PR #{pr_number}的代码文件，仓库: {repo_full_name}")
+        logger.info("开始索引PR #{}的代码文件，仓库: {}", pr_number, repo_full_name)
 
         indexed_count = 0
         skipped_count = 0
@@ -112,7 +112,7 @@ class CodeIndexService:
                         if existing:
                             existing.is_deleted = 1
                             removed_count += 1
-                            logger.info(f"已清理删除文件的索引: {file_path}")
+                            logger.info("已清理删除文件的索引: {}", file_path)
                     except Exception as e:
                         logger.error("清理删除文件索引失败 ({}): {}", file_path, e)
                         failed_count += 1
@@ -120,7 +120,7 @@ class CodeIndexService:
                     continue
 
                 if not content:
-                    logger.warning(f"文件 {file_path} 没有内容，跳过索引")
+                    logger.warning("文件 {} 没有内容，跳过索引", file_path)
                     skipped_count += 1
                     consecutive_failures = 0
                     continue
@@ -138,7 +138,7 @@ class CodeIndexService:
                         and existing.file_hash == file_hash
                         and not existing.is_deleted
                     ):
-                        logger.debug(f"文件 {file_path} 未变化，跳过索引")
+                        logger.debug("文件 {} 未变化，跳过索引", file_path)
                         skipped_count += 1
                         continue
 
@@ -157,7 +157,7 @@ class CodeIndexService:
                     )
 
                     if not chunks:
-                        logger.warning(f"文件 {file_path} 解析后没有生成代码块")
+                        logger.warning("文件 {} 解析后没有生成代码块", file_path)
                         skipped_count += 1
                         continue
 
@@ -249,7 +249,7 @@ class CodeIndexService:
         Returns:
             索引结果统计
         """
-        logger.info(f"开始索引仓库代码，仓库: {repo_full_name}, 路径: {repo_path}")
+        logger.info("开始索引仓库代码，仓库: {}，路径: {}", repo_full_name, repo_path)
 
         indexed_count = 0
         skipped_count = 0
@@ -258,13 +258,13 @@ class CodeIndexService:
 
         repo_path_obj = Path(repo_path)
         if not repo_path_obj.exists():
-            logger.error(f"仓库路径不存在: {repo_path}")
+            logger.error("仓库路径不存在: {}", repo_path)
             return {"indexed": 0, "skipped": 0, "failed": 0, "total_chunks": 0}
 
         # 收集要索引的文件
         code_files = self._collect_code_files(repo_path_obj, paths)
 
-        logger.info(f"找到 {len(code_files)} 个代码文件")
+        logger.info("找到 {} 个代码文件", len(code_files))
 
         async with async_session() as session:
             for file_path in code_files:
@@ -367,7 +367,7 @@ class CodeIndexService:
                         )
                         indexed_file.is_deleted = 1
                         cleaned_count += 1
-                        logger.debug(f"清理已删除文件的索引: {indexed_file.file_path}")
+                        logger.debug("清理已删除文件的索引: {}", indexed_file.file_path)
                     except Exception as e:
                         logger.error(
                             f"清理文件索引失败 ({indexed_file.file_path}): {e}"
@@ -477,13 +477,13 @@ class CodeIndexService:
         Returns:
             更新结果统计
         """
-        logger.info(f"开始增量更新索引，仓库: {repo_full_name}")
+        logger.info("开始增量更新索引，仓库: {}", repo_full_name)
 
         # 获取上一次索引的 commit hash
         last_commit_hash = await self._get_last_commit_hash(repo_full_name)
 
         if not last_commit_hash:
-            logger.info(f"仓库 {repo_full_name} 无历史索引记录，执行全量索引")
+            logger.info("仓库 {} 无历史索引记录，执行全量索引", repo_full_name)
             return await self.index_repository_code(
                 repo_full_name=repo_full_name,
                 repo_path=repo_path,
@@ -497,7 +497,7 @@ class CodeIndexService:
 
         if changed_files is None:
             # git diff 失败，回退到全量索引
-            logger.warning(f"获取变更文件列表失败，回退到全量索引: {repo_full_name}")
+            logger.warning("获取变更文件列表失败，回退到全量索引: {}", repo_full_name)
             return await self.index_repository_code(
                 repo_full_name=repo_full_name,
                 repo_path=repo_path,
@@ -676,7 +676,7 @@ class CodeIndexService:
             stdout, stderr = await proc.communicate()
 
             if proc.returncode != 0:
-                logger.warning(f"git diff 执行失败: {stderr.decode()[:200]}")
+                logger.warning("git diff 执行失败: {}", stderr.decode()[:200])
                 return None
 
             added, modified, deleted = [], [], []
@@ -756,7 +756,7 @@ class CodeIndexService:
                     code_file.is_deleted = 1
                     await session.commit()
 
-            logger.info(f"✅ 已删除文件 {file_path} 的索引 ({deleted_count} 个代码块)")
+            logger.info("✅ 已删除文件 {} 的索引 ({} 个代码块)", file_path, deleted_count)
             return True
 
         except Exception as e:
@@ -785,7 +785,7 @@ class CodeIndexService:
                 repo_full_name, file_path
             )
             if deleted_count > 0:
-                logger.debug(f"已清理文件 {file_path} 的 {deleted_count} 个旧代码块")
+                logger.debug("已清理文件 {} 的 {} 个旧代码块", file_path, deleted_count)
             return deleted_count
         except Exception as e:
             logger.warning("清理旧代码块失败 ({}): {}", file_path, e)

--- a/backend/services/code_index_service.py
+++ b/backend/services/code_index_service.py
@@ -114,7 +114,7 @@ class CodeIndexService:
                             removed_count += 1
                             logger.info(f"已清理删除文件的索引: {file_path}")
                     except Exception as e:
-                        logger.error(f"清理删除文件索引失败 ({file_path}): {e}")
+                        logger.error("清理删除文件索引失败 ({}): {}", file_path, e)
                         failed_count += 1
                     consecutive_failures = 0
                     continue
@@ -202,7 +202,7 @@ class CodeIndexService:
                     )
 
                 except Exception as e:
-                    logger.error(f"❌ 索引文件 {file_path} 失败: {e}")
+                    logger.error("❌ 索引文件 {} 失败: {}", file_path, e)
                     failed_count += 1
                     consecutive_failures += 1
 
@@ -342,7 +342,7 @@ class CodeIndexService:
                     indexed_count += 1
 
                 except Exception as e:
-                    logger.error(f"❌ 索引文件 {file_path} 失败: {e}")
+                    logger.error("❌ 索引文件 {} 失败: {}", file_path, e)
                     failed_count += 1
 
             # 差异清理：比对当前文件列表与数据库索引，清理已删除文件
@@ -594,7 +594,7 @@ class CodeIndexService:
                     indexed_count += 1
 
                 except Exception as e:
-                    logger.error(f"增量索引文件 {file_path} 失败: {e}")
+                    logger.error("增量索引文件 {} 失败: {}", file_path, e)
                     failed_count += 1
 
             # 处理删除的文件
@@ -608,7 +608,7 @@ class CodeIndexService:
                         existing.is_deleted = 1
                         cleaned_count += 1
                 except Exception as e:
-                    logger.error(f"清理删除文件索引失败 ({file_path}): {e}")
+                    logger.error("清理删除文件索引失败 ({}): {}", file_path, e)
                     failed_count += 1
 
             # 更新索引状态
@@ -711,7 +711,7 @@ class CodeIndexService:
             return added, modified, deleted
 
         except Exception as e:
-            logger.error(f"获取变更文件列表失败: {e}")
+            logger.error("获取变更文件列表失败: {}", e)
             return None
 
     def _is_supported_code_file(self, file_path: str) -> bool:
@@ -760,7 +760,7 @@ class CodeIndexService:
             return True
 
         except Exception as e:
-            logger.error(f"❌ 删除文件索引失败 (file: {file_path}): {e}")
+            logger.error("❌ 删除文件索引失败 (file: {}): {}", file_path, e)
             return False
 
     async def _cleanup_stale_file_chunks(
@@ -788,7 +788,7 @@ class CodeIndexService:
                 logger.debug(f"已清理文件 {file_path} 的 {deleted_count} 个旧代码块")
             return deleted_count
         except Exception as e:
-            logger.warning(f"清理旧代码块失败 ({file_path}): {e}")
+            logger.warning("清理旧代码块失败 ({}): {}", file_path, e)
             return 0
 
     def _collect_code_files(

--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -63,7 +63,7 @@ class EmbeddingService:
                     base_url=settings.embedding_base_url,
                     api_key=settings.embedding_api_key or "ollama",  # Ollama 不需要 key
                 )
-                logger.info(f"✅ 嵌入服务初始化成功: {self.provider}")
+                logger.info("✅ 嵌入服务初始化成功: {}", self.provider)
 
             elif self.provider == "hf" or self.provider == "huggingface":
                 # HuggingFace 本地模型（使用 sentence-transformers）
@@ -143,7 +143,7 @@ class EmbeddingService:
                 batch_embeddings = [item.embedding for item in response.data]
                 all_embeddings.extend(batch_embeddings)
 
-            logger.debug(f"✅ 成功生成 {len(all_embeddings)} 个嵌入向量")
+            logger.debug("✅ 成功生成 {} 个嵌入向量", len(all_embeddings))
             return all_embeddings
 
         except Exception as e:
@@ -165,7 +165,7 @@ class EmbeddingService:
 
             # 懒加载模型（只在第一次使用时加载）
             if not hasattr(self, "_hf_model"):
-                logger.info(f"🔄 加载 HuggingFace 模型: {settings.embedding_model}")
+                logger.info("🔄 加载 HuggingFace 模型: {}", settings.embedding_model)
                 self._hf_model = SentenceTransformer(settings.embedding_model)
                 logger.info("✅ HuggingFace 模型加载完成")
 
@@ -173,7 +173,7 @@ class EmbeddingService:
             embeddings = self._hf_model.encode(texts, convert_to_numpy=True)
             embeddings = embeddings.tolist()
 
-            logger.debug(f"✅ 成功生成 {len(embeddings)} 个嵌入向量")
+            logger.debug("✅ 成功生成 {} 个嵌入向量", len(embeddings))
             return embeddings
 
         except ImportError:
@@ -238,7 +238,7 @@ class RerankerService:
                 self.client = None
 
             else:
-                logger.warning(f"⚠️  不支持的重排序提供商: {self.provider}，已禁用")
+                logger.warning("⚠️  不支持的重排序提供商: {}，已禁用", self.provider)
                 self.client = None
 
         except Exception as e:
@@ -326,7 +326,7 @@ class RerankerService:
             ]
 
             if not filtered_results:
-                logger.debug(f"所有文档都低于阈值 {score_threshold}，返回空列表")
+                logger.debug("所有文档都低于阈值 {}，返回空列表", score_threshold)
                 return []
 
             # 根据返回的索引重新排序

--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -73,7 +73,7 @@ class EmbeddingService:
                 raise ValueError(f"不支持的嵌入提供商: {self.provider}")
 
         except Exception as e:
-            logger.error(f"❌ 嵌入服务初始化失败: {e}")
+            logger.error("❌ 嵌入服务初始化失败: {}", e)
             raise
 
     async def embed_texts(self, texts: List[str]) -> List[List[float]]:
@@ -101,7 +101,7 @@ class EmbeddingService:
                 raise ValueError(f"不支持的嵌入提供商: {self.provider}")
 
         except Exception as e:
-            logger.error(f"❌ 生成嵌入向量失败: {e}")
+            logger.error("❌ 生成嵌入向量失败: {}", e)
             raise
 
     @staticmethod
@@ -148,8 +148,10 @@ class EmbeddingService:
 
         except Exception as e:
             logger.error(
-                f"❌ Embedding API 请求失败 ({settings.embedding_base_url}): "
-                f"{type(e).__name__}: {e}"
+                "❌ Embedding API 请求失败 ({}): {}: {}",
+                settings.embedding_base_url,
+                type(e).__name__,
+                e,
             )
             raise
 
@@ -180,7 +182,7 @@ class EmbeddingService:
             )
             raise RuntimeError("sentence-transformers 未安装")
         except Exception as e:
-            logger.error(f"❌ HuggingFace 嵌入失败: {e}")
+            logger.error("❌ HuggingFace 嵌入失败: {}", e)
             raise
 
     async def embed_query(self, query: str) -> List[float]:
@@ -240,7 +242,7 @@ class RerankerService:
                 self.client = None
 
         except Exception as e:
-            logger.warning(f"⚠️  重排序服务初始化失败: {e}，已禁用")
+            logger.warning("⚠️  重排序服务初始化失败: {}，已禁用", e)
             self.client = None
 
     async def rerank(
@@ -282,7 +284,7 @@ class RerankerService:
                 return docs[:top_k]
 
         except Exception as e:
-            logger.warning(f"⚠️  重排序失败: {e}，返回原始结果")
+            logger.warning("⚠️  重排序失败: {}，返回原始结果", e)
             return docs[:top_k]
 
     async def _rerank_via_siliconflow(
@@ -337,10 +339,10 @@ class RerankerService:
             return reranked_docs
 
         except httpx.HTTPError as e:
-            logger.warning(f"SiliconFlow Rerank API 请求失败: {e}")
+            logger.warning("SiliconFlow Rerank API 请求失败: {}", e)
             return docs[:top_k]
         except Exception as e:
-            logger.warning(f"SiliconFlow 重排序失败: {e}")
+            logger.warning("SiliconFlow 重排序失败: {}", e)
             return docs[:top_k]
 
     async def close(self):

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -866,17 +866,32 @@ class PaymentService:
         )
         return order
 
-    async def cancel_expired_order(self, order_no: str) -> Order:
-        """Cancel an expired PENDING order"""
+    async def cancel_expired_order(
+        self, order_no: str
+    ) -> Optional[Order]:
+        """Cancel an expired PENDING order (idempotent).
+
+        Returns the cancelled order, or ``None`` when the order is already
+        gone or already in a terminal state — callers should treat this as
+        success because the desired end-state (order not active) is already
+        reached.
+        """
         stmt = select(Order).where(Order.order_no == order_no)
         order = (await self.session.execute(stmt)).scalar_one_or_none()
         if not order:
-            raise PaymentError(f"Order not found: {order_no}")
+            logger.info(
+                "cancel_expired_order: order not found, already gone: {}",
+                order_no,
+            )
+            return None
 
         if order.status != OrderStatus.PENDING.value:
-            raise PaymentError(
-                f"Cannot cancel order in status: {order.status}"
+            logger.info(
+                "cancel_expired_order: order {} already in status {}, skip",
+                order_no,
+                order.status,
             )
+            return None
 
         order.status = OrderStatus.CANCELLED.value
         await self._log_payment(

--- a/backend/webui/routes/billing.py
+++ b/backend/webui/routes/billing.py
@@ -454,7 +454,8 @@ async def payment_result(
             result = await svc.cancel_expired_order(order_no)
             if result:
                 await db.commit()
-        except Exception:
+        except Exception as e:
+            logger.warning("Failed to cancel order {}: {}", order_no, e)
             await db.rollback()
 
     return render_template(

--- a/backend/webui/routes/billing.py
+++ b/backend/webui/routes/billing.py
@@ -447,14 +447,11 @@ async def payment_result(
     order_no = request.query_params.get("order_no", "")
     status = request.query_params.get("status", "failed")
 
-    # If user cancelled, mark the order as cancelled
+    # If user cancelled, mark the order as cancelled (idempotent — no-op if already gone)
     if status == "cancel" and order_no:
-        try:
-            svc = PaymentService(db)
-            await svc.cancel_expired_order(order_no)
-            await db.commit()
-        except Exception:
-            await db.rollback()
+        svc = PaymentService(db)
+        await svc.cancel_expired_order(order_no)
+        await db.commit()
 
     return render_template(
         "billing/payment_result.html",

--- a/backend/webui/routes/billing.py
+++ b/backend/webui/routes/billing.py
@@ -449,9 +449,13 @@ async def payment_result(
 
     # If user cancelled, mark the order as cancelled (idempotent — no-op if already gone)
     if status == "cancel" and order_no:
-        svc = PaymentService(db)
-        await svc.cancel_expired_order(order_no)
-        await db.commit()
+        try:
+            svc = PaymentService(db)
+            result = await svc.cancel_expired_order(order_no)
+            if result:
+                await db.commit()
+        except Exception:
+            await db.rollback()
 
     return render_template(
         "billing/payment_result.html",

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -58,7 +58,7 @@ async def _load_max_concurrent() -> int:
         val = await get_dynamic_config("max_concurrent_reviews")
         return int(val) if val is not None else get_settings().max_concurrent_reviews
     except Exception as e:
-        logger.warning(f"读取 max_concurrent_reviews 配置失败，使用默认值: {e}")
+        logger.warning("读取 max_concurrent_reviews 配置失败，使用默认值: {}", e)
         return get_settings().max_concurrent_reviews
 
 
@@ -69,7 +69,7 @@ def _get_label_rec_setting(key: str, default=None):
 
         return get_label_config().get_recommendation_settings().get(key, default)
     except (OSError, AttributeError) as e:
-        logger.debug(f"读取标签推荐配置 [{key}] 失败，使用降级值: {e}")
+        logger.debug("读取标签推荐配置 [{}] 失败，使用降级值: {}", key, e)
         return default
 
 
@@ -648,7 +648,9 @@ class ReviewWorker:
                             )
                     except Exception as e:
                         logger.warning(
-                            f"[{task_id}] 语义 Issue 关联失败（不影响审查）: {e}",
+                            "[{}] 语义 Issue 关联失败（不影响审查）: {}",
+                            task_id,
+                            e,
                             exc_info=True,
                         )
 

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -41,7 +41,7 @@ async def _get_review_semaphore() -> asyncio.Semaphore:
     if _review_semaphore is None:
         max_concurrent = await _load_max_concurrent()
         _review_semaphore = asyncio.Semaphore(max_concurrent)
-        logger.info(f"审查并发信号量初始化: 最大 {max_concurrent} 个并发任务")
+        logger.info("审查并发信号量初始化: 最大 {} 个并发任务", max_concurrent)
     return _review_semaphore
 
 
@@ -186,7 +186,7 @@ class ReviewWorker:
         event = self._cancel_events.get(task_key)
         if event and not event.is_set():
             event.set()
-            logger.info(f"[cancel] 已设置取消信号: {task_key}")
+            logger.info("[cancel] 已设置取消信号: {}", task_key)
             return True
         return False
 
@@ -208,7 +208,7 @@ class ReviewWorker:
         Deletes placeholder comment and updates DB status to CANCELLED.
         Safe to call when review_obj/review_id are None (early checkpoints).
         """
-        logger.info(f"[{task_id}] 任务已被取消，{reason}: {task_key}")
+        logger.info("[{}] 任务已被取消，{}: {}", task_id, reason, task_key)
         if review_obj:
             await self.comment_service.delete_placeholder_comment(review_obj)
         if review_id:
@@ -248,7 +248,7 @@ class ReviewWorker:
 
                 # 2. 检查是否应该跳过
                 if analysis.should_skip:
-                    logger.info(f"[{task_id}] 跳过审查: {analysis.skip_reason}")
+                    logger.info("[{}] 跳过审查: {}", task_id, analysis.skip_reason)
                     await self._save_skip_record(analysis, pr_info)
                     return task_id
 
@@ -265,7 +265,7 @@ class ReviewWorker:
                         from backend.services.pr_code_indexer import get_pr_code_indexer
 
                         indexer = get_pr_code_indexer()
-                        logger.info(f"[{task_id}] 开始代码索引...")
+                        logger.info("[{}] 开始代码索引...", task_id)
                         await self._log_activity(review_id, "tool_call", {
                             "tool": "index_pr_changes",
                             "status": "running",
@@ -276,7 +276,7 @@ class ReviewWorker:
                             pr_number=pr_info["pr_number"],
                             install_id=pr_info.get("install_id", 0),
                         )
-                        logger.info(f"[{task_id}] 代码索引完成")
+                        logger.info("[{}] 代码索引完成", task_id)
                         await self._log_activity(review_id, "tool_result", {
                             "tool": "index_pr_changes",
                             "status": "completed",
@@ -410,7 +410,7 @@ class ReviewWorker:
                             pr, summary
                         )
                         pr_summary_text = summary
-                        logger.info(f"[{task_id}] PR 变更总结已更新")
+                        logger.info("[{}] PR 变更总结已更新", task_id)
                     except Exception as e:
                         logger.warning("[{}] PR 变更总结生成失败: {}", task_id, str(e))
 
@@ -428,7 +428,7 @@ class ReviewWorker:
                         await depgraph_service.generate_dependency_graph(
                             analysis, pr_info, pr
                         )
-                        logger.info(f"[{task_id}] PR 依赖图已生成并注入")
+                        logger.info("[{}] PR 依赖图已生成并注入", task_id)
                     except Exception as e:
                         logger.warning(
                             f"[{task_id}] PR 依赖图生成失败（不影响审查）: {e}"
@@ -439,7 +439,7 @@ class ReviewWorker:
                 )
 
                 # 5. 【第一阶段】创建占位评论
-                logger.info(f"[{task_id}] 创建占位评论...")
+                logger.info("[{}] 创建占位评论...", task_id)
                 review_obj = await self.comment_service.create_placeholder_comment(
                     pr, analysis.strategy, output_language=output_language
                 )
@@ -721,12 +721,12 @@ class ReviewWorker:
                         )
                     )
                 else:
-                    logger.info(f"[{task_id}] 使用标准模式进行审查")
+                    logger.info("[{}] 使用标准模式进行审查", task_id)
                     tasks.append(self.ai_reviewer.review_pr(context, analysis.strategy))
 
                 # 任务2: AI标签推荐（并行）
                 if enable_label_recommendation:
-                    logger.info(f"[{task_id}] 并行启动AI标签推荐...")
+                    logger.info("[{}] 并行启动AI标签推荐...", task_id)
 
                     async def run_label_recommendation():
                         try:
@@ -779,7 +779,7 @@ class ReviewWorker:
                                 )
                                 return label_results
                             else:
-                                logger.info(f"[{task_id}] AI未推荐任何标签")
+                                logger.info("[{}] AI未推荐任何标签", task_id)
                                 return None
 
                         except Exception as label_error:
@@ -824,11 +824,11 @@ class ReviewWorker:
 
                 # 9. 【第二阶段】删除占位评论，准备创建最终Review
                 if review_obj:
-                    logger.info(f"[{task_id}] 删除占位评论...")
+                    logger.info("[{}] 删除占位评论...", task_id)
                     await self.comment_service.delete_placeholder_comment(review_obj)
 
                 # 10. 【新增】决策引擎：做出审查决定并提交到GitHub（包含行内评论）
-                logger.info(f"[{task_id}] 执行决策引擎...")
+                logger.info("[{}] 执行决策引擎...", task_id)
                 decision, decision_reason = await self._make_and_submit_decision(
                     pr_info,
                     review_result,
@@ -885,7 +885,7 @@ class ReviewWorker:
                         )
                         self._background_tasks.add(task)
                         task.add_done_callback(self._background_tasks.discard)
-                        logger.info(f"[{task_id}] 已触发 .sakura/ 反思任务")
+                        logger.info("[{}] 已触发 .sakura/ 反思任务", task_id)
                 except Exception as e:
                     logger.warning(
                         "[{}] 触发 .sakura/ 反思失败（不影响审查）: {}",
@@ -924,7 +924,7 @@ class ReviewWorker:
                             pr,
                             output_language=output_language,
                         )
-                        logger.info(f"[{task_id}] 已更新占位评论为错误状态")
+                        logger.info("[{}] 已更新占位评论为错误状态", task_id)
                     except Exception as update_error:
                         logger.error(
                             "[{}] 更新错误消息失败: {}",
@@ -992,7 +992,7 @@ class ReviewWorker:
                 session.add(record)
                 await session.commit()
                 await session.refresh(record)
-                logger.info(f"[{task_id}] 创建审查记录: {record.id}")
+                logger.info("[{}] 创建审查记录: {}", task_id, record.id)
                 return record.id
 
         return await _db_retry(_do)
@@ -1154,7 +1154,7 @@ class ReviewWorker:
                 )
                 session.add(record)
                 await session.commit()
-                logger.info(f"[{task_id}] 保存错误记录")
+                logger.info("[{}] 保存错误记录", task_id)
 
         await _db_retry(_do)
 
@@ -1268,7 +1268,7 @@ class ReviewWorker:
                     # Incremental review: old reviews already dismissed in webhook handler,
                     # skip idempotency check to allow new review submission
                     enable_idempotency = False
-                    logger.info(f"[{task_id}] 增量审查模式，跳过幂等性检查")
+                    logger.info("[{}] 增量审查模式，跳过幂等性检查", task_id)
                 else:
                     # Full review fallback (force push etc.):
                     # dismiss again in case webhook dismiss was missed or failed
@@ -1284,7 +1284,7 @@ class ReviewWorker:
                             f"[{task_id}] 已撤回 {dismissed} 条旧 Review，将提交全量审查"
                         )
                     else:
-                        logger.debug(f"[{task_id}] 全量审查模式，无旧 Review 需撤回")
+                        logger.debug("[{}] 全量审查模式，无旧 Review 需撤回", task_id)
 
             # 使用 submit_review_with_inline_comments 方法（带重试机制）
             max_retries = 1  # 失败后重试1次
@@ -1342,9 +1342,9 @@ class ReviewWorker:
                     enable_idempotency_check=enable_idempotency,
                 )
                 if success:
-                    logger.info(f"[{task_id}] ✅ 降级成功: 已提交无行内评论的Review")
+                    logger.info("[{}] ✅ 降级成功: 已提交无行内评论的Review", task_id)
                 else:
-                    logger.error(f"[{task_id}] 重试 {max_retries} 次后仍然失败")
+                    logger.error("[{}] 重试 {} 次后仍然失败", task_id, max_retries)
 
             if success:
                 if inline_comments:

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -767,7 +767,7 @@ class TestCancelExpiredOrder:
 
         assert cancelled.status == OrderStatus.CANCELLED.value
 
-    async def test_cancel_non_pending_order_raises(self, svc, mock_session):
+    async def test_cancel_non_pending_order_returns_none(self, svc, mock_session):
         from backend.models.payment_models import Order
 
         order = Order(
@@ -782,9 +782,16 @@ class TestCancelExpiredOrder:
         mock_result.scalar_one_or_none.return_value = order
         mock_session.execute.return_value = mock_result
 
-        with pytest.raises(PaymentError, match="Cannot cancel order"):
-            await svc.cancel_expired_order("ORD_FULFILLED")
+        result = await svc.cancel_expired_order("ORD_FULFILLED")
+        assert result is None
 
+    async def test_cancel_expired_order_not_found(self, svc, mock_session):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await svc.cancel_expired_order("ORD_NONEXISTENT")
+        assert result is None
 
 @pytest.mark.asyncio
 class TestProcessRefund:

--- a/tests/test_payment_webhook.py
+++ b/tests/test_payment_webhook.py
@@ -130,6 +130,50 @@ class TestStripeWebhookEndpoint:
             assert response.status_code == 200
             body = json.loads(response.body.decode())
             assert body["event"] == "payment_expired"
+            mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_webhook_payment_expired_order_already_gone(
+        self, mock_db_session, mock_gateway
+    ):
+        """When cancel_expired_order returns None (order gone), commit should NOT be called."""
+        from backend.services.payment.gateway_base import (
+            WebhookEvent,
+            WebhookEventType,
+        )
+
+        event = WebhookEvent(
+            event_type=WebhookEventType.PAYMENT_EXPIRED,
+            provider_tx_id="cs_test_expired",
+            order_no="ORD20240101000000EXPI1234",
+        )
+        mock_gateway.verify_webhook.return_value = event
+
+        with patch(
+            "backend.api.webhook.get_async_session",
+            return_value=mock_db_session,
+        ), patch(
+            "backend.services.payment.get_gateway",
+            new_callable=AsyncMock,
+            return_value=mock_gateway,
+        ), patch(
+            "backend.services.payment_service.PaymentService.cancel_expired_order",
+            new_callable=AsyncMock,
+            return_value=None,  # order already gone
+        ):
+            from backend.api.webhook import handle_stripe_webhook
+            from fastapi import Request
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.body = AsyncMock(return_value=b'{"test": true}')
+            mock_request.headers = {"stripe-signature": "t=123,v1=abc"}
+
+            response = await handle_stripe_webhook(mock_request)
+
+            assert response.status_code == 200
+            body = json.loads(response.body.decode())
+            assert body["event"] == "payment_expired"
+            mock_db_session.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_webhook_invalid_signature(self, mock_gateway):

--- a/tests/test_payment_webhook.py
+++ b/tests/test_payment_webhook.py
@@ -116,7 +116,7 @@ class TestStripeWebhookEndpoint:
         ), patch(
             "backend.services.payment_service.PaymentService.cancel_expired_order",
             new_callable=AsyncMock,
-            return_value=mock_order,
+            return_value=mock_order,  # non-None → triggers commit
         ):
             from backend.api.webhook import handle_stripe_webhook
             from fastapi import Request


### PR DESCRIPTION
Updates the various webhook handlers (Stripe, Paddle, Alipay, NOWPayments) to directly use `event.order_no` when logging and calling cancellation services, avoiding unnecessary retrieval of the full `Order` object in all cases.

In `PaymentService`, the `cancel_expired_order` method is enhanced:
- It now returns `Optional[Order]` instead of always raising an error if not found.
- It logs a message when the order is not found, treating this as a successful idempotent operation.
- It adds logging to indicate when an order is already in a non-PENDING state and is skipped for cancellation.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**
本次 PR 在之前重构基础上，进一步完善了错误处理机制，并显著增强了测试覆盖。主要新增了对订单状态“不存在”场景的健壮性处理及对应测试用例，同时对计费路由进行了适配性微调，提升了支付系统的整体可靠性。

**主要改动列表**
1.  **`backend/webui/routes/billing.py`**：调整了计费路由中支付服务的调用方式，以完全适配重构后的 `cancel_expired_order` 接口。
2.  **`tests/test_payment_webhook.py`**：大幅扩展测试用例，新增了对订单在支付处理前已被删除（“订单已不存在”）这一异常场景的验证，确保系统在并发或边界情况下的幂等性。
3.  **错误处理增强**：在关键路径上改进了异常处理逻辑，确保操作在预期失败时能安全退出，避免脏数据。

**影响范围**
- **支付幂等性与稳定性**：通过覆盖更多边界测试用例（如订单不存在），使 `cancel_expired_order` 的幂等性逻辑更加严密，系统稳定性得到进一步保障。
- **代码健壮性**：强化了错误处理，防止因订单状态异常导致的潜在问题，提升了整体代码质量。
- **测试覆盖率**：核心支付流程的测试得到显著加强，为后续重构和功能迭代提供了更坚实的安全网。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/webui/routes/billing.py"]
    N2["tests/test_payment_webhook.py"]
```

<!-- sakura-ai-depgraph-end -->