### PR TITLE
feat: 刷新 AI 客户端以支持动态配置变更

### DIFF
--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -469,6 +469,21 @@ class ReviewWorker:
                         "跳过 PR 总结和 AI 审查",
                     )
 
+                # Refresh AI clients before auxiliary tasks that run ahead of
+                # review_pr_with_tools — the only internal refresh point of
+                # AIReviewer. PR summary / dependency graph / history-context
+                # services read self.ai_reviewer.summary_api_client directly,
+                # so without an explicit refresh here they reuse the client
+                # left over from the previous review. Changing the auxiliary
+                # (summary) provider/model in the WebUI then has no effect on
+                # these tasks: they keep calling the stale provider and the
+                # new model name is rejected as "model not found".
+                # 刷新 AI 客户端：辅助任务在 review_pr_with_tools 之前执行，
+                # 必须在此显式刷新，否则会复用上一次审查遗留的 summary_api_client
+                # （旧辅助模型 provider），导致 WebUI 即时修改辅助 AI 配置后，
+                # PR 总结 / 依赖图 / 历史上下文仍使用旧 provider 并报“找不到模型”。
+                self.ai_reviewer._refresh_ai_clients()
+
                 # 4.5 PR 变更总结（如果启用）
                 pr_summary_text = None
                 if settings.enable_pr_summary:

--- a/tests/test_ai_runtime_config_refresh.py
+++ b/tests/test_ai_runtime_config_refresh.py
@@ -54,6 +54,60 @@ def test_reviewer_refreshes_clients_after_dynamic_config_change(monkeypatch):
     assert reviewer.label_recommender.model == "new-model"
 
 
+def test_reviewer_refreshes_summary_client_when_auxiliary_config_changes(monkeypatch):
+    """辅助模型独立配置变化后，_refresh_ai_clients 重建 summary_api_client。
+
+    覆盖 summary_api_base/key 非空（独立 provider）场景：修改辅助模型凭据后，
+    summary_api_client 应重建为新凭据并始终与主 AI api_client 解耦；
+    summary_model 跟随最新 settings；主 AI client 不受影响。
+    对应 WebUI 即时修改辅助 AI 配置后辅助任务（PR 总结/依赖图/历史上下文）
+    必须使用新 provider 的回归保护。
+    """
+    settings = SimpleNamespace(
+        openai_api_base="https://main.example/v1",
+        openai_api_key="main-key",
+        openai_model="main-model",
+        summary_api_base="https://aux-old.example/v1",
+        summary_api_key="aux-old-key",
+        summary_model="aux-old-model",
+    )
+    monkeypatch.setattr(reviewer_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(reviewer_module, "AIApiClient", _FakeAIApiClient)
+
+    reviewer = reviewer_module.AIReviewer.__new__(reviewer_module.AIReviewer)
+    reviewer._ai_client_config = None
+    reviewer._summary_client_config = None
+    reviewer.context_compressor = SimpleNamespace(api_client=None, model=None)
+    reviewer.label_recommender = SimpleNamespace(api_client=None, model=None)
+
+    reviewer._refresh_ai_clients()
+    # 独立 provider：summary_api_client 与主 api_client 解耦
+    assert reviewer.summary_api_client is not reviewer.api_client
+    assert reviewer.summary_api_client.base_url == "https://aux-old.example/v1"
+    assert reviewer.summary_api_client.api_key == "aux-old-key"
+    assert reviewer.summary_model == "aux-old-model"
+    old_summary_client = reviewer.summary_api_client
+
+    # 仅修改辅助模型凭据（主 AI 不变）
+    settings.summary_api_base = "https://aux-new.example/v1"
+    settings.summary_api_key = "aux-new-key"
+    settings.summary_model = "aux-new-model"
+    reviewer._refresh_ai_clients()
+
+    # summary_api_client 重建为新凭据，主 api_client 保持不变
+    assert reviewer.summary_api_client is not old_summary_client
+    assert reviewer.summary_api_client.base_url == "https://aux-new.example/v1"
+    assert reviewer.summary_api_client.api_key == "aux-new-key"
+    assert reviewer.summary_model == "aux-new-model"
+    assert reviewer.api_client.base_url == "https://main.example/v1"
+    assert reviewer.api_client.api_key == "main-key"
+    # context_compressor / label_recommender 跟随最新辅助凭据
+    assert reviewer.context_compressor.api_client is reviewer.summary_api_client
+    assert reviewer.context_compressor.model == "aux-new-model"
+    assert reviewer.label_recommender.api_client is reviewer.summary_api_client
+    assert reviewer.label_recommender.model == "aux-new-model"
+
+
 def test_issue_analyzer_refreshes_client_after_dynamic_config_change(monkeypatch):
     settings = SimpleNamespace(
         openai_api_base="https://old.example/v1",


### PR DESCRIPTION
<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**
本次为新增功能，实现了 AI 客户端的动态配置刷新机制，确保运行时配置发生变更后能够立即生效。

**主要改动列表**
- **新增刷新逻辑**：在 `review_worker.py` 中实现 AI 客户端的刷新功能（+15行）。
- **新增单元测试**：添加 `test_ai_runtime_config_refresh.py` 测试文件，完善动态配置刷新场景的测试覆盖（+54行）。

**影响范围**
主要影响后端审核 Worker 模块及测试套件。本次变更为纯新增代码（+69/-0），未修改现有逻辑，无破坏性影响。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/workers/review_worker.py"]
    N2["tests/test_ai_runtime_config_refresh.py"]
```

<!-- sakura-ai-depgraph-end -->