### PR TITLE
feat: 增强权限校验的健壮性并增加不可用响应处理

### DIFF
--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -749,6 +749,15 @@ async def _handle_label_checkbox_toggle_inner(
             github_app.check_collaborator_permission,
             repo_owner, repo_name, editor_login,
         )
+        if permission == "unknown":
+            logger.warning(
+                f"[{comment_source}] 无法校验用户 {editor_login} 在 "
+                f"{repo_owner}/{repo_name} 的权限，跳过标签切换"
+            )
+            return JSONResponse(
+                status_code=503,
+                content={"status": "error", "reason": "permission check unavailable"},
+            )
         is_collaborator = permission in ("admin", "write")
 
     if not is_pr_author and not is_collaborator and not is_review_body_edit:

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -458,6 +458,15 @@ async def handle_issue_comment_event(payload: Dict[str, Any]) -> JSONResponse:
             permission = github_app.check_collaborator_permission(
                 repo_owner, repo_name, commenter_login
             )
+            if permission == "unknown":
+                return await _permission_check_unavailable_response(
+                    github_app,
+                    repo_owner,
+                    repo_name,
+                    repo_full_name,
+                    pr_number,
+                    commenter_login,
+                )
             is_collaborator = permission in ("admin", "write")
 
         if not is_pr_author and not is_collaborator:
@@ -1002,6 +1011,17 @@ async def handle_revoke_command(payload: Dict[str, Any]) -> JSONResponse:
             repo_owner, repo_name, commenter_login
         )
 
+        if permission == "unknown":
+            return await _permission_check_unavailable_response(
+                github_app,
+                repo_owner,
+                repo_name,
+                repo_full_name,
+                pr_number,
+                commenter_login,
+                log_prefix="/revoke",
+            )
+
         if permission != "admin":
             logger.info(
                 f"用户 {commenter_login} 无权撤回评论 (权限: {permission}, 需要 admin)"
@@ -1433,6 +1453,36 @@ async def _post_issue_comment(
         logger.warning("发送 Issue 评论失败: {}#{} - {}", repo_full_name, issue_number, e)
 
 
+async def _permission_check_unavailable_response(
+    github_app: "GitHubAppClient",
+    repo_owner: str,
+    repo_name: str,
+    repo_full_name: str,
+    issue_number: int,
+    commenter: str,
+    log_prefix: str = "权限检查",
+) -> JSONResponse:
+    """权限校验不可用时返回可重试错误，避免误报用户无权限。"""
+    logger.warning(
+        "{} 无法校验用户 {} 在 {} 的权限，请稍后重试",
+        log_prefix,
+        commenter,
+        repo_full_name,
+    )
+    await _post_issue_comment(
+        github_app,
+        repo_owner,
+        repo_name,
+        repo_full_name,
+        issue_number,
+        f"⚠️ @{commenter}，暂时无法连接 GitHub 校验权限，请稍后重试。",
+    )
+    return JSONResponse(
+        status_code=503,
+        content={"status": "error", "reason": "permission check unavailable"},
+    )
+
+
 def _parse_agent_base_branch(
     comment_body: str,
 ) -> tuple[str | None, JSONResponse | None]:
@@ -1482,6 +1532,17 @@ async def _check_agent_permission(
         repo_name,
         commenter,
     )
+    if permission == "unknown":
+        return await _permission_check_unavailable_response(
+            github_app,
+            repo_owner,
+            repo_name,
+            repo_full_name,
+            issue_number,
+            commenter,
+            log_prefix=log_prefix,
+        )
+
     if permission not in ("admin", "write"):
         logger.info("{} 权限不足: {} 权限为 {}", log_prefix, commenter, permission)
         await _post_issue_comment(

--- a/backend/core/github_app.py
+++ b/backend/core/github_app.py
@@ -765,15 +765,15 @@ class GitHubAppClient:
             username: GitHub用户名
 
         Returns:
-            权限级别字符串 (admin, write, read, none)，出错返回 "none"
+            权限级别字符串 (admin, write, read, none)，无法校验时返回 "unknown"
         """
         try:
             client = self.get_repo_client(repo_owner, repo_name)
             if not client:
                 logger.warning(
-                    f"无法获取 {repo_owner}/{repo_name} 的客户端，跳过权限检查"
+                    f"无法获取 {repo_owner}/{repo_name} 的客户端，无法完成权限检查"
                 )
-                return "none"
+                return "unknown"
 
             repo = client.get_repo(f"{repo_owner}/{repo_name}")
             permission = repo.get_collaborator_permission(username)
@@ -783,8 +783,12 @@ class GitHubAppClient:
             return permission
 
         except Exception as e:
-            logger.warning(f"检查用户权限失败 (user={username}): {e}")
-            return "none"
+            logger.warning(
+                f"检查用户权限失败，无法确认权限 "
+                f"(repo={repo_owner}/{repo_name}, user={username}): {e}",
+                exc_info=True,
+            )
+            return "unknown"
 
     def submit_review(
         self,

--- a/tests/test_agent_command.py
+++ b/tests/test_agent_command.py
@@ -1,5 +1,7 @@
 """Unit tests for /agent command in webhook handler."""
 
+import json
+
 import pytest
 
 from backend.api import webhook
@@ -163,6 +165,14 @@ async def _async_noop(*a, **kw):
     return None
 
 
+class _PostCommentRecorder:
+    def __init__(self):
+        self.messages = []
+
+    async def __call__(self, *args):
+        self.messages.append(args[-1])
+
+
 async def _async_true(*a, **kw):
     """返回 True 的异步函数，用于 mock 功能开关启用"""
     return True
@@ -254,6 +264,24 @@ async def test_agent_command_denied_for_insufficient_permission(monkeypatch):
 
     assert response.status_code == 200
     assert b"denied" in response.body
+
+
+@pytest.mark.asyncio
+async def test_agent_command_permission_unknown_returns_retryable_message(monkeypatch):
+    payload = _base_payload()
+    recorder = _PostCommentRecorder()
+    _make_base_mocks(monkeypatch, permission="unknown")
+    monkeypatch.setattr(webhook, "_post_issue_comment", recorder)
+
+    response = await webhook.handle_agent_command(payload)
+    body = json.loads(response.body.decode())
+
+    assert response.status_code == 503
+    assert body["status"] == "error"
+    assert body["reason"] == "permission check unavailable"
+    assert recorder.messages == [
+        "⚠️ @collaborator，暂时无法连接 GitHub 校验权限，请稍后重试。"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_full_review_command.py
+++ b/tests/test_full_review_command.py
@@ -1,0 +1,116 @@
+"""Unit tests for /full-review command in webhook handler."""
+
+import json
+
+import pytest
+
+from backend.api import webhook
+from backend.core.github_app import GitHubAppClient
+
+
+class _CommentCapturingClient:
+    def __init__(self, comments):
+        self._comments = comments
+
+    def get_repo(self, _full_name):
+        return self
+
+    def get_issue(self, _number):
+        return self
+
+    def create_comment(self, body):
+        self._comments.append(body)
+
+
+class _FakeGitHubApp:
+    def __init__(self, permission):
+        self._permission = permission
+        self.comments = []
+        self._client = _CommentCapturingClient(self.comments)
+
+    def check_collaborator_permission(self, *args, **kwargs):
+        return self._permission
+
+    def get_repo_client(self, *args, **kwargs):
+        return self._client
+
+
+def _full_review_payload(body="/full-review"):
+    return {
+        "action": "created",
+        "comment": {
+            "body": body,
+            "user": {"login": "Sakura520222"},
+        },
+        "issue": {
+            "number": 2,
+            "user": {"login": "sakura-ai-agent"},
+            "pull_request": {"url": "https://github.com/Sakura520222/repo/pull/2"},
+        },
+        "repository": {
+            "name": "repo",
+            "full_name": "Sakura520222/repo",
+            "owner": {"login": "Sakura520222"},
+        },
+        "installation": {"id": 123},
+    }
+
+
+@pytest.mark.asyncio
+async def test_full_review_permission_unknown_returns_retryable_message(monkeypatch):
+    fake_app = _FakeGitHubApp(permission="unknown")
+    monkeypatch.setattr(webhook, "GitHubAppClient", lambda: fake_app)
+
+    response = await webhook.handle_issue_comment_event(_full_review_payload())
+    body = json.loads(response.body.decode())
+
+    assert response.status_code == 503
+    assert body["status"] == "error"
+    assert body["reason"] == "permission check unavailable"
+    assert fake_app.comments == [
+        "⚠️ @Sakura520222，暂时无法连接 GitHub 校验权限，请稍后重试。"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_revoke_permission_unknown_returns_retryable_message(monkeypatch):
+    fake_app = _FakeGitHubApp(permission="unknown")
+    monkeypatch.setattr(webhook, "GitHubAppClient", lambda: fake_app)
+
+    response = await webhook.handle_issue_comment_event(_full_review_payload("/revoke"))
+    body = json.loads(response.body.decode())
+
+    assert response.status_code == 503
+    assert body["status"] == "error"
+    assert body["reason"] == "permission check unavailable"
+    assert fake_app.comments == [
+        "⚠️ @Sakura520222，暂时无法连接 GitHub 校验权限，请稍后重试。"
+    ]
+
+
+def test_collaborator_permission_is_unknown_when_repo_client_unavailable(monkeypatch):
+    github_app = GitHubAppClient()
+    monkeypatch.setattr(github_app, "get_repo_client", lambda *_args, **_kwargs: None)
+
+    permission = github_app.check_collaborator_permission("owner", "repo", "alice")
+
+    assert permission == "unknown"
+
+
+def test_collaborator_permission_is_unknown_when_github_permission_api_fails(
+    monkeypatch,
+):
+    class _FailingClient:
+        def get_repo(self, _full_name):
+            raise RuntimeError("GitHub timeout")
+
+    github_app = GitHubAppClient()
+    monkeypatch.setattr(
+        github_app,
+        "get_repo_client",
+        lambda *_args, **_kwargs: _FailingClient(),
+    )
+
+    permission = github_app.check_collaborator_permission("owner", "repo", "alice")
+
+    assert permission == "unknown"

--- a/tests/test_label_checkbox_toggle.py
+++ b/tests/test_label_checkbox_toggle.py
@@ -331,3 +331,51 @@ class TestWebhookRouting:
         response = await handle_pull_request_review_event(payload)
         body = response.body.decode()
         assert "ignored" in body
+
+    @pytest.mark.anyio
+    async def test_label_toggle_permission_unknown_returns_retryable(self, monkeypatch):
+        """Permission check unavailable should not revert checkbox or post denial."""
+        import json
+
+        from backend.api import webhook
+
+        # Stub label_service so the function reaches the permission check
+        class _StubLabelService:
+            def is_sakura_label_comment(self, _body):
+                return True
+
+            def parse_checkbox_changes(self, _old, _new):
+                return ({"bug"}, set())
+
+            async def handle_label_checkbox_toggle(self, **kwargs):
+                return {"applied": [], "removed": [], "failed": []}
+
+        monkeypatch.setattr(
+            "backend.services.label_service.label_service", _StubLabelService()
+        )
+
+        class _FakeGitHubApp:
+            def check_collaborator_permission(self, *_args, **_kwargs):
+                return "unknown"
+
+            def get_repo_client(self, *_args, **_kwargs):
+                return None
+
+        monkeypatch.setattr(webhook, "GitHubAppClient", lambda: _FakeGitHubApp())
+
+        response = await webhook._handle_label_checkbox_toggle_inner(
+            repo_owner="owner",
+            repo_name="repo",
+            pr_number=42,
+            old_body="<!-- sakura-label-section -->\n- [ ] **bug**",
+            new_body="<!-- sakura-label-section -->\n- [x] **bug**",
+            editor_login="outside_user",
+            pr_author_login="pr_author",
+            comment_source="issue_comment",
+            comment_id=100,
+        )
+
+        body = json.loads(response.body.decode())
+        assert response.status_code == 503
+        assert body["status"] == "error"
+        assert body["reason"] == "permission check unavailable"


### PR DESCRIPTION
在 `webhook.py` 中，增加了对 GitHub API 返回权限为 `"unknown"` 时的统一处理逻辑：
- 在处理 Issue 评论事件时，如果权限未知，会立即返回一个 503 错误响应。
- 在处理撤回命令事件时，也增加了对权限未知的提前检查和响应。
- 在 `_check_agent_permission` 中，当权限为 `"unknown"` 时，也会调用新的辅助函数发送不可用响应。

同时，新增了私有方法 `_permission_check_unavailable_response` 来集中处理权限校验失败时的逻辑：记录警告日志、向 GitHub 发送带有特定提示的评论（503 状态码），并返回相应的 JSON 响应。

在 `github_app.py` 中，增强了 `get_collaborator_permission` 方法的健壮性：
- 当无法获取到仓库客户端时，原先返回 `"none"`，现改为返回更精确的 `"unknown"`。
- 在捕获异常时，日志记录更加详细，明确指出是哪个仓库和用户权限检查失败了，并返回 `"unknown"` 而非 `"none"`。

在 `test_agent_command.py` 中，添加了一个测试辅助类 `_PostCommentRecorder`，用于方便地记录和模拟发送的评论消息。

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**
本 PR 增强了后端权限校验的健壮性，新增权限校验失败与服务不可用等异常处理机制，并补充了完善的单元测试。

**主要改动列表**
1. **权限与异常处理增强**：修改 `github_app.py` 提升核心权限校验的鲁棒性；扩展 `webhook.py`，新增权限校验失败错误处理以及服务不可用响应的捕获逻辑。
2. **测试用例补充**：新增 `test_full_review_command.py` 覆盖 Review 命令；新增 `test_label_checkbox_toggle.py` 覆盖标签切换场景；扩展 `test_agent_command.py` 以覆盖新增的权限校验异常场景。

**影响范围**
主要影响后端 Webhook 接口层、GitHub App �

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/api/webhook.py"]
    N2["tests/test_label_checkbox_toggle.py"]
```

<!-- sakura-ai-depgraph-end -->