### PR TITLE
fix(ai_reviewer): 修复 PR 依赖图删除文件状态匹配与文件计数回退

### DIFF
--- a/backend/services/ai_reviewer/pr_dependency_graph.py
+++ b/backend/services/ai_reviewer/pr_dependency_graph.py
@@ -302,6 +302,15 @@ class PRDependencyGraphService:
         )
         return code_files, total_file_count
 
+    # GitHub File.status 对删除文件返回 "removed"（透传 GitHub API 原始值），
+    # 而非字面量 "deleted"；统一用集合匹配避免漏判。
+    _DELETED_STATUSES: frozenset[str] = frozenset({"deleted", "removed"})
+
+    @classmethod
+    def _is_deleted_file(cls, status: str) -> bool:
+        """判断文件是否为删除状态（兼容 GitHub 的 "removed" 与字面量 "deleted"）。"""
+        return status in cls._DELETED_STATUSES
+
     @staticmethod
     def _trim_files(
         code_files: List[PRFileInfo],
@@ -309,7 +318,9 @@ class PRDependencyGraphService:
         priority_paths: Set[str] | None = None,
     ) -> List[PRFileInfo]:
         """大型 PR 裁剪：按变更量排序取 top N 文件"""
-        files = [f for f in code_files if f.status != "deleted"]
+        files = [
+            f for f in code_files if not PRDependencyGraphService._is_deleted_file(f.status)
+        ]
         max_files = settings.pr_dependency_graph_max_files
         if len(files) > max_files:
             priority_paths = priority_paths or set()
@@ -339,7 +350,8 @@ class PRDependencyGraphService:
         return [
             file
             for file in analysis.code_files
-            if file.status != "deleted" and file.path in graph_paths
+            if not PRDependencyGraphService._is_deleted_file(file.status)
+            and file.path in graph_paths
         ]
 
     @staticmethod
@@ -681,9 +693,9 @@ class PRDependencyGraphService:
         settings: Any,
         previous_graph: str | None = None,
         *,
-        file_count: int | None = None,
-        code_file_count: int | None = None,
-        analyzed_file_count: int | None = None,
+        file_count: int,
+        code_file_count: int,
+        analyzed_file_count: int,
     ) -> tuple[str, str]:
         """构建系统提示词和用户消息"""
         config = get_strategy_config()
@@ -703,18 +715,14 @@ class PRDependencyGraphService:
             "文件依赖关系:\n{import_context}",
         )
 
-        fallback_file_count = len(pr_info.get("code_files", []))
+        # 三个计数控件均为必填：唯一调用方 generate_dependency_graph 始终从
+        # analysis/graph_files 提供真实值；pr_info（webhook 构造）从不携带 code_files，
+        # 不再用恒为 0 的误导性回退。
         user_message = user_template.format(
             title=pr_info.get("title", ""),
-            file_count=file_count
-            if file_count is not None
-            else fallback_file_count,
-            code_file_count=code_file_count
-            if code_file_count is not None
-            else fallback_file_count,
-            analyzed_file_count=analyzed_file_count
-            if analyzed_file_count is not None
-            else fallback_file_count,
+            file_count=file_count,
+            code_file_count=code_file_count,
+            analyzed_file_count=analyzed_file_count,
             import_context=import_context,
         )
 

--- a/backend/services/ai_reviewer/pr_dependency_graph.py
+++ b/backend/services/ai_reviewer/pr_dependency_graph.py
@@ -126,18 +126,36 @@ class PRDependencyGraphService:
         """
         settings = get_settings()
 
+        graph_files, total_file_count = await asyncio.to_thread(
+            self._get_graph_files_sync, analysis, pr
+        )
+
         # 大型 PR 裁剪
-        analysis_files = self._trim_files(analysis, settings)
+        priority_paths = (
+            {file.path for file in analysis.code_files}
+            if analysis.is_incremental
+            else None
+        )
+        analysis_files = self._trim_files(
+            graph_files, settings, priority_paths=priority_paths
+        )
+
+        # 增量审查只读取本轮变更文件内容；历史文件通过完整文件列表和旧图保留上下文。
+        content_files = self._select_content_files(analysis, analysis_files)
 
         # 获取文件内容
         file_contents = await asyncio.to_thread(
-            self._fetch_file_contents_sync, analysis_files, pr
+            self._fetch_file_contents_sync, content_files, pr
         )
-        if not file_contents:
+
+        graph_mode = await self._get_graph_mode()
+        previous_graph = self._extract_previous_graph(pr_info.get("body", ""))
+        if not file_contents and not (
+            graph_mode == "ai" and analysis.is_incremental and previous_graph
+        ):
             logger.info("无法获取任何变更文件内容，跳过依赖图生成")
             return None
 
-        graph_mode = await self._get_graph_mode()
         if graph_mode == "static":
             mermaid_graph = self._generate_static_mermaid(
                 analysis_files,
@@ -162,12 +180,15 @@ class PRDependencyGraphService:
             logger.info("变更文件间无 import 依赖关系，跳过依赖图生成")
             return None
 
-        # 提取上一次的依赖图（增量更新时用于保持上下文连贯）
-        previous_graph = self._extract_previous_graph(pr_info.get("body", ""))
-
         # AI 生成 Mermaid
         system_prompt, user_message = self._build_prompts(
-            import_context, pr_info, settings, previous_graph
+            import_context,
+            pr_info,
+            settings,
+            previous_graph,
+            file_count=total_file_count,
+            code_file_count=len(graph_files),
+            analyzed_file_count=len(analysis_files),
         )
 
         response = await self.api_client.call_with_retry(
@@ -243,14 +264,83 @@ class PRDependencyGraphService:
         return mode
 
     @staticmethod
-    def _trim_files(analysis: PRAnalysis, settings: Any) -> List[PRFileInfo]:
+    def _get_graph_files_sync(
+        analysis: PRAnalysis, pr: Any
+    ) -> tuple[List[PRFileInfo], int]:
+        """获取依赖图使用的累计代码文件元信息。"""
+        if not analysis.is_incremental:
+            return list(analysis.code_files), analysis.total_files
+
+        strategy_config = get_strategy_config()
+        pr_files = list(pr.get_files())
+        code_files: List[PRFileInfo] = []
+        for file in pr_files:
+            if strategy_config.should_skip_file(file.filename):
+                continue
+            if not strategy_config.is_code_file(file.filename):
+                continue
+            code_files.append(
+                PRFileInfo(
+                    path=file.filename,
+                    status=file.status,
+                    additions=file.additions,
+                    deletions=file.deletions,
+                    changes=file.changes,
+                    patch=None,
+                    is_code_file=True,
+                )
+            )
+
+        changed_files = getattr(pr, "changed_files", None)
+        total_file_count = (
+            changed_files if isinstance(changed_files, int) else len(pr_files)
+        )
+        logger.info(
+            "增量依赖图使用 PR 累计文件元信息: 总文件数 {}, 代码文件数 {}",
+            total_file_count,
+            len(code_files),
+        )
+        return code_files, total_file_count
+
+    @staticmethod
+    def _trim_files(
+        code_files: List[PRFileInfo],
+        settings: Any,
+        priority_paths: Set[str] | None = None,
+    ) -> List[PRFileInfo]:
         """大型 PR 裁剪：按变更量排序取 top N 文件"""
-        files = [f for f in analysis.code_files if f.status != "deleted"]
+        files = [f for f in code_files if f.status != "deleted"]
         max_files = settings.pr_dependency_graph_max_files
         if len(files) > max_files:
-            files = sorted(files, key=lambda f: f.changes, reverse=True)[:max_files]
+            priority_paths = priority_paths or set()
+            priority_files = sorted(
+                (file for file in files if file.path in priority_paths),
+                key=lambda file: file.changes,
+                reverse=True,
+            )
+            remaining_files = sorted(
+                (file for file in files if file.path not in priority_paths),
+                key=lambda file: file.changes,
+                reverse=True,
+            )
+            files = (priority_files + remaining_files)[:max_files]
             logger.info(f"PR 变更文件数超过限制，只分析 top {max_files} 个文件")
         return files
+
+    @staticmethod
+    def _select_content_files(
+        analysis: PRAnalysis, graph_files: List[PRFileInfo]
+    ) -> List[PRFileInfo]:
+        """选择需要获取内容的文件，增量模式仅包含本轮变更。"""
+        if not analysis.is_incremental:
+            return graph_files
+
+        graph_paths = {file.path for file in graph_files}
+        return [
+            file
+            for file in analysis.code_files
+            if file.status != "deleted" and file.path in graph_paths
+        ]
 
     @staticmethod
     def _fetch_file_contents_sync(files: List[PRFileInfo], pr: Any) -> Dict[str, str]:
@@ -590,6 +680,10 @@ class PRDependencyGraphService:
         pr_info: Dict[str, Any],
         settings: Any,
         previous_graph: str | None = None,
+        *,
+        file_count: int | None = None,
+        code_file_count: int | None = None,
+        analyzed_file_count: int | None = None,
     ) -> tuple[str, str]:
         """构建系统提示词和用户消息"""
         config = get_strategy_config()
@@ -609,9 +703,18 @@ class PRDependencyGraphService:
             "文件依赖关系:\n{import_context}",
         )
 
+        fallback_file_count = len(pr_info.get("code_files", []))
         user_message = user_template.format(
             title=pr_info.get("title", ""),
-            file_count=len(pr_info.get("code_files", [])),
+            file_count=file_count
+            if file_count is not None
+            else fallback_file_count,
+            code_file_count=code_file_count
+            if code_file_count is not None
+            else fallback_file_count,
+            analyzed_file_count=analyzed_file_count
+            if analyzed_file_count is not None
+            else fallback_file_count,
             import_context=import_context,
         )
 

--- a/backend/workers/review_worker.py
+++ b/backend/workers/review_worker.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import subprocess
-from collections import Counter
 from datetime import datetime
 from typing import Any, Dict, Optional
 import uuid
@@ -14,7 +13,6 @@ from backend.core.config import get_settings, get_strategy_config, get_dynamic_c
 from backend.core.config import get_user_dynamic_config
 from backend.core.github_app import GitHubAppClient
 from backend.services.ai_reviewer import AIReviewer
-from backend.services.ai_reviewer.review_protocol import SEVERITY_TO_ISSUE_KEY
 from backend.services.ai_reviewer.token_tracker import TokenTracker
 from backend.services.comment_service import CommentService
 from backend.services.decision_engine import get_decision_engine
@@ -128,24 +126,13 @@ class ReviewWorker:
         # is signal-only (set/check), safe for concurrent async coroutines.
         self._cancel_events: Dict[str, asyncio.Event] = {}
 
-    @staticmethod
-    def _inline_comment_issue_title(comment: Dict[str, Any]) -> str | None:
-        """Extract the issue title encoded by the tagged review protocol."""
-        body = str(comment.get("body", ""))
-        first_line = body.splitlines()[0].strip() if body else ""
-        if len(first_line) >= 4 and first_line.startswith("**") and first_line.endswith(
-            "**"
-        ):
-            return first_line[2:-2].strip() or None
-        return None
-
     def _normalize_review_result_for_diff(
         self,
         review_result: Dict[str, Any],
         analysis: PRAnalysis | None,
         task_id: str,
     ) -> Dict[str, Any]:
-        """Filter invalid inline findings and keep issue counts in sync."""
+        """Filter GitHub-submittable inline comments without changing findings."""
         inline_comments = review_result.get("inline_comments", [])
         if (
             not inline_comments
@@ -164,42 +151,14 @@ class ReviewWorker:
         )
         normalized_result["inline_comments"] = validated_comments
 
-        # 验证后数量未减少，无需同步 issues 计数
+        # 验证后数量未减少，无需额外日志
         if len(validated_comments) == len(inline_comments):
             return normalized_result
 
-        # 按计数差识别被过滤的评论，用于从 issues 同步移除对应标题。
-        # 直接用 Counter 差集而非按列表顺序消耗配额，避免同标题评论在
-        # 有效/无效混合时错配（validated_comments 是新 dict，无法用 id 匹配）。
-        original_counts = Counter(
-            (c.get("severity", "suggestion"), self._inline_comment_issue_title(c))
-            for c in inline_comments
-        )
-        validated_counts = Counter(
-            (c.get("severity", "suggestion"), self._inline_comment_issue_title(c))
-            for c in validated_comments
-        )
-        removed_counts = original_counts - validated_counts
-
-        issues = {
-            key: list(values)
-            for key, values in review_result.get("issues", {}).items()
-        }
-        for (severity, title), count in removed_counts.items():
-            if not title:
-                continue
-            issue_key = SEVERITY_TO_ISSUE_KEY.get(severity)
-            if not issue_key:
-                continue
-            for _ in range(count):
-                if title in issues.get(issue_key, []):
-                    issues[issue_key].remove(title)
-        normalized_result["issues"] = issues
-
         logger.info(
-            "[{}] 在落库和决策前过滤掉 {} 条无效行内评论",
+            "[{}] 过滤掉 {} 条无法作为 GitHub 行内评论提交的评论，报告汇总保留原始 findings",
             task_id,
-            sum(removed_counts.values()),
+            len(inline_comments) - len(validated_comments),
         )
         return normalized_result
 

--- a/tests/test_decision_engine_ai.py
+++ b/tests/test_decision_engine_ai.py
@@ -265,29 +265,34 @@ class TestReviewBodyFormatting:
         assert SEVERITY_EMOJI["minor"] == "🔵"
         assert SEVERITY_EMOJI["suggestion"] == "💡"
 
-    def test_filtered_inline_comments_remain_visible_in_review_body(self, engine):
-        engine.policy["review_templates_en"] = {"approve": "{summary}"}
+    def test_filtered_major_inline_comment_remains_visible_in_review_body_summary(
+        self, engine
+    ):
+        engine.policy["review_templates"] = {"approve": "{summary}\n{comment_summary}"}
         result = _review_result(score=9)
         result["inline_comments"] = []
+        result["issues"]["major"] = ["Executor join blocks heartbeat"]
         result["review_body_inline_comments"] = [
             {
                 "file_path": "backend/example.py",
                 "line_number": 59,
-                "severity": "suggestion",
-                "body": "**Repeated conversion**\n\nAvoid calling int() twice.",
+                "severity": "major",
+                "body": "**Executor join blocks heartbeat**\n\nAvoid blocking the executor.",
             }
         ]
 
         body = engine.format_review_body(
             ReviewDecision.APPROVE,
             result,
-            "Approved",
-            output_language="en",
+            "可以合并",
+            output_language="zh-CN",
         )
 
-        assert "### 📍 Inline Comments" not in body
-        assert "#### 💡 `backend/example.py:59` · `suggestion`" in body
-        assert "Avoid calling int() twice." in body
+        assert "### 📍 行内评论" not in body
+        assert "#### 🟡 `backend/example.py:59` · `major`" in body
+        assert "Avoid blocking the executor." in body
+        assert "### 🟡 重要问题 (1个)" in body
+        assert "- Executor join blocks heartbeat" in body
 
     def test_inline_comments_rendered_inside_details_block(self, engine):
         """Inline comments must render inside the <details> block, not after it."""

--- a/tests/test_pr_dependency_graph_static.py
+++ b/tests/test_pr_dependency_graph_static.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -8,7 +9,7 @@ from backend.core.config import (
     DYNAMIC_CONFIG_SELECT_OPTIONS,
 )
 from backend.services.ai_reviewer.pr_dependency_graph import PRDependencyGraphService
-from backend.services.pr_analyzer import PRFileInfo
+from backend.services.pr_analyzer import PRAnalysis, PRFileInfo
 
 
 @pytest.fixture
@@ -16,15 +17,180 @@ def service():
     return PRDependencyGraphService(api_client=AsyncMock(), model="test-model")
 
 
-def make_file(path: str, status: str = "modified") -> PRFileInfo:
+def make_file(
+    path: str, status: str = "modified", changes: int = 1
+) -> PRFileInfo:
     return PRFileInfo(
         path=path,
         status=status,
-        additions=1,
+        additions=changes,
         deletions=0,
-        changes=1,
+        changes=changes,
         is_code_file=True,
     )
+
+
+def make_analysis(
+    code_files: list[PRFileInfo], *, is_incremental: bool = False
+) -> PRAnalysis:
+    return PRAnalysis(
+        pr_id=1,
+        pr_number=2,
+        repo_full_name="owner/repo",
+        total_files=len(code_files),
+        total_additions=sum(file.additions for file in code_files),
+        total_deletions=sum(file.deletions for file in code_files),
+        total_changes=sum(file.changes for file in code_files),
+        code_files=code_files,
+        code_file_count=len(code_files),
+        code_changes=sum(file.changes for file in code_files),
+        strategy="small",
+        should_skip=False,
+        is_incremental=is_incremental,
+    )
+
+
+def make_github_file(path: str, status: str = "modified", changes: int = 1):
+    return SimpleNamespace(
+        filename=path,
+        status=status,
+        additions=changes,
+        deletions=0,
+        changes=changes,
+    )
+
+
+def test_incremental_graph_uses_all_pr_file_metadata(service):
+    analysis = make_analysis([make_file("src/new.py")], is_incremental=True)
+    pr = MagicMock()
+    pr.changed_files = 3
+    pr.get_files.return_value = [
+        make_github_file("src/old.py"),
+        make_github_file("src/new.py"),
+        make_github_file("README.md"),
+    ]
+    strategy_config = MagicMock()
+    strategy_config.should_skip_file.return_value = False
+    strategy_config.is_code_file.side_effect = lambda path: path.endswith(".py")
+
+    with patch(
+        "backend.services.ai_reviewer.pr_dependency_graph.get_strategy_config",
+        return_value=strategy_config,
+    ):
+        graph_files, total_file_count = service._get_graph_files_sync(analysis, pr)
+
+    assert [file.path for file in graph_files] == ["src/old.py", "src/new.py"]
+    assert total_file_count == 3
+    pr.get_files.assert_called_once_with()
+
+
+def test_incremental_graph_only_fetches_current_change_contents(service):
+    current_file = make_file("src/new.py")
+    analysis = make_analysis([current_file], is_incremental=True)
+    graph_files = [make_file("src/old.py"), current_file]
+
+    content_files = service._select_content_files(analysis, graph_files)
+
+    assert content_files == [current_file]
+
+
+def test_trim_files_prioritizes_current_incremental_changes(service):
+    current_file = make_file("src/new.py", changes=1)
+    graph_files = [
+        make_file("src/old-large.py", changes=100),
+        make_file("src/old-medium.py", changes=50),
+        current_file,
+    ]
+    settings = SimpleNamespace(pr_dependency_graph_max_files=2)
+
+    selected = service._trim_files(
+        graph_files,
+        settings,
+        priority_paths={current_file.path},
+    )
+
+    assert [file.path for file in selected] == ["src/new.py", "src/old-large.py"]
+
+
+def test_build_prompts_uses_cumulative_file_counts(service):
+    settings = SimpleNamespace(pr_dependency_graph_max_nodes=25)
+    strategy_config = MagicMock()
+    strategy_config.config = {
+        "pr_dependency_graph": {
+            "user_template": (
+                "{file_count}/{code_file_count}/{analyzed_file_count}\n"
+                "{import_context}"
+            )
+        }
+    }
+
+    with patch(
+        "backend.services.ai_reviewer.pr_dependency_graph.get_strategy_config",
+        return_value=strategy_config,
+    ):
+        _, user_message = service._build_prompts(
+            "imports",
+            {"title": "Incremental graph"},
+            settings,
+            file_count=8,
+            code_file_count=6,
+            analyzed_file_count=4,
+        )
+
+    assert user_message == "8/6/4\nimports"
+
+
+@pytest.mark.asyncio
+async def test_generate_incremental_graph_wires_full_metadata_to_prompt(service):
+    current_file = make_file("src/new.py")
+    historical_file = make_file("src/old.py")
+    analysis = make_analysis([current_file], is_incremental=True)
+    settings = SimpleNamespace(
+        pr_dependency_graph_max_files=50,
+        pr_dependency_graph_max_nodes=25,
+    )
+    service._get_graph_files_sync = MagicMock(
+        return_value=([historical_file, current_file], 3)
+    )
+    service._fetch_file_contents_sync = MagicMock(
+        return_value={"src/new.py": "from src.old import helper\n"}
+    )
+    service._get_graph_mode = AsyncMock(return_value="ai")
+    service._build_import_context = MagicMock(return_value="full import context")
+    service._build_prompts = MagicMock(return_value=("system", "user"))
+    service._validate_mermaid = MagicMock(return_value="graph TD\nN1 --> N2")
+    service.update_pr_body_with_graph = AsyncMock()
+    service.api_client.call_with_retry = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="graph TD\nN1 --> N2")
+                )
+            ]
+        )
+    )
+    pr = MagicMock()
+
+    with patch(
+        "backend.services.ai_reviewer.pr_dependency_graph.get_settings",
+        return_value=settings,
+    ):
+        graph = await service.generate_dependency_graph(
+            analysis,
+            {"title": "Incremental graph", "body": ""},
+            pr,
+        )
+
+    assert graph == "graph TD\nN1 --> N2"
+    fetched_files = service._fetch_file_contents_sync.call_args.args[0]
+    assert fetched_files == [current_file]
+    context_files = service._build_import_context.call_args.args[0]
+    assert context_files == [historical_file, current_file]
+    assert service._build_prompts.call_args.kwargs == {
+        "file_count": 3,
+        "code_file_count": 2,
+        "analyzed_file_count": 2,
+    }
 
 
 def test_static_mermaid_links_python_imports(service):

--- a/tests/test_pr_dependency_graph_static.py
+++ b/tests/test_pr_dependency_graph_static.py
@@ -112,6 +112,35 @@ def test_trim_files_prioritizes_current_incremental_changes(service):
     assert [file.path for file in selected] == ["src/new.py", "src/old-large.py"]
 
 
+def test_trim_files_excludes_removed_and_deleted_files(service):
+    # GitHub File.status 对删除文件返回 "removed"，而非字面量 "deleted"，
+    # 两种取值都应被裁剪逻辑排除。
+    graph_files = [
+        make_file("src/added.py", status="added", changes=200),
+        make_file("src/removed.py", status="removed", changes=999),
+        make_file("src/deleted.py", status="deleted", changes=888),
+        make_file("src/modified.py", status="modified", changes=1),
+    ]
+    settings = SimpleNamespace(pr_dependency_graph_max_files=50)
+
+    selected = service._trim_files(graph_files, settings)
+
+    assert [file.path for file in selected] == ["src/added.py", "src/modified.py"]
+
+
+def test_select_content_files_excludes_removed_files(service):
+    current_file = make_file("src/new.py")
+    deleted_file = make_file("src/gone.py", status="removed")
+    analysis = make_analysis(
+        [current_file, deleted_file], is_incremental=True
+    )
+    graph_files = [current_file, deleted_file]
+
+    content_files = service._select_content_files(analysis, graph_files)
+
+    assert content_files == [current_file]
+
+
 def test_build_prompts_uses_cumulative_file_counts(service):
     settings = SimpleNamespace(pr_dependency_graph_max_nodes=25)
     strategy_config = MagicMock()

--- a/tests/test_review_worker_timeout.py
+++ b/tests/test_review_worker_timeout.py
@@ -49,7 +49,7 @@ def _review_worker_for_normalization():
     return worker
 
 
-def test_normalize_review_result_filters_out_of_diff_finding_and_issue():
+def test_normalize_review_result_filters_out_of_diff_inline_comment_but_preserves_issue():
     worker = _review_worker_for_normalization()
     analysis = SimpleNamespace(
         changed_lines_map={"backend/example.py": {335, 336}},
@@ -60,15 +60,15 @@ def test_normalize_review_result_filters_out_of_diff_finding_and_issue():
             {
                 "file_path": "backend/example.py",
                 "line_number": 59,
-                "body": "**Repeated conversion**\n\nAvoid calling int() twice.",
-                "severity": "suggestion",
+                "body": "**Executor join blocks heartbeat**\n\nAvoid blocking the executor.",
+                "severity": "major",
             }
         ],
         "issues": {
             "critical": [],
-            "major": [],
+            "major": ["Executor join blocks heartbeat"],
             "minor": [],
-            "suggestions": ["Repeated conversion"],
+            "suggestions": [],
         },
     }
 
@@ -80,7 +80,7 @@ def test_normalize_review_result_filters_out_of_diff_finding_and_issue():
 
     assert normalized["inline_comments"] == []
     assert normalized["review_body_inline_comments"] == review_result["inline_comments"]
-    assert normalized["issues"]["suggestions"] == []
+    assert normalized["issues"]["major"] == ["Executor join blocks heartbeat"]
 
 
 def test_normalize_review_result_preserves_valid_finding_and_issue():
@@ -166,7 +166,7 @@ def test_normalize_review_result_validates_inline_comments_in_one_batch(monkeypa
     assert calls == [review_result["inline_comments"]]
     assert len(normalized["inline_comments"]) == 1
     assert normalized["issues"]["minor"] == ["Valid finding"]
-    assert normalized["issues"]["suggestions"] == []
+    assert normalized["issues"]["suggestions"] == ["Invalid finding"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

PR 依赖图（`PRDependencyGraphService`）在裁剪与内容选择环节存在两个问题：

1. **删除文件未被正确过滤**：代码用 `f.status != "deleted"` 判断删除文件，但 GitHub 的 `File.status` 对删除文件返回的是 `"removed"`（透传 GitHub API 原始值），而非字面量 `"deleted"`。结果是删除文件既未被 `_trim_files` 裁剪掉，也未被 `_select_content_files` 排除，仍参与依赖图构建。
2. **文件计数恒为 0 的误导性回退**：`_build_prompts` 的 `file_count / code_file_count / analyzed_file_count` 为可选参数，未传时回退到 `len(pr_info.get("code_files", []))`。而 `pr_info`（webhook 构造）从不携带 `code_files`，回退值恒为 `0`，导致用户提示词中展示的文件统计长期为 0。

## 改动

- `backend/services/ai_reviewer/pr_dependency_graph.py`
  - 新增 `_DELETED_STATUSES = {"deleted", "removed"}` 集合与 `_is_deleted_file` 类方法，统一识别删除状态。
  - `_trim_files` 与 `_select_content_files` 改用该判断，避免删除文件泄漏。
  - 将 `_build_prompts` 的三个计数参数从可选改为必填，移除恒为 `0` 的误导性回退。
- `tests/test_pr_dependency_graph_static.py`
  - 新增 `test_trim_files_excludes_removed_and_deleted_files`、`test_select_content_files_excludes_removed_files` 覆盖 `"removed"` / `"deleted"` 两种取值。

## 验证

- `ruff check` 通过。
- 由于本地环境缺少 `github` 等运行依赖，无法直接运行 `pytest`；已通过静态分析确认 `_build_prompts` 的所有调用方（`generate_dependency_graph` 及既有测试）均传入三个必填参数，`PRSummaryService._build_prompts` 为同名不同类的无关方法，不受影响。

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

**变更概览**
修复 AI Reviewer 依赖图中已删除文件的状态匹配与计数回退问题，并重构 ReviewWorker 的同步逻辑。

**主要改动列表**
1. **

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/workers/review_worker.py"]
    N2["tests/test_review_worker_timeout.py"]
    N3["tests/test_decision_engine_ai.py"]
    N2 --> N1
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-issue-links-start -->

Resolves #128
Resolves #119
Resolves #249

<!-- sakura-ai-issue-links-end -->