### PR TITLE
feat(database): 统一数据库连接串规范化并兼容旧驱动

### DIFF
--- a/backend/core/setup_service.py
+++ b/backend/core/setup_service.py
@@ -94,24 +94,39 @@ class SetupService:
         if not database_url:
             return {"success": False, "message": "数据库连接字符串不能为空"}
 
-        # 确保使用异步驱动
-        if not database_url.startswith(("mysql+aiomysql://", "postgresql+asyncpg://")):
+        # 与 init_async_db 一致：接受所有可规范化的异步驱动连接串
+        if not database_url.startswith(
+            (
+                "mysql+aiomysql://",
+                "mysql+asyncmy://",
+                "mysql://",
+                "postgresql+asyncpg://",
+                "postgresql://",
+            )
+        ):
             return {
                 "success": False,
-                "message": "连接字符串必须以 mysql+aiomysql:// 或 postgresql+asyncpg:// 开头",
+                "message": "连接字符串必须以 mysql+aiomysql://、mysql+asyncmy:// 或 postgresql+asyncpg:// 开头",
             }
 
+        # 规范化到实际使用的异步驱动（aiomysql → asyncmy），否则 SQLAlchemy 会尝试
+        # 加载未安装的 aiomysql 而报 ModuleNotFoundError
+        from backend.models.database import normalize_database_url
+
+        normalized_url = normalize_database_url(database_url)
+
         try:
-            engine = create_async_engine(database_url)
+            engine = create_async_engine(normalized_url)
             async with engine.connect() as conn:
                 await conn.execute(select(1))
             await engine.dispose()
             return {"success": True, "message": "数据库连接成功"}
         except Exception as e:
             error_msg = str(e)
-            # 脱敏：不暴露完整连接字符串
-            if database_url in error_msg:
-                error_msg = error_msg.replace(database_url, "***")
+            # 脱敏：不暴露完整连接字符串（原始与规范化后的都需脱敏）
+            for secret in (database_url, normalized_url):
+                if secret and secret in error_msg:
+                    error_msg = error_msg.replace(secret, "***")
             return {"success": False, "message": f"连接失败: {error_msg}"}
 
     async def test_redis_connection(self, redis_url: str) -> dict[str, Any]:

--- a/backend/core/setup_service.py
+++ b/backend/core/setup_service.py
@@ -106,7 +106,7 @@ class SetupService:
         ):
             return {
                 "success": False,
-                "message": "连接字符串必须以 mysql+aiomysql://、mysql+asyncmy:// 或 postgresql+asyncpg:// 开头",
+                "message": "连接字符串必须以 mysql+aiomysql://、mysql+asyncmy://、mysql://、postgresql+asyncpg:// 或 postgresql:// 开头",
             }
 
         # 规范化到实际使用的异步驱动（aiomysql → asyncmy），否则 SQLAlchemy 会尝试

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -30,6 +30,23 @@ async_engine = None
 async_session = None
 
 
+def normalize_database_url(database_url: str) -> str:
+    """将数据库连接字符串规范化为项目支持的异步驱动 URL。"""
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if "mysql+aiomysql://" in database_url:
+        database_url = database_url.replace("mysql+aiomysql://", "mysql+asyncmy://", 1)
+        logger.info("已将数据库驱动从 aiomysql 自动转换为 asyncmy")
+
+    if database_url.startswith("mysql://"):
+        return database_url.replace("mysql://", "mysql+asyncmy://", 1)
+    if database_url.startswith("postgresql://"):
+        return database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return database_url
+
+
 class PRStatus(str, enum.Enum):
     """PR审查状态"""
 
@@ -937,24 +954,7 @@ def init_async_db(database_url: str):
     logger = logging.getLogger(__name__)
 
     try:
-        # 向后兼容：将旧版 aiomysql 驱动自动转换为 asyncmy
-        if "mysql+aiomysql://" in database_url:
-            database_url = database_url.replace(
-                "mysql+aiomysql://", "mysql+asyncmy://", 1
-            )
-            logger.info("已将数据库驱动从 aiomysql 自动转换为 asyncmy")
-
-        # 确保使用异步驱动
-        if not database_url.startswith(
-            "mysql+asyncmy://"
-        ) and not database_url.startswith("postgresql+asyncpg://"):
-            # 如果不是异步URL，尝试转换
-            if database_url.startswith("mysql://"):
-                database_url = database_url.replace("mysql://", "mysql+asyncmy://", 1)
-            elif database_url.startswith("postgresql://"):
-                database_url = database_url.replace(
-                    "postgresql://", "postgresql+asyncpg://", 1
-                )
+        database_url = normalize_database_url(database_url)
 
         logger.info(f"初始化异步数据库引擎: {database_url}")
 

--- a/backend/services/ai_reviewer/api_client.py
+++ b/backend/services/ai_reviewer/api_client.py
@@ -235,6 +235,8 @@ class AIApiClient:
                 # 检查空响应
                 if not self._is_valid_response(response):
                     if attempt < max_retries - 1:
+                        # 重新计算已耗时，需包含本次调用真实耗时
+                        elapsed = time.monotonic() - start_time
                         delay = self._calculate_delay(attempt)
                         logger.warning(
                             "AI返回空响应，{:.1f}秒后重试 ({}/{}, 已耗时 {:.1f}s)",
@@ -306,6 +308,8 @@ class AIApiClient:
                     ) from e
 
                 if attempt < max_retries - 1:
+                    # 重新计算已耗时，需包含本次调用真实耗时
+                    elapsed = time.monotonic() - start_time
                     delay = self._calculate_delay(attempt)
                     logger.warning(
                         "AI调用失败 [{}]: {}，{:.1f}秒后重试 ({}/{}, 已耗时 {:.1f}s)",

--- a/backend/webui/routes/system_config.py
+++ b/backend/webui/routes/system_config.py
@@ -86,9 +86,17 @@ async def save_system_config(
             if not val:
                 continue
 
-            # 数据库连接字符串验证
+            # 数据库连接字符串验证（接受所有可规范化的异步驱动格式）
             if key == "database_url":
-                if not val.startswith(("mysql+aiomysql://", "postgresql+asyncpg://")):
+                if not val.startswith(
+                    (
+                        "mysql+aiomysql://",
+                        "mysql+asyncmy://",
+                        "mysql://",
+                        "postgresql+asyncpg://",
+                        "postgresql://",
+                    )
+                ):
                     return toast_redirect(
                         "/system-config/",
                         "system_config.invalid_db_url",

--- a/backend/webui/templates/setup_wizard.html
+++ b/backend/webui/templates/setup_wizard.html
@@ -123,10 +123,10 @@
                             支持 MySQL 和 PostgreSQL。应用会自动创建所需的数据表。
                         </p>
                         <input type="text" x-model="form.database_url"
-                               placeholder="mysql+aiomysql://user:password@localhost:3306/pr_reviewer"
+                               placeholder="mysql+asyncmy://user:password@localhost:3306/sakura_ai"
                                class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-pink-500 focus:border-transparent outline-none">
                         <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                            格式: mysql+aiomysql://用户名:密码@主机:端口/数据库名
+                            格式: mysql+asyncmy://用户名:密码@主机:端口/数据库名
                         </p>
                     </div>
 

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1338,7 +1338,7 @@ system_config:
   save_hint: "Keys marked \"Restart Required\" need a service restart to fully apply. Other changes take effect immediately."
   saved: "System config saved and applied live"
   saved_restart_required: "System config saved. Some changes require a service restart to take effect."
-  invalid_db_url: "Invalid database URL. Must start with mysql+aiomysql://, mysql+asyncmy:// or postgresql+asyncpg://"
+  invalid_db_url: "Invalid database URL. Must start with mysql+aiomysql://, mysql+asyncmy://, mysql://, postgresql+asyncpg:// or postgresql://"
   invalid_port: "Invalid port number. Must be between 1 and 65535."
   invalid_log_level: "Invalid log level. Allowed: DEBUG, INFO, WARNING, ERROR, CRITICAL"
   group_database: "Database & Cache"

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1338,7 +1338,7 @@ system_config:
   save_hint: "Keys marked \"Restart Required\" need a service restart to fully apply. Other changes take effect immediately."
   saved: "System config saved and applied live"
   saved_restart_required: "System config saved. Some changes require a service restart to take effect."
-  invalid_db_url: "Invalid database URL. Must start with mysql+aiomysql:// or postgresql+asyncpg://"
+  invalid_db_url: "Invalid database URL. Must start with mysql+aiomysql://, mysql+asyncmy:// or postgresql+asyncpg://"
   invalid_port: "Invalid port number. Must be between 1 and 65535."
   invalid_log_level: "Invalid log level. Allowed: DEBUG, INFO, WARNING, ERROR, CRITICAL"
   group_database: "Database & Cache"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1338,7 +1338,7 @@ system_config:
   save_hint: "标记为「需重启」的配置修改后需要重启服务才能完全生效，其余配置修改后即时生效。"
   saved: "系统配置已保存并即时生效"
   saved_restart_required: "系统配置已保存，部分配置需重启服务后生效"
-  invalid_db_url: "数据库连接字符串格式错误，需以 mysql+aiomysql:// 或 postgresql+asyncpg:// 开头"
+  invalid_db_url: "数据库连接字符串格式错误，需以 mysql+aiomysql://、mysql+asyncmy:// 或 postgresql+asyncpg:// 开头"
   invalid_port: "端口号无效，需为 1-65535 之间的整数"
   invalid_log_level: "日志级别无效，允许值：DEBUG、INFO、WARNING、ERROR、CRITICAL"
   group_database: "数据库 & 缓存"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1338,7 +1338,7 @@ system_config:
   save_hint: "标记为「需重启」的配置修改后需要重启服务才能完全生效，其余配置修改后即时生效。"
   saved: "系统配置已保存并即时生效"
   saved_restart_required: "系统配置已保存，部分配置需重启服务后生效"
-  invalid_db_url: "数据库连接字符串格式错误，需以 mysql+aiomysql://、mysql+asyncmy:// 或 postgresql+asyncpg:// 开头"
+  invalid_db_url: "数据库连接字符串格式错误，需以 mysql+aiomysql://、mysql+asyncmy://、mysql://、postgresql+asyncpg:// 或 postgresql:// 开头"
   invalid_port: "端口号无效，需为 1-65535 之间的整数"
   invalid_log_level: "日志级别无效，允许值：DEBUG、INFO、WARNING、ERROR、CRITICAL"
   group_database: "数据库 & 缓存"

--- a/tests/test_normalize_database_url.py
+++ b/tests/test_normalize_database_url.py
@@ -1,0 +1,43 @@
+"""normalize_database_url 的单元测试。
+
+锁定数据库连接串规范化行为：旧版 aiomysql 驱动自动转为 asyncmy，
+裸 mysql:// / postgresql:// 自动补齐异步驱动前缀。
+"""
+
+import pytest
+
+from backend.models.database import normalize_database_url
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 向后兼容：aiomysql 自动转 asyncmy（项目已迁移到 asyncmy 驱动）
+        (
+            "mysql+aiomysql://user:pass@localhost:3306/sakura_ai",
+            "mysql+asyncmy://user:pass@localhost:3306/sakura_ai",
+        ),
+        # 已是 asyncmy，保持不变
+        (
+            "mysql+asyncmy://user:pass@localhost:3306/sakura_ai",
+            "mysql+asyncmy://user:pass@localhost:3306/sakura_ai",
+        ),
+        # 裸 mysql:// 补齐异步驱动
+        (
+            "mysql://user:pass@localhost:3306/sakura_ai",
+            "mysql+asyncmy://user:pass@localhost:3306/sakura_ai",
+        ),
+        # 裸 postgresql:// 补齐异步驱动
+        (
+            "postgresql://user:pass@localhost:5432/sakura_ai",
+            "postgresql+asyncpg://user:pass@localhost:5432/sakura_ai",
+        ),
+        # 已是 postgresql+asyncpg，保持不变
+        (
+            "postgresql+asyncpg://user:pass@localhost:5432/sakura_ai",
+            "postgresql+asyncpg://user:pass@localhost:5432/sakura_ai",
+        ),
+    ],
+)
+def test_normalize_database_url(raw, expected):
+    assert normalize_database_url(raw) == expected

--- a/tests/test_setup_service_database.py
+++ b/tests/test_setup_service_database.py
@@ -1,0 +1,95 @@
+"""SetupService.test_database_connection 的单元测试。
+
+锁定初始配置向导"测试连接"对连接串的处理：
+- 接受 mysql+asyncmy / mysql+aiomysql / mysql / postgresql+asyncpg / postgresql
+- 拒绝不支持的格式
+- aiomysql URL 会被规范化为 asyncmy 后再传给引擎（回归保护：项目驱动已
+  迁移到 asyncmy，原样传 aiomysql 会触发 ModuleNotFoundError）
+- 连接失败时错误消息不得泄露连接串
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.core.setup_service import SetupService
+
+
+def _fake_engine_ok():
+    """构造一个连接成功的假引擎，避免真实数据库连接。"""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    connect_cm = MagicMock()
+    connect_cm.__aenter__ = AsyncMock(return_value=conn)
+    connect_cm.__aexit__ = AsyncMock(return_value=None)
+    engine = MagicMock()
+    engine.connect = MagicMock(return_value=connect_cm)
+    engine.dispose = AsyncMock(return_value=None)
+    return engine
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "mysql+asyncmy://u:p@localhost:3306/sakura_ai",
+        "mysql+aiomysql://u:p@localhost:3306/sakura_ai",
+        "mysql://u:p@localhost:3306/sakura_ai",
+        "postgresql+asyncpg://u:p@localhost:5432/sakura_ai",
+        "postgresql://u:p@localhost:5432/sakura_ai",
+    ],
+)
+@pytest.mark.asyncio
+async def test_accepts_supported_database_urls(url):
+    with patch(
+        "backend.core.setup_service.create_async_engine",
+        return_value=_fake_engine_ok(),
+    ):
+        result = await SetupService().test_database_connection(url)
+    assert result["success"] is True, result["message"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_unsupported_database_url():
+    result = await SetupService().test_database_connection("sqlite://x")
+    assert result["success"] is False
+    assert "必须以" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_aiomysql_url_is_normalized_before_engine():
+    """回归保护：aiomysql URL 必须规范化为 asyncmy 再传给 create_async_engine。
+
+    这是本次修复的核心：项目驱动已从 aiomysql 迁移到 asyncmy，若把 aiomysql
+    URL 原样传给 create_async_engine，SQLAlchemy 会因 aiomysql 未安装而报
+    ModuleNotFoundError（初始配置向导"测试连接"曾出现的 bug）。
+    """
+    captured = {}
+
+    def fake_create_async_engine(url, **kwargs):
+        captured["url"] = url
+        return _fake_engine_ok()
+
+    with patch(
+        "backend.core.setup_service.create_async_engine",
+        side_effect=fake_create_async_engine,
+    ):
+        result = await SetupService().test_database_connection(
+            "mysql+aiomysql://u:p@localhost:3306/sakura_ai"
+        )
+    assert result["success"] is True
+    assert captured["url"].startswith("mysql+asyncmy://")
+    assert "aiomysql" not in captured["url"]
+
+
+@pytest.mark.asyncio
+async def test_error_message_redacts_connection_string():
+    """连接失败时，错误消息不得泄露原始连接串（含密码）。"""
+    secret = "mysql+aiomysql://u:SECRET_PASS@localhost:3306/sakura_ai"
+    with patch(
+        "backend.core.setup_service.create_async_engine",
+        side_effect=RuntimeError(f"boom {secret}"),
+    ):
+        result = await SetupService().test_database_connection(secret)
+    assert result["success"] is False
+    assert "SECRET_PASS" not in result["message"]
+    assert "***" in result["message"]


### PR DESCRIPTION
- 新增数据库 URL 规范化函数，统一将 mysql/postgresql 连接串转换为异步驱动格式
- 让初始化、连接测试和系统配置校验共享同一套规则
- 支持 mysql+aiomysql、mysql+asyncmy、mysql、postgresql+asyncpg、postgresql 等格式
- 增强错误信息脱敏，避免泄露原始或规范化后的连接串

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

### 变更概览
本次 PR 实现了数据库连接串统一规范化与旧驱动兼容，并修复了 AI 审查模块的日志计算 Bug。

### 主要改动列表
- **新增功能**：引入统一的数据库连接串规范化机制，兼容旧版驱动。
- **逻辑重构**：重构 `database.py` 及 `setup_service.py` 的连接串解析与生成逻辑。
- **前后端适配**：更新系统配置路由与安装向导模板，适配规范化后的新格式。
- **测试增强**：新增 2 个测试文件，充分覆盖规范化逻辑与初始化流程。
- **Bug修复**：修正 `ai_reviewer/api_client.py` 中重试日志的已耗时计算错误。

### 影响范围
主要影响后端数据库配置核心逻辑、系统配置 API、前端安装向导及 AI 审查服务。此变更仅作用于系统初始化配置环节及 AI 审查重试场景，不影响已配置完成系统的日常运行。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/core/setup_service.py"]
    N2["backend/models/database.py"]
    N3["tests/test_normalize_database_url.py"]
    N4["tests/test_setup_service_database.py"]
    N5["backend/services/ai_reviewer/api_client.py"]
    N3 --> N2
    N4 --> N1
```

<!-- sakura-ai-depgraph-end -->