### PR TITLE
fix(issue-protocol): 支持单行 NONE 建议标题解析

### DIFF
--- a/backend/services/issue_protocol.py
+++ b/backend/services/issue_protocol.py
@@ -232,18 +232,50 @@ class TaggedIssueAnalysisParser:
                 raise IssueProtocolError(f"reserved tag syntax in {field}")
             return value.strip(), index + 1
 
-        if stripped != single_prefix:
+        if stripped.startswith(single_prefix) and stripped.endswith(single_suffix):
+            value = stripped[len(single_prefix) : -len(single_suffix)]
+            if self._is_reserved_tag_line(value.strip()):
+                raise IssueProtocolError(f"reserved protocol tag inside {field}")
+            return value, index + 1
+
+        if not stripped.startswith(single_prefix):
             raise IssueProtocolError(f"expected {single_prefix}")
+        after_open = stripped[len(single_prefix) :]
         index += 1
         content: list[str] = []
-        while index < len(lines) and lines[index].strip() != single_suffix:
-            if self._is_reserved_tag_line(lines[index].strip()):
+        if after_open.strip():
+            content.append(after_open)
+
+        closed = False
+        while index < len(lines):
+            current = lines[index]
+            stripped_current = current.strip()
+            if stripped_current == single_suffix:
+                index += 1
+                closed = True
+                break
+            if stripped_current.endswith(single_suffix):
+                content.append(current[: current.rfind(single_suffix)])
+                index += 1
+                closed = True
+                break
+            if self._is_reserved_tag_line(stripped_current):
                 raise IssueProtocolError(f"reserved protocol tag inside {field}")
-            content.append(lines[index])
+            content.append(current)
             index += 1
-        if index >= len(lines):
+
+        if not closed:
             raise IssueProtocolError(f"missing {single_suffix}")
-        return "\n".join(content).strip(), index + 1
+        return self._strip_blank_lines(content), index
+
+    @staticmethod
+    def _strip_blank_lines(lines: list[str]) -> str:
+        body = list(lines)
+        while body and not body[0].strip():
+            body.pop(0)
+        while body and not body[-1].strip():
+            body.pop()
+        return "\n".join(body)
 
     @staticmethod
     def _consume_block(

--- a/tests/test_issue_analysis_protocol.py
+++ b/tests/test_issue_analysis_protocol.py
@@ -96,6 +96,19 @@ def test_parses_complete_tagged_issue_analysis():
     assert result["suggested_title"] == "Fix review flow failure"
 
 
+def test_accepts_single_line_none_for_multiline_suggested_title():
+    analyzer = IssueAnalyzer.__new__(IssueAnalyzer)
+    text = _issue_analysis().replace(
+        "<SUGGESTED_TITLE>\nFix review flow failure\n</SUGGESTED_TITLE>",
+        "<SUGGESTED_TITLE>NONE</SUGGESTED_TITLE>",
+    )
+
+    result = analyzer._parse_analysis_result(text)
+
+    assert result["parse_source"] == "tagged_issue"
+    assert result["suggested_title"] is None
+
+
 def test_issue_prompt_keeps_task_data_in_user_evidence_boundary(monkeypatch):
     class _StrategyConfig:
         def get_issue_analysis_config(self):


### PR DESCRIPTION
- 允许 `<SUGGESTED_TITLE>NONE</SUGGESTED_TITLE>` 作为多行字段的单行写法
- 增强多行标签解析，支持首尾同行闭合并去除首尾空白行
- 补充对应测试，验证 suggested_title 可解析为 None

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
- 修复 `issue-protocol` 中建议标题解析问题，支持单行 `NONE` 建议标题的识别与处理。

**主要改动列表**
- 调整 `backend/services/issue_protocol.py` 的解析逻辑，增强对单行 `NONE` 标题格式的兼容性。
- 新增/补充 `tests/test_issue_analysis_protocol.py` 测试，覆盖该场景并防止回归。

**影响范围**
- 影响 issue 分析/协议解析流程。
- 提升对异常或简化标题格式的容错能力，降低解析失败风险。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/services/issue_protocol.py"]
    N2["tests/test_issue_analysis_protocol.py"]
    N2 --> N1
```

<!-- sakura-ai-depgraph-end -->