### PR TITLE
fix(ci): allow updater workflow to read artifacts

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -761,6 +761,7 @@ jobs:
       needs.generate-release.result == 'success' &&
       needs.build-and-upload-assets.result == 'success'
     permissions:
+      actions: read
       contents: write
     uses: ./.github/workflows/updater-build.yml
     with:


### PR DESCRIPTION
## Summary

- grant the release workflow caller `actions: read` when invoking `updater-build.yml`
- preserve the existing `contents: write` permission used to publish updater binaries
- fix the startup-time reusable-workflow permission validation failure

## Root cause

The `publish-updater-assets` caller explicitly set only `contents: write`, which reduced every omitted permission to `none`. The nested publish job in `updater-build.yml` requires `actions: read` to download the two updater artifacts, and reusable workflows cannot elevate permissions beyond the caller. GitHub therefore rejected the workflow before creating any jobs.

Failed run: https://github.com/Sakura520222/Sakura-AI/actions/runs/31461543619

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-on-pr-merge.yml .github/workflows/updater-build.yml .github/workflows/docker-publish.yml`
- parsed all three related workflow files with PyYAML and asserted the caller covers all callee job permissions
- `python run_ruff.py --check`
- `git diff --check`

## Impact

- CI/release workflow permissions only
- no application behavior, configuration, database, API, or packaged artifact content changes
- merging to `main` will trigger a new release workflow run using the corrected permission contract; re-running the old failed SHA would still use the invalid workflow

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本次 PR 修复了 CI 配置，允许 updater 工作流读取工件。

**主要改动列表**
*   修改了 GitHub Actions 工作流文件 `.github/workflows/release-on-pr-merge.yml`，新增一行配置（+1/-0）。

**影响范围**
*   **影响系统**：CI/CD 自动化流程。
*   **具体影响**：解决了 updater 工作流可能因权限不足而无法读取构建产物（Artifacts）的问题，确保发布流程能够正确执行。

<!-- sakura-ai-summary-end -->