### PR TITLE
fix(ci): set repository for updater release upload

### DIFF
--- a/.github/workflows/updater-build.yml
+++ b/.github/workflows/updater-build.yml
@@ -130,6 +130,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -127,6 +127,9 @@ def test_publish_is_single_writer_and_uploads_only_two_binaries_and_checksum():
     assert publish["runs-on"] == "ubuntu-24.04"
     assert publish["permissions"]["contents"] == "write"
 
+    publish_step = publish["steps"][_step_index(publish, "Verify assets")]
+    assert publish_step["env"]["GH_REPO"] == "${{ github.repository }}"
+
     download_steps = [
         step
         for step in publish["steps"]


### PR DESCRIPTION
## Summary

- provide `GH_REPO` to the updater Release upload step, which intentionally runs without a repository checkout
- keep the existing artifact verification and single-writer upload design unchanged
- add a regression assertion for the explicit GitHub repository context

## Root cause

The updater build jobs and both artifact downloads succeeded, but the publish job runs without `actions/checkout`. When `gh release view v3.0.0` ran from `release-assets/final`, GitHub CLI tried to infer the repository from `.git` and failed with:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Setting `GH_REPO` lets both `gh release view` and `gh release upload` target the current GitHub repository without adding an unnecessary checkout.

Failed job: https://github.com/Sakura520222/Sakura-AI/actions/runs/31462448393/job/93689241032

## Validation

- `.venv/Scripts/python.exe -m pytest tests/test_release_workflows.py -q` (`6 passed`)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/updater-build.yml .github/workflows/release-on-pr-merge.yml .github/workflows/docker-publish.yml`
- parsed the related workflows and asserted the no-checkout publish job has `GH_REPO` and `GH_TOKEN`
- `python run_ruff.py --check`
- `git diff --check`

## Impact

- release workflow context only
- no application, database, API, configuration, updater binary, or packaged-content changes
- merging to `main` triggers a new release run that can upload both updater binaries and `SHA256SUMS`, then publish `update-manifest.json` after the stable image succeeds
- rerunning the old failed SHA would still use the workflow without `GH_REPO`

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本次 PR 是一个 CI 流程的修复，主要解决了 `updater` 组件在发布时，上传构建产物至 GitHub Release 时未指定目标仓库的问题。

**主要改动列表**
1.  **`.github/workflows/updater-build.yml`**: 在 `actions/upload-release-asset` 步骤中，增加了 `repository` 参数的显式设置，确保上传操作指向正确的代码仓库。
2.  **`tests/test_release_workflows.py`**: 新增了测试用例，用于验证上述工作流修改后，`repository` 参数能被正确传递和生效。

**影响范围**
*   **直接影响**：`updater` 组件的 CI/CD 构建与发布流程。
*   **修复效果**：确保了构建产物能够准确上传到预定的 GitHub Release 中，提升了发布流程的可靠性。
*   **间接影响**：无业务逻辑变更，不影响运行时功能。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_release_workflows.py"]
```

<!-- sakura-ai-depgraph-end -->