### PR TITLE
docs: 更新部署文档，添加 Host Updater 支持和使用说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,18 +153,19 @@
 
 ### Docker 一键部署（推荐自建）
 
-**全量部署**（拉起 Web + MySQL + Redis）：
+**Linux 全量部署**（Web + MySQL + Redis + Host Updater）：
 
 ```bash
 mkdir sakura-ai && cd sakura-ai
-mkdir -p docker .deploy
+mkdir -p docker
 curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
   -o docker/docker-compose.prod.yml
-umask 077
-printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest\nSAKURA_DB_PASSWORD=%s\n' \
-  "$(openssl rand -hex 32)" > .deploy/deployment.env
-docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
+chmod +x start.sh
+sudo ./start.sh --prod
 ```
+
+该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 
@@ -175,6 +176,8 @@ docker run -d -p 8000:8000 \
   -v $(pwd)/config:/app/config \
   ghcr.io/sakura520222/sakura-ai:latest
 ```
+
+此方式不包含 Host Updater，只提供版本检查，不支持在 WebUI 中执行更新。
 
 首次启动后访问 `http://localhost:8000/setup`，按 Setup Wizard 完成配置。
 

--- a/README.md
+++ b/README.md
@@ -156,16 +156,20 @@
 **Linux 全量部署**（Web + MySQL + Redis + Host Updater）：
 
 ```bash
-mkdir sakura-ai && cd sakura-ai
-mkdir -p docker
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
-  -o docker/docker-compose.prod.yml
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
-chmod +x start.sh
+sudo install -d -o root -g root -m 0755 /opt/sakura-ai/docker
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
+  --output /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh \
+  --output /opt/sakura-ai/start.sh
+sudo chmod 0644 /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo chmod 0755 /opt/sakura-ai/start.sh
+cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
+`/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 
@@ -190,7 +194,7 @@ pip install -r requirements.txt
 python -m backend.main
 ```
 
-> 部署细节（镜像 Tag、固定版本、GitHub App 创建、数据库准备、Setup Wizard 全流程、Host Updater 自动更新守护进程、升级与密码轮换）详见 [部署指南](docs/DEPLOYMENT.md)。
+> 部署细节（镜像 Tag、固定版本、GitHub App 创建、数据库准备、Setup Wizard 全流程、Host Updater 守护进程、升级与密码轮换）详见 [部署指南](docs/DEPLOYMENT.md)。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -156,16 +156,20 @@ Visit [https://ai.firefly520.top/](https://ai.firefly520.top/) — register for 
 **Linux full deployment** (Web + MySQL + Redis + Host Updater):
 
 ```bash
-mkdir sakura-ai && cd sakura-ai
-mkdir -p docker
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
-  -o docker/docker-compose.prod.yml
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
-chmod +x start.sh
+sudo install -d -o root -g root -m 0755 /opt/sakura-ai/docker
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
+  --output /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh \
+  --output /opt/sakura-ai/start.sh
+sudo chmod 0644 /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo chmod 0755 /opt/sakura-ai/start.sh
+cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
+`/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
 
 **Web image only** (bring your own MySQL/Redis):
 
@@ -190,7 +194,7 @@ pip install -r requirements.txt
 python -m backend.main
 ```
 
-> Deployment details (image tags, pinned versions, GitHub App creation, database setup, full Setup Wizard flow, Host Updater auto-update daemon, upgrade and password rotation) are in the [Deployment Guide](docs/DEPLOYMENT.md) (Chinese).
+> Deployment details (image tags, pinned versions, GitHub App creation, database setup, full Setup Wizard flow, Host Updater daemon, upgrade and password rotation) are in the [Deployment Guide](docs/DEPLOYMENT.md) (Chinese).
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -153,18 +153,19 @@ Visit [https://ai.firefly520.top/](https://ai.firefly520.top/) — register for 
 
 ### Docker One-Click Deployment (Recommended for Self-hosting)
 
-**Full deployment** (spins up Web + MySQL + Redis):
+**Linux full deployment** (Web + MySQL + Redis + Host Updater):
 
 ```bash
 mkdir sakura-ai && cd sakura-ai
-mkdir -p docker .deploy
+mkdir -p docker
 curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
   -o docker/docker-compose.prod.yml
-umask 077
-printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest\nSAKURA_DB_PASSWORD=%s\n' \
-  "$(openssl rand -hex 32)" > .deploy/deployment.env
-docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
+chmod +x start.sh
+sudo ./start.sh --prod
 ```
+
+This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
 
 **Web image only** (bring your own MySQL/Redis):
 
@@ -175,6 +176,8 @@ docker run -d -p 8000:8000 \
   -v $(pwd)/config:/app/config \
   ghcr.io/sakura520222/sakura-ai:latest
 ```
+
+This mode does not include the Host Updater. It can report available releases, but it cannot apply an update from the WebUI.
 
 After first start, visit `http://localhost:8000/setup` and complete configuration via the Setup Wizard.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,12 +8,13 @@
 
 ## 部署方式概览
 
-| 方式 | 适用场景 | 是否需要源码 | 说明 |
-|---|---|---|---|
-| 官方在线服务 | 快速体验 | 否 | [https://ai.firefly520.top/](https://ai.firefly520.top/) 注册即用 |
-| Docker 全量部署 | 生产自建（推荐） | 否 | 一条命令拉起 Web + MySQL + Redis |
-| Docker 仅 Web 镜像 | 已有 MySQL/Redis | 否 | 仅启动 Web 容器，连接外部存储 |
-| 源码部署 / 开发 | 二次开发、自定义构建 | 是 | 克隆仓库本地运行 |
+| 方式 | 适用场景 | 是否需要源码 | WebUI 手动更新 | 说明 |
+|---|---|---|---|---|
+| 官方在线服务 | 快速体验 | 否 | 由平台管理 | [https://ai.firefly520.top/](https://ai.firefly520.top/) 注册即用 |
+| Linux Docker 全量部署 | 生产自建（推荐） | 否 | 支持 | 拉起 Web + MySQL + Redis，并安装 Host Updater |
+| macOS / Windows Compose 部署 | 容器化自建 | 否 | 不支持 | 可检查新版本，更新时需手动拉取并重建容器 |
+| Docker 仅 Web 镜像 | 已有 MySQL/Redis | 否 | 不支持 | 仅启动 Web 容器，连接外部存储 |
+| 源码部署 / 开发 | 二次开发、自定义构建 | 是 | 不支持 | 克隆仓库本地运行 |
 
 > 所有配置（GitHub App、AI 模型、数据库等）通过首次启动后的 Setup Wizard 在 Web 界面完成，无需手动编辑配置文件。
 
@@ -23,7 +24,21 @@
 
 ### 1.1 全量部署（MySQL + Redis 一并拉起）
 
-**Linux / macOS**：
+**Linux（包含 Host Updater，推荐）**：
+
+```bash
+mkdir sakura-ai && cd sakura-ai
+mkdir -p docker
+curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
+  -o docker/docker-compose.prod.yml
+curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
+chmod +x start.sh
+sudo ./start.sh --prod
+```
+
+`start.sh --prod` 会生成权限为 `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
+
+**macOS（仅容器，不包含 Host Updater）**：
 
 ```bash
 mkdir sakura-ai && cd sakura-ai
@@ -51,6 +66,8 @@ $dbPassword = [Convert]::ToHexString($bytes).ToLowerInvariant()
   Set-Content -Encoding ascii .deploy/deployment.env
 docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
 ```
+
+macOS、Windows 和其他仅容器部署可以自动显示新版本，但不能从 WebUI 执行更新；请手动拉取目标镜像并重新运行 Compose。Host Updater 当前仅支持 Linux `amd64`/`arm64` 宿主机。
 
 首次启动后访问 `http://localhost:8000/setup`：数据库/Redis 连接串已自动预填，点击"测试连接"通过后即可继续 Setup Wizard（其余步骤与源码部署一致）。
 
@@ -260,7 +277,9 @@ WebUI：`https://your-domain.com/`
 
 ## 八、Host Updater 守护进程（自动更新）
 
-Host updater 是一个独立守护进程，负责管理 Sakura AI 镜像的自动更新（自动更新功能目前逐步上线中，P0 阶段先铺基础）。
+Host updater 是一个独立的 Linux 宿主守护进程。Backend 会定期检查新 Release；超级管理员在 WebUI 版本管理器中确认更新后，Host Updater 执行预检、拉取镜像、原子更新部署状态、重建容器并校验新版本健康状态。它不会无人值守安装更新。
+
+通过本指南推荐的 `sudo ./start.sh --prod` 首次部署时，updater 会随应用自动完成安装和启动，无需再单独执行下面的管理命令。
 
 ### 管理命令
 
@@ -283,11 +302,24 @@ sudo ./start.sh updater start     # 启动守护进程
 
 安装严格绑定当前部署的 Sakura AI 版本，不下载 `latest` updater。版本解析是 **deployment-mode-aware** 的：
 
-- `SAKURA_DEPLOY_MODE=image`：优先使用 `deployment.env` 中 `SAKURA_AI_IMAGE=:vX.Y.Z`（可带 digest）的镜像版本作为权威来源；镜像为 `:latest` 或无具体 tag 时，回退到 `backend/__init__.py` 的 `__version__`。镜像部署时 host checkout 版本与实际运行版本可能不同，镜像版本始终权威。
+- `SAKURA_DEPLOY_MODE=image`：优先使用 `deployment.env` 中 `SAKURA_AI_IMAGE=:vX.Y.Z`（可带 digest）的镜像版本作为权威来源；镜像为 `:latest` 或无具体 tag 时，读取已健康运行服务的 `/health` 版本；服务尚未就绪时才回退到 `backend/__init__.py` 的 `__version__`。镜像部署时实际运行版本始终优先于 host checkout 版本。
 - `SAKURA_DEPLOY_MODE=source`：以 `backend/__init__.py` 的 `__version__ = "X.Y.Z"` 为权威来源。
 - `deployment.env` 缺失或 `SAKURA_DEPLOY_MODE` 不是 `image`/`source` 时 fail-closed，不猜测版本。
 
-`:latest` 不是具体版本。两者都无法确定具体版本时 fail-closed。仅支持 Linux `amd64` 与 `arm64`，其他操作系统或架构会明确失败。
+`:latest` 不是具体版本。以上来源都无法确定具体版本时 fail-closed。仅支持 Linux `amd64` 与 `arm64`，其他操作系统或架构会明确失败。
+
+### 现有 Curl + Compose 部署启用 WebUI 更新
+
+如果之前按旧 README 只下载了 `docker-compose.prod.yml`，可在原部署目录补充 `start.sh`，保留原 `.deploy/deployment.env` 和所有 Compose volumes：
+
+```bash
+curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
+chmod +x start.sh
+sudo ./start.sh updater install
+sudo ./start.sh updater start
+```
+
+当 `SAKURA_AI_IMAGE=:latest` 时，执行 `install` 前 Web 容器必须已健康运行，以便从 `/health` 取得实际版本并下载严格匹配的 updater。完成后刷新 WebUI 版本管理器，应显示 updater 已连接并允许超级管理员执行预检和更新。
 
 **state directory 与 binary 校验**：state directory 首次创建为 root-owned `0700`。如果目录已存在（如从旧版升级），只要 owner 为 root 且 group/other 无写权限就会自动 harden 到 `0700`；owner 非 root、group/other 可写或目录是 symlink 时 fail-closed。binary 和 `SHA256SUMS` 从对应 GitHub Release 通过 HTTPS 获取，并严格校验目标 binary 的 SHA256 条目。binary 为 root-owned `0700`；install lock 防止并发 acquisition；下载临时文件位于同一 state directory，校验、临时文件 fsync 和安全检查通过后以同文件系统 atomic rename 替换最终 binary。
 
@@ -314,8 +346,8 @@ SAKURA_UPDATER_DEV=1 SAKURA_UPDATER_PYTHON=/path/to/python ./start.sh updater st
 ### 安全边界
 
 - Web 容器通过只读挂载 `/run/sakura-ai` 目录（Unix Domain Socket）与 updater 通信，**不挂载 `docker.sock`**
-- updater 不依赖 systemd 或 cron 自启；每次通过 `start.sh` 时会调用 `ensure_updater_running` 兜底恢复
+- updater 不依赖 systemd 或 cron 自启；宿主机重启后请运行 `sudo ./start.sh updater start`，或再次执行 `sudo ./start.sh --prod` 兜底恢复。这只恢复更新服务，不会自动安装应用更新
 
 ---
 
-*最后更新：2026-8-10 · 发现错误？[提 Issue](https://github.com/Sakura520222/Sakura-AI/issues)*
+*最后更新：2026-8-11 · 发现错误？[提 Issue](https://github.com/Sakura520222/Sakura-AI/issues)*

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # 部署指南
 
-> Sakura AI 完整部署流程：Docker 镜像、源码部署、GitHub App、数据库、Setup Wizard 与 Host Updater 自动更新守护进程。
+> Sakura AI 完整部署流程：Docker 镜像、源码部署、GitHub App、数据库、Setup Wizard 与 Host Updater 守护进程。
 
 ← [文档索引](README.md) · [README](../README.md)
 
@@ -27,16 +27,20 @@
 **Linux（包含 Host Updater，推荐）**：
 
 ```bash
-mkdir sakura-ai && cd sakura-ai
-mkdir -p docker
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
-  -o docker/docker-compose.prod.yml
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
-chmod +x start.sh
+sudo install -d -o root -g root -m 0755 /opt/sakura-ai/docker
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
+  --output /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo curl --fail --location \
+  https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh \
+  --output /opt/sakura-ai/start.sh
+sudo chmod 0644 /opt/sakura-ai/docker/docker-compose.prod.yml
+sudo chmod 0755 /opt/sakura-ai/start.sh
+cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`start.sh --prod` 会生成权限为 `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
+推荐路径固定为 root 管理的 `/opt/sakura-ai`。`start.sh --prod` 会生成 root-owned `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。生产 daemon 启动前还会验证 binary、Compose、`deployment.env` 及其完整父目录链均由 root 控制且不可由 group/other 写入；校验失败时拒绝启动更新能力。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
 
 **macOS（仅容器，不包含 Host Updater）**：
 
@@ -275,7 +279,7 @@ WebUI：`https://your-domain.com/`
 
 ---
 
-## 八、Host Updater 守护进程（自动更新）
+## 八、Host Updater 守护进程
 
 Host updater 是一个独立的 Linux 宿主守护进程。Backend 会定期检查新 Release；超级管理员在 WebUI 版本管理器中确认更新后，Host Updater 执行预检、拉取镜像、原子更新部署状态、重建容器并校验新版本健康状态。它不会无人值守安装更新。
 
@@ -308,20 +312,7 @@ sudo ./start.sh updater start     # 启动守护进程
 
 `:latest` 不是具体版本。以上来源都无法确定具体版本时 fail-closed。仅支持 Linux `amd64` 与 `arm64`，其他操作系统或架构会明确失败。
 
-### 现有 Curl + Compose 部署启用 WebUI 更新
-
-如果之前按旧 README 只下载了 `docker-compose.prod.yml`，可在原部署目录补充 `start.sh`，保留原 `.deploy/deployment.env` 和所有 Compose volumes：
-
-```bash
-curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh -o start.sh
-chmod +x start.sh
-sudo ./start.sh updater install
-sudo ./start.sh updater start
-```
-
-当 `SAKURA_AI_IMAGE=:latest` 时，执行 `install` 前 Web 容器必须已健康运行，以便从 `/health` 取得实际版本并下载严格匹配的 updater。完成后刷新 WebUI 版本管理器，应显示 updater 已连接并允许超级管理员执行预检和更新。
-
-**state directory 与 binary 校验**：state directory 首次创建为 root-owned `0700`。如果目录已存在（如从旧版升级），只要 owner 为 root 且 group/other 无写权限就会自动 harden 到 `0700`；owner 非 root、group/other 可写或目录是 symlink 时 fail-closed。binary 和 `SHA256SUMS` 从对应 GitHub Release 通过 HTTPS 获取，并严格校验目标 binary 的 SHA256 条目。binary 为 root-owned `0700`；install lock 防止并发 acquisition；下载临时文件位于同一 state directory，校验、临时文件 fsync 和安全检查通过后以同文件系统 atomic rename 替换最终 binary。
+**state directory 与 binary 校验**：state directory 首次创建为 root-owned `0700`。重复执行安装时，只要现有目录 owner 为 root 且 group/other 无写权限就会自动 harden 到 `0700`；owner 非 root、group/other 可写或目录是 symlink 时 fail-closed。binary 和 `SHA256SUMS` 从对应 GitHub Release 通过 HTTPS 获取，并严格校验目标 binary 的 SHA256 条目。binary 为 root-owned `0700`；install lock 防止并发 acquisition；下载临时文件位于同一 state directory，校验、临时文件 fsync 和安全检查通过后以同文件系统 atomic rename 替换最终 binary。
 
 **安装失败保护**（两个阶段）：
 
@@ -346,7 +337,8 @@ SAKURA_UPDATER_DEV=1 SAKURA_UPDATER_PYTHON=/path/to/python ./start.sh updater st
 ### 安全边界
 
 - Web 容器通过只读挂载 `/run/sakura-ai` 目录（Unix Domain Socket）与 updater 通信，**不挂载 `docker.sock`**
-- updater 不依赖 systemd 或 cron 自启；宿主机重启后请运行 `sudo ./start.sh updater start`，或再次执行 `sudo ./start.sh --prod` 兜底恢复。这只恢复更新服务，不会自动安装应用更新
+- 生产部署必须位于 root-owned、group/other 不可写的目录链中；推荐固定使用 `/opt/sakura-ai`。updater 启动时会对 binary、Compose 和 `deployment.env` 逐级 `lstat` 并 fail-closed，拒绝 symlink、非 root owner、共享写权限或非 `0600` 的部署状态
+- updater 不依赖 systemd 或 cron 自启；宿主机重启后，在 `/opt/sakura-ai` 运行 `sudo ./start.sh updater start`，或再次执行 `sudo ./start.sh --prod`。`start` 会重新创建 tmpfs 中消失的 `/run/sakura-ai` 后再拉起 daemon；这只恢复更新服务，不会自动安装应用更新
 
 ---
 

--- a/start.sh
+++ b/start.sh
@@ -189,6 +189,7 @@ UPDATER_SOCKET_PATH="/run/sakura-ai/updater.sock"
 UPDATER_DEPLOYMENT_ENV_FILE="${UPDATER_DEPLOYMENT_ENV_FILE:-$DEPLOYMENT_ENV_FILE}"
 UPDATER_BACKEND_VERSION_FILE="${UPDATER_BACKEND_VERSION_FILE:-backend/__init__.py}"
 UPDATER_RELEASE_BASE_URL="https://github.com/Sakura520222/Sakura-AI/releases/download"
+UPDATER_HEALTH_URL="${UPDATER_HEALTH_URL:-http://localhost:8000/health}"
 
 # 依据持久化部署模式选择 updater 使用的 Compose 定义。
 #
@@ -261,6 +262,27 @@ updater_curl() {
     fi
     http_status=${http_status//$'\r'/}
     [[ "$http_status" =~ ^2[0-9][0-9]$ ]]
+}
+
+# Read the already-running image version without requiring a source checkout.
+# 读取已运行镜像的实际版本，使最小 Curl + Compose 部署无需源码版本文件。
+updater_health_payload() {
+    curl --fail --silent --show-error \
+        --connect-timeout 2 --max-time 5 \
+        --header 'Accept: application/json' \
+        "$UPDATER_HEALTH_URL"
+}
+
+resolve_running_image_version() {
+    local payload
+    if ! payload=$(updater_health_payload); then
+        return 1
+    fi
+    if [[ "$payload" =~ \"version\"[[:space:]]*:[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\" ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
 }
 
 updater_sha256() {
@@ -457,7 +479,7 @@ updater_prepare_state_dir() {
 }
 
 resolve_updater_app_version() {
-    local deploy_mode="" image_version="" package_version="" line image version
+    local deploy_mode="" image_version="" running_version="" package_version="" line image version
 
     if [[ -f "$UPDATER_DEPLOYMENT_ENV_FILE" ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
@@ -478,6 +500,8 @@ resolve_updater_app_version() {
         image)
             if [[ -n "$image_version" ]]; then
                 version="$image_version"
+            elif running_version=$(resolve_running_image_version); then
+                version="$running_version"
             fi
             ;;
         source) ;;

--- a/start.sh
+++ b/start.sh
@@ -870,12 +870,7 @@ cmd_updater() {
             cmd_updater_install "$@"
             ;;
         start)
-            select_compose_from_deployment_mode
-            updater_backend start \
-                --state-dir "$UPDATER_STATE_DIR" \
-                --socket-path "$UPDATER_SOCKET_PATH" \
-                --compose-file "$COMPOSE_FILE" \
-                --deployment-env "$UPDATER_DEPLOYMENT_ENV_FILE" "$@"
+            ensure_updater_running "$@"
             ;;
         stop|status|is-running)
             updater_backend "$action" \

--- a/tests/test_deployment_documentation.py
+++ b/tests/test_deployment_documentation.py
@@ -10,16 +10,19 @@ def test_recommended_readme_deployment_bootstraps_host_updater() -> None:
     readme_en = (ROOT / "README_EN.md").read_text(encoding="utf-8")
 
     for text in (readme_zh, readme_en):
+        assert "/opt/sakura-ai" in text
+        assert "sudo install -d -o root -g root -m 0755" in text
         assert "docker/docker-compose.prod.yml" in text
         assert "raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh" in text
         assert "sudo ./start.sh --prod" in text
 
 
-def test_deployment_guide_documents_manual_update_and_existing_install_upgrade() -> None:
+def test_deployment_guide_documents_manual_update_and_trusted_root_path() -> None:
     guide = (ROOT / "docs" / "DEPLOYMENT.md").read_text(encoding="utf-8")
 
     assert "它不会无人值守安装更新" in guide
-    assert "现有 Curl + Compose 部署启用 WebUI 更新" in guide
-    assert "sudo ./start.sh updater install" in guide
+    assert "现有 Curl + Compose 部署启用 WebUI 更新" not in guide
+    assert "root-owned、group/other 不可写的目录链" in guide
+    assert "逐级 `lstat` 并 fail-closed" in guide
     assert "sudo ./start.sh updater start" in guide
     assert "Host Updater 当前仅支持 Linux `amd64`/`arm64` 宿主机" in guide

--- a/tests/test_deployment_documentation.py
+++ b/tests/test_deployment_documentation.py
@@ -1,0 +1,25 @@
+"""Deployment documentation contracts for the Host Updater bootstrap path."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_recommended_readme_deployment_bootstraps_host_updater() -> None:
+    readme_zh = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_en = (ROOT / "README_EN.md").read_text(encoding="utf-8")
+
+    for text in (readme_zh, readme_en):
+        assert "docker/docker-compose.prod.yml" in text
+        assert "raw.githubusercontent.com/Sakura520222/Sakura-AI/main/start.sh" in text
+        assert "sudo ./start.sh --prod" in text
+
+
+def test_deployment_guide_documents_manual_update_and_existing_install_upgrade() -> None:
+    guide = (ROOT / "docs" / "DEPLOYMENT.md").read_text(encoding="utf-8")
+
+    assert "它不会无人值守安装更新" in guide
+    assert "现有 Curl + Compose 部署启用 WebUI 更新" in guide
+    assert "sudo ./start.sh updater install" in guide
+    assert "sudo ./start.sh updater start" in guide
+    assert "Host Updater 当前仅支持 Linux `amd64`/`arm64` 宿主机" in guide

--- a/tests/test_start_sh_updater.sh
+++ b/tests/test_start_sh_updater.sh
@@ -51,6 +51,7 @@ updater_binary_mode() {
 }
 updater_directory_owner_uid() { printf '%s\n' "$FAKE_STATE_OWNER"; }
 updater_directory_mode() { printf '%s\n' "$FAKE_STATE_MODE"; }
+updater_chown() { :; }
 updater_binary_is_safe() {
     local binary="$1" owner mode
     [[ -f "$binary" && ! -L "$binary" ]] || return 1
@@ -389,6 +390,7 @@ __version__ = "3.0.0"
 EOF
 updater_uname_s() { printf '%s\n' Linux; }
 updater_uname_m() { printf '%s\n' x86_64; }
+updater_health_payload() { return 1; }
 cat > "$UPDATER_DEPLOYMENT_ENV_FILE" <<EOF
 SAKURA_DEPLOY_MODE=image
 SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:v3.1.0@sha256:$(printf '%064d' 0)
@@ -402,6 +404,13 @@ SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest
 EOF
 [ "$(resolve_updater_app_version)" = "3.0.0" ] \
     && report 0 "V3: image latest falls back to package version" || report 1 "V3"
+updater_health_payload() { printf '%s\n' '{"status":"healthy","version":"3.2.0"}'; }
+[ "$(resolve_updater_app_version)" = "3.2.0" ] \
+    && report 0 "V3b: running image version is authoritative for latest" || report 1 "V3b"
+updater_health_payload() { printf '%s\n' '{"status":"healthy","version":"latest"}'; }
+[ "$(resolve_updater_app_version)" = "3.0.0" ] \
+    && report 0 "V3c: malformed health version falls back to package" || report 1 "V3c"
+updater_health_payload() { return 1; }
 rm -f "$UPDATER_BACKEND_VERSION_FILE"
 cat > "$UPDATER_DEPLOYMENT_ENV_FILE" <<'EOF'
 SAKURA_DEPLOY_MODE=image

--- a/tests/test_start_sh_updater.sh
+++ b/tests/test_start_sh_updater.sh
@@ -692,6 +692,13 @@ updater_backend() { echo "BACKEND:$@" >> "$FAKE_LOG"; }
 cmd_updater status --extra-opt 2>/dev/null
 grep -q "BACKEND:status" "$FAKE_LOG" && report 0 "S7: cmd_updater 透传 action" || report 1 "S7"
 
+# S8: start 必须复用 ensure 路径，在 /run 被重启清空后重新执行 install bootstrap。
+ensure_updater_running() { echo "ENSURE:$*" >> "$FAKE_LOG"; }
+: > "$FAKE_LOG"
+cmd_updater start --extra-opt 2>/dev/null
+grep -q "ENSURE:--extra-opt" "$FAKE_LOG" \
+    && report 0 "S8: cmd_updater start 复用 bootstrap ensure" || report 1 "S8"
+
 # --- missing failure matrix: real lock contention ---
 run_real_flock_busy_case() {
     local case_dir="$TMPDIR/real-flock-busy"

--- a/updater/src/sakura_ai_updater/__main__.py
+++ b/updater/src/sakura_ai_updater/__main__.py
@@ -25,6 +25,7 @@ from sakura_ai_updater.backends.daemon import (
     DEFAULT_STARTUP_TIMEOUT,
     GIDConflictError,
     PrivilegeError,
+    UnsafeDeploymentPathError,
     UpdaterNotInstalledError,
     UpdaterStartError,
 )
@@ -45,6 +46,7 @@ _BACKEND_ERRORS = (
     UpdaterStartError,
     GIDConflictError,
     PrivilegeError,
+    UnsafeDeploymentPathError,
 )
 
 

--- a/updater/src/sakura_ai_updater/backends/daemon.py
+++ b/updater/src/sakura_ai_updater/backends/daemon.py
@@ -80,6 +80,10 @@ class PrivilegeError(RuntimeError):
     """权限不足（生产 install/start 必须 root）。"""
 
 
+class UnsafeDeploymentPathError(RuntimeError):
+    """生产 updater 的可执行文件或部署输入不在受信任的 root 路径中。"""
+
+
 def _read_proc_cmdline(pid: int) -> tuple[str, ...]:
     """读取 ``/proc/<pid>/cmdline``（NUL-separated argv）。
 
@@ -319,6 +323,84 @@ class DaemonBackend:
         if geteuid() != 0:
             raise PrivilegeError(f"{action} requires root privileges; run as root or sudo")
 
+    @staticmethod
+    def _trusted_file(path: str, label: str, *, exact_mode: int | None = None) -> str:
+        """验证 root daemon 将读取或执行的文件及其完整目录链。
+
+        ``lstat`` 检查每一级以拒绝 symlink。文件必须 root-owned，且 group/other
+        不可写；敏感部署状态还可要求精确 mode。所有父目录直到文件系统根都必须
+        root-owned 且 group/other 不可写，避免普通用户通过 rename/replace 在校验后
+        替换 Compose、deployment.env 或 updater binary。
+        """
+
+        absolute = os.path.abspath(path)
+        try:
+            file_stat = os.lstat(absolute)
+        except OSError as exc:
+            raise UnsafeDeploymentPathError(
+                f"unsafe {label}: cannot lstat {absolute!r}: {exc}"
+            ) from exc
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise UnsafeDeploymentPathError(
+                f"unsafe {label}: {absolute!r} must be a regular file, not a symlink"
+            )
+        if file_stat.st_uid != 0:
+            raise UnsafeDeploymentPathError(
+                f"unsafe {label}: {absolute!r} must be owned by root"
+            )
+        mode = stat.S_IMODE(file_stat.st_mode)
+        if mode & 0o022:
+            raise UnsafeDeploymentPathError(
+                f"unsafe {label}: {absolute!r} must not be group/other writable"
+            )
+        if exact_mode is not None and mode != exact_mode:
+            raise UnsafeDeploymentPathError(
+                f"unsafe {label}: {absolute!r} must have mode {exact_mode:04o}"
+            )
+
+        directory = os.path.dirname(absolute)
+        while True:
+            try:
+                directory_stat = os.lstat(directory)
+            except OSError as exc:
+                raise UnsafeDeploymentPathError(
+                    f"unsafe {label} parent: cannot lstat {directory!r}: {exc}"
+                ) from exc
+            if not stat.S_ISDIR(directory_stat.st_mode):
+                raise UnsafeDeploymentPathError(
+                    f"unsafe {label} parent: {directory!r} must be a directory, not a symlink"
+                )
+            if directory_stat.st_uid != 0:
+                raise UnsafeDeploymentPathError(
+                    f"unsafe {label} parent: {directory!r} must be owned by root"
+                )
+            if stat.S_IMODE(directory_stat.st_mode) & 0o022:
+                raise UnsafeDeploymentPathError(
+                    f"unsafe {label} parent: {directory!r} must not be group/other writable"
+                )
+            parent = os.path.dirname(directory)
+            if parent == directory:
+                break
+            directory = parent
+        return absolute
+
+    def _validate_production_paths(self) -> None:
+        """生产启动前冻结为已验证的绝对路径；开发模式不会调用。"""
+
+        self.binary_path = self._trusted_file(self.binary_path, "updater binary")
+        if self.compose_file is None and self.deployment_env is None:
+            return
+        if self.compose_file is None or self.deployment_env is None:
+            raise UnsafeDeploymentPathError(
+                "compose_file and deployment_env must be configured together"
+            )
+        self.compose_file = self._trusted_file(self.compose_file, "Compose file")
+        self.deployment_env = self._trusted_file(
+            self.deployment_env,
+            "deployment.env",
+            exact_mode=0o600,
+        )
+
     # ------------------------------------------------------------- bootstrap
 
     def ensure_group(self) -> None:
@@ -494,9 +576,11 @@ class DaemonBackend:
         if self.is_running():
             return
         argv_exe, identity = self._resolve_executable()
-        argv = argv_exe + self._serve_args()
         if identity == IDENTITY_BINARY:
             self._require_root("start")
+            self._validate_production_paths()
+            argv_exe = [self.binary_path]
+        argv = argv_exe + self._serve_args()
         os.makedirs(self.state_dir, exist_ok=True)
         log_path = self._log_path
         with open(log_path, "ab") as logf:

--- a/updater/tests/test_daemon_backend.py
+++ b/updater/tests/test_daemon_backend.py
@@ -30,6 +30,7 @@ from sakura_ai_updater.backends.daemon import (
     DaemonBackend,
     GIDConflictError,
     PrivilegeError,
+    UnsafeDeploymentPathError,
     UpdaterNotInstalledError,
     UpdaterStartError,
     _is_same_process,
@@ -141,7 +142,10 @@ def _patch_root_owned_lstat(monkeypatch):
 
     def fake_lstat(path):
         result = real_lstat(path)
-        mode = result.st_mode if result.st_mode & 0o111 else stat.S_IFREG | 0o700
+        if stat.S_ISDIR(result.st_mode):
+            mode = stat.S_IFDIR | 0o755
+        else:
+            mode = stat.S_IFREG | 0o700
         return SimpleNamespace(st_mode=mode, st_uid=0)
 
     monkeypatch.setattr(daemon_mod.os, "lstat", fake_lstat)
@@ -157,6 +161,34 @@ def _patch_target_owned_lstat(monkeypatch, target: Path, uid: int):
             return result
         mode = result.st_mode if result.st_mode & 0o111 else stat.S_IFREG | 0o700
         return SimpleNamespace(st_mode=mode, st_uid=uid)
+
+    monkeypatch.setattr(daemon_mod.os, "lstat", fake_lstat)
+
+
+def _patch_trusted_path_tree(
+    monkeypatch,
+    *,
+    file_modes: dict[Path, int],
+    overrides: dict[Path, tuple[int, int]] | None = None,
+):
+    """把临时目录映射为 Linux root-owned 安全路径，可精确注入不安全 inode。"""
+
+    real_lstat = daemon_mod.os.lstat
+    normalized_modes = {os.path.abspath(path): mode for path, mode in file_modes.items()}
+    normalized_overrides = {
+        os.path.abspath(path): value for path, value in (overrides or {}).items()
+    }
+
+    def fake_lstat(path):
+        absolute = os.path.abspath(path)
+        if absolute in normalized_overrides:
+            mode, uid = normalized_overrides[absolute]
+            return SimpleNamespace(st_mode=mode, st_uid=uid)
+        result = real_lstat(path)
+        if stat.S_ISDIR(result.st_mode):
+            return SimpleNamespace(st_mode=stat.S_IFDIR | 0o755, st_uid=0)
+        mode = normalized_modes.get(absolute, 0o700)
+        return SimpleNamespace(st_mode=stat.S_IFREG | mode, st_uid=0)
 
     monkeypatch.setattr(daemon_mod.os, "lstat", fake_lstat)
 
@@ -186,6 +218,7 @@ def test_module_exports_error_types():
     assert issubclass(UpdaterStartError, RuntimeError)
     assert issubclass(GIDConflictError, RuntimeError)
     assert issubclass(PrivilegeError, RuntimeError)
+    assert issubclass(UnsafeDeploymentPathError, RuntimeError)
 
 
 # =============================================================================
@@ -557,6 +590,87 @@ def test_start_allows_root_for_production_binary(tmp_path, monkeypatch):
     backend.start()
     data = json.loads(Path(backend._pid_meta_path).read_text(encoding="utf-8"))
     assert data == {"pid": 4242, "starttime": "555666", "identity": "sakura-ai-updater"}
+
+
+def _production_paths(tmp_path: Path) -> tuple[Path, Path, Path, DaemonBackend]:
+    binary = tmp_path / ".deploy" / "updater" / "sakura-ai-updater"
+    compose = tmp_path / "docker" / "docker-compose.prod.yml"
+    deployment_env = tmp_path / ".deploy" / "deployment.env"
+    for path in (binary, compose, deployment_env):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("test\n", encoding="utf-8")
+    backend = _make_backend(
+        tmp_path,
+        binary_path=str(binary),
+        compose_file=str(compose),
+        deployment_env=str(deployment_env),
+    )
+    return binary, compose, deployment_env, backend
+
+
+def test_validate_production_paths_accepts_trusted_root_tree(tmp_path, monkeypatch):
+    binary, compose, deployment_env, backend = _production_paths(tmp_path)
+    _patch_trusted_path_tree(
+        monkeypatch,
+        file_modes={binary: 0o700, compose: 0o644, deployment_env: 0o600},
+    )
+
+    backend._validate_production_paths()
+
+    assert backend.binary_path == os.path.abspath(binary)
+    assert backend.compose_file == os.path.abspath(compose)
+    assert backend.deployment_env == os.path.abspath(deployment_env)
+
+
+@pytest.mark.parametrize(
+    ("target_name", "unsafe_mode", "unsafe_uid", "message"),
+    [
+        ("compose", stat.S_IFREG | 0o644, 1000, "owned by root"),
+        ("compose", stat.S_IFREG | 0o666, 0, "group/other writable"),
+        ("compose", stat.S_IFLNK | 0o777, 0, "regular file"),
+        ("compose_parent", stat.S_IFDIR | 0o777, 0, "parent"),
+        ("deployment_env", stat.S_IFREG | 0o644, 0, "mode 0600"),
+    ],
+)
+def test_validate_production_paths_rejects_untrusted_inputs(
+    tmp_path,
+    monkeypatch,
+    target_name,
+    unsafe_mode,
+    unsafe_uid,
+    message,
+):
+    binary, compose, deployment_env, backend = _production_paths(tmp_path)
+    targets = {
+        "compose": compose,
+        "compose_parent": compose.parent,
+        "deployment_env": deployment_env,
+    }
+    _patch_trusted_path_tree(
+        monkeypatch,
+        file_modes={binary: 0o700, compose: 0o644, deployment_env: 0o600},
+        overrides={targets[target_name]: (unsafe_mode, unsafe_uid)},
+    )
+
+    with pytest.raises(UnsafeDeploymentPathError, match=message):
+        backend._validate_production_paths()
+
+
+def test_start_dev_mode_does_not_require_trusted_production_paths(tmp_path, monkeypatch):
+    backend = _make_backend(tmp_path)
+    monkeypatch.setenv("SAKURA_UPDATER_DEV", "1")
+    monkeypatch.setattr(
+        backend,
+        "_validate_production_paths",
+        lambda: pytest.fail("dev start must not validate production deployment paths"),
+    )
+    child = FakePopen(pid=4242)
+    _patch_popen(monkeypatch, child)
+    monkeypatch.setattr(daemon_mod, "_read_proc_starttime", lambda pid: "555666")
+    monkeypatch.setattr(daemon_mod, "_is_same_process", lambda pid, st, ident: True)
+    monkeypatch.setattr(backend, "_health_ready", lambda *a: True)
+
+    backend.start()
 
 
 def test_start_fails_when_child_exits_immediately(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

## 变更概览
本次PR主要针对项目的部署文档进行了更新和完善，并补充了相应的测试用例。核心变更是为部署流程增加了 Host Updater 的支持与说明。

## 主要改动列表
1.  **文档更新**：
    *   `docs/DEPLOYMENT.md`（主部署文档）进行了大幅修订（+44/-12），新增了 Host Updater 的配置与使用说明。
    *   `README.md` 和 `README_EN.md`（项目主说明文件）同步更新了相关部署信息。
2.  **脚本调整**：
    *   `start.sh`（启动脚本）有显著修改（+25/-1），可能集成了对 Host Updater 的调用或逻辑支持。
3.  **测试补充**：
    *   新增 `tests/test_deployment_documentation.py` 测试部署文档的完整性或示例代码。
    *   新增 `tests/test_start_sh_updater.sh` 测试启动脚本中与更新器相关的功能。

## 影响范围
*   **对用户**：开发者（特别是新用户）部署项目时将获得更清晰、完整的指南，可以了解和使用新的 Host Updater 功能。
*   **对项目**：提升了部署文档的质量和项目的可维护性。新增的自动化测试有助于确保文档和脚本在未来修改中的正确性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_deployment_documentation.py"]
```

<!-- sakura-ai-depgraph-end -->