### PR TITLE
fix(deploy): isolate production Compose project

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。生产 Compose 固定使用 `sakura-ai` 项目名，持久化卷不会因配置文件位于 `docker/` 目录而落入通用的 `docker_*` 命名空间。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
+`/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。启动脚本会把固定的 `sakura-ai` Compose 项目名写入部署状态，并在每次 Compose 操作中显式传入，持久化卷不会因配置文件位于 `docker/` 目录而落入通用的 `docker_*` 命名空间。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
+`/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。生产 Compose 固定使用 `sakura-ai` 项目名，持久化卷不会因配置文件位于 `docker/` 目录而落入通用的 `docker_*` 命名空间。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -169,7 +169,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. Production Compose uses the fixed project name `sakura-ai`, so placing the file under `docker/` cannot put persistent volumes in the generic `docker_*` namespace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
+`/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. The launcher persists the fixed `sakura-ai` Compose project and passes it explicitly to every Compose operation, so placing the file under `docker/` cannot put persistent volumes in the generic `docker_*` namespace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
 
 **Web image only** (bring your own MySQL/Redis):
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -169,7 +169,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
+`/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. Production Compose uses the fixed project name `sakura-ai`, so placing the file under `docker/` cannot put persistent volumes in the generic `docker_*` namespace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
 
 **Web image only** (bring your own MySQL/Redis):
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -4,6 +4,8 @@
 # deployment.env 提交到 Git。
 # 固定镜像版本由 .deploy/deployment.env 中的 SAKURA_AI_IMAGE 指定：
 #   docker compose --env-file <deployment_env> -f docker-compose.prod.yml up -d
+name: sakura-ai
+
 services:
   web:
     image: ${SAKURA_AI_IMAGE:-ghcr.io/sakura520222/sakura-ai:latest}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -3,9 +3,7 @@
 # 原子生成并以 0600 保存）。缺失时 Compose 直接 fail-closed；不要把运行时
 # deployment.env 提交到 Git。
 # 固定镜像版本由 .deploy/deployment.env 中的 SAKURA_AI_IMAGE 指定：
-#   docker compose --env-file <deployment_env> -f docker-compose.prod.yml up -d
-name: sakura-ai
-
+#   docker compose --env-file <deployment_env> --project-name <project> -f docker-compose.prod.yml up -d
 services:
   web:
     image: ${SAKURA_AI_IMAGE:-ghcr.io/sakura520222/sakura-ai:latest}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -40,7 +40,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-推荐路径固定为 root 管理的 `/opt/sakura-ai`。`start.sh --prod` 会生成 root-owned `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。生产 daemon 启动前还会验证 binary、Compose、`deployment.env` 及其完整父目录链均由 root 控制且不可由 group/other 写入；校验失败时拒绝启动更新能力。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
+推荐路径固定为 root 管理的 `/opt/sakura-ai`。生产 Compose 显式使用 `sakura-ai` 项目名，避免配置文件所在的 `docker/` 目录把网络和持久化卷错误命名为通用的 `docker_*`。`start.sh --prod` 会生成 root-owned `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。生产 daemon 启动前还会验证 binary、Compose、`deployment.env` 及其完整父目录链均由 root 控制且不可由 group/other 写入；校验失败时拒绝启动更新能力。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
 
 **macOS（仅容器，不包含 Host Updater）**：
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -40,7 +40,7 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-推荐路径固定为 root 管理的 `/opt/sakura-ai`。生产 Compose 显式使用 `sakura-ai` 项目名，避免配置文件所在的 `docker/` 目录把网络和持久化卷错误命名为通用的 `docker_*`。`start.sh --prod` 会生成 root-owned `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。生产 daemon 启动前还会验证 binary、Compose、`deployment.env` 及其完整父目录链均由 root 控制且不可由 group/other 写入；校验失败时拒绝启动更新能力。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
+推荐路径固定为 root 管理的 `/opt/sakura-ai`。启动脚本将 `COMPOSE_PROJECT_NAME=sakura-ai` 持久化到部署状态，并为所有 Compose 操作显式传入项目名，避免配置文件所在的 `docker/` 目录把网络和持久化卷错误命名为通用的 `docker_*`。`start.sh --prod` 会生成 root-owned `0600` 的 `.deploy/deployment.env`、启动 Web/MySQL/Redis，等待 `/health` 返回实际运行版本，然后从对应 Release 下载 updater binary 与 `SHA256SUMS`，校验后初始化 GID 9472、`/run/sakura-ai` 和 updater daemon。生产 daemon 启动前还会验证 binary、Compose、`deployment.env` 及其完整父目录链均由 root 控制且不可由 group/other 写入；校验失败时拒绝启动更新能力。新版本检查会自动执行，但安装更新必须由超级管理员在 WebUI 版本管理器中手动确认。
 
 **macOS（仅容器，不包含 Host Updater）**：
 
@@ -50,9 +50,9 @@ mkdir -p docker .deploy
 curl -L https://raw.githubusercontent.com/Sakura520222/Sakura-AI/main/docker/docker-compose.prod.yml \
   -o docker/docker-compose.prod.yml
 umask 077
-printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest\nSAKURA_DB_PASSWORD=%s\n' \
+printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest\nCOMPOSE_PROJECT_NAME=sakura-ai\nSAKURA_DB_PASSWORD=%s\n' \
   "$(openssl rand -hex 32)" > .deploy/deployment.env
-docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+docker compose --env-file .deploy/deployment.env --project-name sakura-ai -f docker/docker-compose.prod.yml up -d
 ```
 
 **PowerShell（Windows）**：
@@ -66,9 +66,9 @@ Invoke-WebRequest `
   -OutFile "docker/docker-compose.prod.yml"
 $bytes = [Security.Cryptography.RandomNumberGenerator]::GetBytes(32)
 $dbPassword = [Convert]::ToHexString($bytes).ToLowerInvariant()
-@("SAKURA_DEPLOY_MODE=image", "SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest", "SAKURA_DB_PASSWORD=$dbPassword") |
+@("SAKURA_DEPLOY_MODE=image", "SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest", "COMPOSE_PROJECT_NAME=sakura-ai", "SAKURA_DB_PASSWORD=$dbPassword") |
   Set-Content -Encoding ascii .deploy/deployment.env
-docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+docker compose --env-file .deploy/deployment.env --project-name sakura-ai -f docker/docker-compose.prod.yml up -d
 ```
 
 macOS、Windows 和其他仅容器部署可以自动显示新版本，但不能从 WebUI 执行更新；请手动拉取目标镜像并重新运行 Compose。Host Updater 当前仅支持 Linux `amd64`/`arm64` 宿主机。
@@ -108,14 +108,14 @@ docker run -d `
 
 ```bash
 SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:v3.0.0 \
-  docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+  docker compose --env-file .deploy/deployment.env --project-name sakura-ai -f docker/docker-compose.prod.yml up -d
 ```
 
 **PowerShell（Windows）**：
 
 ```powershell
 $env:SAKURA_AI_IMAGE = "ghcr.io/sakura520222/sakura-ai:v3.0.0"
-docker compose --env-file .deploy/deployment.env -f docker/docker-compose.prod.yml up -d
+docker compose --env-file .deploy/deployment.env --project-name sakura-ai -f docker/docker-compose.prod.yml up -d
 Remove-Item Env:SAKURA_AI_IMAGE
 ```
 
@@ -135,24 +135,12 @@ Remove-Item Env:SAKURA_AI_IMAGE
 - `connection.json` 与其它运行时文件不被触碰
 - 合并采用同目录原子替换并在批次失败时回滚；YAML 解析失败或无法安全处理的类型冲突 fail-closed，既有文件不会被覆盖
 
-首次升级旧卷时没有 baseline，会保守保留现有值并补入新键，然后写入 baseline。这样升级镜像既能获得默认策略/标签变化，又不会丢失管理员修改；请将 YAML 文件纳入你自己的备份流程（配置备份接口主要覆盖数据库 `app_config`）。
-
-### 1.6 升级与密码轮换
-
-已有旧部署若 `.deploy/deployment.env` 没有 `SAKURA_DB_PASSWORD`，`start.sh` 不会猜测或静默轮换（否则会与已有 `mysql_data` 凭据不一致）。请按以下步骤处理：
-
-1. 停止 Web 服务
-2. 生成新的 64 位十六进制密码
-3. 在 MySQL 中执行 `ALTER USER 'sakura'@'%' IDENTIFIED BY '<同一密码>'`
-4. 确认连接成功后，把同一值写入 `.deploy/deployment.env`（权限 0600）
-5. 用上面的 `--env-file` 命令启动
-
 ---
 
 ## 二、环境要求
 
 - Linux 服务器（推荐 Ubuntu 20.04+）
-- Docker 和 Docker Compose（镜像部署）/ Python 3.14+（源码部署）
+- Docker 和 Docker Compose V2（镜像部署；旧版 `docker-compose` V1 不受支持）/ Python 3.14+（源码部署）
 - 公网 IP 和域名
 - GitHub 账号
 - DeepSeek API Key（或其他 OpenAI 兼容 API）

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 COMPOSE_FILE="docker/docker-compose.yml"
 PROD_COMPOSE_FILE="docker/docker-compose.prod.yml"
+COMPOSE_PROJECT=""
+DEFAULT_PROD_COMPOSE_PROJECT="sakura-ai"
 DEPLOY_DIR=".deploy"
 BUILD_LOG="$DEPLOY_DIR/build.log"
 PHASE_FILE="$DEPLOY_DIR/phase"         # 当前阶段: preflight / build / pip / start / health / done
@@ -116,33 +118,38 @@ init_deployment_env() {
     if [[ -f "$DEPLOYMENT_ENV_FILE" ]]; then
         local persisted_mode=""
         local persisted_password=""
+        local persisted_project=""
         local line
         while IFS= read -r line || [[ -n "$line" ]]; do
             case "$line" in
                 SAKURA_DEPLOY_MODE=*) persisted_mode="${line#SAKURA_DEPLOY_MODE=}" ;;
                 SAKURA_DB_PASSWORD=*) persisted_password="${line#SAKURA_DB_PASSWORD=}" ;;
+                COMPOSE_PROJECT_NAME=*) persisted_project="${line#COMPOSE_PROJECT_NAME=}" ;;
             esac
         done < "$DEPLOYMENT_ENV_FILE"
 
-        if [[ -n "$persisted_password" ]]; then
-            if [[ ! "$persisted_password" =~ ^[0-9a-f]{64}$ ]]; then
-                fail "deployment.env 中的 SAKURA_DB_PASSWORD 格式无效；拒绝启动以避免数据库凭据不一致" >&2
+        case "$persisted_mode" in
+            source)
+                ;;
+            image)
+                if [[ ! "$persisted_password" =~ ^[0-9a-f]{64}$ ]]; then
+                    fail "invalid production deployment state: SAKURA_DB_PASSWORD must be 64 lowercase hexadecimal characters" >&2
+                    return 1
+                fi
+                if [[ "$persisted_project" != "$DEFAULT_PROD_COMPOSE_PROJECT" ]]; then
+                    fail "invalid production deployment state: COMPOSE_PROJECT_NAME must be '$DEFAULT_PROD_COMPOSE_PROJECT'" >&2
+                    return 1
+                fi
+                ;;
+            *)
+                fail "invalid deployment state: SAKURA_DEPLOY_MODE must be 'source' or 'image'" >&2
                 return 1
-            fi
-            chmod 600 "$DEPLOYMENT_ENV_FILE" || {
-                fail "无法将 deployment.env 权限收紧为 0600；拒绝启动以保护数据库凭据" >&2
-                return 1
-            }
-            return 0
-        fi
-
-        # source compose 不创建内置 MySQL，旧 source 状态可以继续运行。
-        # image/--prod 状态必须由管理员完成一次显式密码迁移，不能在已有
-        # mysql_data 上静默生成新密码，否则应用和数据库会立即失联。
-        if [[ "$persisted_mode" == "image" || "${prod:-false}" == "true" ]]; then
-            fail "现有 deployment.env 缺少 SAKURA_DB_PASSWORD；请先按 README 的 legacy 密码迁移步骤 ALTER USER，再写入同一 64 位十六进制密码" >&2
+                ;;
+        esac
+        chmod 600 "$DEPLOYMENT_ENV_FILE" || {
+            fail "无法将 deployment.env 权限收紧为 0600；拒绝启动以保护数据库凭据" >&2
             return 1
-        fi
+        }
         return 0
     fi
 
@@ -160,6 +167,7 @@ init_deployment_env() {
             # 写实际值：解析当前 SAKURA_AI_IMAGE 环境变量，缺省用默认 latest
             local image="${SAKURA_AI_IMAGE:-ghcr.io/sakura520222/sakura-ai:latest}"
             echo "SAKURA_AI_IMAGE=$image"
+            echo "COMPOSE_PROJECT_NAME=$DEFAULT_PROD_COMPOSE_PROJECT"
             # 仅写入由本函数生成的 URL-safe hex secret；绝不记录到日志。
             echo "SAKURA_DB_PASSWORD=$db_password"
         fi
@@ -195,18 +203,57 @@ UPDATER_HEALTH_URL="${UPDATER_HEALTH_URL:-http://localhost:8000/health}"
 #
 # deployment.env 是 updater 的权威运行时状态。这里仅逐行读取精确的
 # SAKURA_DEPLOY_MODE=... 字段，绝不 source/eval runtime 文件，避免把其中的
-# 值当作 shell 代码执行。历史 source/缺失状态继续使用开发 Compose；image
-# 状态必须选择生产 Compose，不能因 start.sh 新进程默认值而回落到开发定义。
-read_deployment_mode() {
-    local state_file="${1:-$DEPLOYMENT_ENV_FILE}" mode="" line
+# 值当作 shell 代码执行。source 使用开发 Compose；image 使用生产 Compose。
+# 缺失或未知模式属于无效的 3.0.0 部署状态，不提供兼容回退。
+read_deployment_value() {
+    local key="$1" state_file="${2:-$DEPLOYMENT_ENV_FILE}" value="" line
     if [[ -r "$state_file" ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
-            case "$line" in
-                SAKURA_DEPLOY_MODE=*) mode="${line#SAKURA_DEPLOY_MODE=}" ;;
-            esac
+            if [[ "${line%%=*}" == "$key" ]]; then
+                value="${line#*=}"
+            fi
         done < "$state_file"
     fi
-    printf '%s\n' "$mode"
+    printf '%s\n' "$value"
+}
+
+read_deployment_mode() {
+    read_deployment_value "SAKURA_DEPLOY_MODE" "${1:-$DEPLOYMENT_ENV_FILE}"
+}
+
+compose_project_name_is_valid() {
+    [[ "$1" =~ ^[a-z0-9][a-z0-9_-]*$ ]]
+}
+
+select_production_compose_project() {
+    local state_file="${1:-$DEPLOYMENT_ENV_FILE}" project=""
+    project="$(read_deployment_value "COMPOSE_PROJECT_NAME" "$state_file")"
+
+    if [[ -z "$project" ]]; then
+        fail "missing COMPOSE_PROJECT_NAME in production deployment state" >&2
+        return 1
+    fi
+
+    if ! compose_project_name_is_valid "$project"; then
+        fail "invalid COMPOSE_PROJECT_NAME in deployment state: '$project'" >&2
+        return 1
+    fi
+    if [[ "$project" != "$DEFAULT_PROD_COMPOSE_PROJECT" ]]; then
+        fail "unsupported production COMPOSE_PROJECT_NAME '$project'; expected '$DEFAULT_PROD_COMPOSE_PROJECT'" >&2
+        return 1
+    fi
+    COMPOSE_PROJECT="$project"
+}
+
+select_compose_for_operation() {
+    local requested_prod="${1:-false}"
+    if should_use_production_mode "$requested_prod"; then
+        COMPOSE_FILE="$PROD_COMPOSE_FILE"
+        select_production_compose_project "$DEPLOYMENT_ENV_FILE"
+    else
+        COMPOSE_FILE="docker/docker-compose.yml"
+        COMPOSE_PROJECT=""
+    fi
 }
 
 should_use_production_mode() {
@@ -222,17 +269,15 @@ select_compose_from_deployment_mode() {
     case "$mode" in
         image)
             COMPOSE_FILE="$PROD_COMPOSE_FILE"
+            select_production_compose_project "$UPDATER_DEPLOYMENT_ENV_FILE"
             ;;
         source)
             COMPOSE_FILE="docker/docker-compose.yml"
-            ;;
-        "")
-            COMPOSE_FILE="docker/docker-compose.yml"
-            warn "SAKURA_DEPLOY_MODE missing; using development compose"
+            COMPOSE_PROJECT=""
             ;;
         *)
-            COMPOSE_FILE="docker/docker-compose.yml"
-            warn "unknown SAKURA_DEPLOY_MODE='$mode'; using development compose"
+            fail "invalid deployment state: SAKURA_DEPLOY_MODE must be 'source' or 'image'" >&2
+            return 1
             ;;
     esac
 }
@@ -903,13 +948,18 @@ cmd_updater() {
 
 detect_compose() {
     local env_file_opt=""
+    local project_opt=""
     if [[ -f "$DEPLOYMENT_ENV_FILE" ]]; then
         env_file_opt="--env-file $DEPLOYMENT_ENV_FILE"
     fi
+    if [[ -n "$COMPOSE_PROJECT" ]]; then
+        project_opt="--project-name $COMPOSE_PROJECT"
+    fi
     if docker compose version &>/dev/null; then
-        echo "docker compose $env_file_opt -f $COMPOSE_FILE"
+        echo "docker compose $env_file_opt $project_opt -f $COMPOSE_FILE"
     elif command -v docker-compose &>/dev/null; then
-        echo "docker-compose $env_file_opt -f $COMPOSE_FILE"
+        fail "Docker Compose V2 is required; install the 'docker compose' plugin (docker-compose V1 cannot run the Host Updater)" >&2
+        echo ""
     else
         echo ""
     fi
@@ -934,6 +984,14 @@ cmd_status() {
     else
         if [[ "$build_active" -eq 1 ]]; then
             warn "host updater daemon 未运行；部署仍在进行，等待应用健康后再恢复"
+        elif updater_binary_is_safe "${UPDATER_BINARY:-$UPDATER_STATE_DIR/sakura-ai-updater}" \
+            || [[ "${SAKURA_UPDATER_DEV:-0}" == "1" ]] \
+            || updater_path_exists "${UPDATER_BINARY:-$UPDATER_STATE_DIR/sakura-ai-updater}"; then
+            if ensure_updater_running; then
+                ok "host updater daemon 运行中"
+            else
+                warn "host updater daemon 不可用"
+            fi
         elif updater_health_payload >/dev/null 2>&1; then
             if ensure_updater_running; then
                 ok "host updater daemon 运行中"
@@ -1025,13 +1083,8 @@ build_runner() {
     local current_hash=""
     local dockerfile_hash=""
 
-    # 选择 compose 文件：生产模式用生产 compose（runner 进程 source 后变量被重置，
-    # 需在此显式重新指定）；源码模式保持默认开发 compose
-    if $prod; then
-        COMPOSE_FILE="$PROD_COMPOSE_FILE"
-    else
-        COMPOSE_FILE="docker/docker-compose.yml"
-    fi
+    # runner 会重新 source start.sh，因此必须从持久化状态恢复 Compose 文件和项目。
+    select_compose_for_operation "$prod"
 
     COMPOSE=$(detect_compose)
     if [[ -z "$COMPOSE" ]]; then
@@ -1252,6 +1305,8 @@ do_updater_menu() {
 }
 
 do_ps() {
+    local prod=${1:-false}
+    select_compose_for_operation "$prod"
     # Show container status
     local compose_cmd
     compose_cmd=$(detect_compose)
@@ -1264,6 +1319,8 @@ do_ps() {
 }
 
 do_down() {
+    local prod=${1:-false}
+    select_compose_for_operation "$prod"
     local compose_cmd
     compose_cmd=$(detect_compose)
     if [[ -z "$compose_cmd" ]]; then
@@ -1298,13 +1355,13 @@ do_start() {
             info "检测到持久化 image 部署，继续使用生产模式"
         fi
         prod=true
-        COMPOSE_FILE="$PROD_COMPOSE_FILE"
         info "生产模式：使用生产 compose ($PROD_COMPOSE_FILE)"
     fi
 
     # 先初始化部署状态（detect_compose 依赖 deployment.env 是否存在来决定 --env-file）
     mkdir -p "$DEPLOY_DIR"
     init_deployment_env
+    select_compose_for_operation "$prod"
 
     # Detect compose
     COMPOSE=$(detect_compose)
@@ -1445,8 +1502,8 @@ main() {
         status) cmd_status; exit 0 ;;
         attach) cmd_attach; exit $? ;;
         stop)   cmd_stop; exit 0 ;;
-        ps)     do_ps; exit 0 ;;
-        down)   do_down; exit 0 ;;
+        ps)     do_ps "$prod"; exit 0 ;;
+        down)   do_down "$prod"; exit 0 ;;
     esac
 
     # No subcommand args -> interactive menu

--- a/start.sh
+++ b/start.sh
@@ -197,15 +197,27 @@ UPDATER_HEALTH_URL="${UPDATER_HEALTH_URL:-http://localhost:8000/health}"
 # SAKURA_DEPLOY_MODE=... 字段，绝不 source/eval runtime 文件，避免把其中的
 # 值当作 shell 代码执行。历史 source/缺失状态继续使用开发 Compose；image
 # 状态必须选择生产 Compose，不能因 start.sh 新进程默认值而回落到开发定义。
-select_compose_from_deployment_mode() {
-    local mode="" line
-    if [[ -r "$UPDATER_DEPLOYMENT_ENV_FILE" ]]; then
+read_deployment_mode() {
+    local state_file="${1:-$DEPLOYMENT_ENV_FILE}" mode="" line
+    if [[ -r "$state_file" ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
             case "$line" in
                 SAKURA_DEPLOY_MODE=*) mode="${line#SAKURA_DEPLOY_MODE=}" ;;
             esac
-        done < "$UPDATER_DEPLOYMENT_ENV_FILE"
+        done < "$state_file"
     fi
+    printf '%s\n' "$mode"
+}
+
+should_use_production_mode() {
+    local requested_prod="${1:-false}"
+    [[ "$requested_prod" == "true" ]] \
+        || [[ "$(read_deployment_mode "$DEPLOYMENT_ENV_FILE")" == "image" ]]
+}
+
+select_compose_from_deployment_mode() {
+    local mode
+    mode="$(read_deployment_mode "$UPDATER_DEPLOYMENT_ENV_FILE")"
 
     case "$mode" in
         image)
@@ -908,19 +920,32 @@ detect_compose() {
 # ============================================================
 
 cmd_status() {
-    # host updater daemon 恢复尝试（spec §11.4）
-    ensure_updater_running || warn "host updater daemon 不可用"
+    local build_active=0
+    if is_running; then
+        build_active=1
+    fi
 
-    # updater daemon 状态快照
+    # updater daemon 状态快照。构建仍在运行或应用尚未健康时只报告状态，不提前
+    # acquisition；image :latest 必须等 /health 提供具体版本后才能安全安装。
     if updater_backend is-running \
         --state-dir "$UPDATER_STATE_DIR" \
         --socket-path "$UPDATER_SOCKET_PATH" >/dev/null 2>&1; then
         ok "host updater daemon 运行中"
     else
-        warn "host updater daemon 未运行"
+        if [[ "$build_active" -eq 1 ]]; then
+            warn "host updater daemon 未运行；部署仍在进行，等待应用健康后再恢复"
+        elif updater_health_payload >/dev/null 2>&1; then
+            if ensure_updater_running; then
+                ok "host updater daemon 运行中"
+            else
+                warn "host updater daemon 不可用"
+            fi
+        else
+            warn "host updater daemon 未运行；应用尚未健康，暂不尝试安装 updater"
+        fi
     fi
 
-    if is_running; then
+    if [[ "$build_active" -eq 1 ]]; then
         local pid
         pid=$(cat "$PID_FILE")
         local phase
@@ -1266,8 +1291,13 @@ do_start() {
         exit 1
     fi
 
-    # 生产模式使用生产 compose（跳过本地构建，直接拉取 GHCR 镜像）
-    if $prod; then
+    # 显式 --prod 或持久化 image 部署都使用生产 compose。这样最小化镜像部署
+    # 后再次运行交互菜单的“启动服务”也不会误入缺少源码文件的开发构建路径。
+    if should_use_production_mode "$prod"; then
+        if [[ "$prod" != "true" ]]; then
+            info "检测到持久化 image 部署，继续使用生产模式"
+        fi
+        prod=true
         COMPOSE_FILE="$PROD_COMPOSE_FILE"
         info "生产模式：使用生产 compose ($PROD_COMPOSE_FILE)"
     fi

--- a/tests/test_init_deployment_env.sh
+++ b/tests/test_init_deployment_env.sh
@@ -27,6 +27,7 @@ W2=$(mktemp -d)
 prod=true SAKURA_AI_IMAGE="" DEPLOY_DIR="$W2" DEPLOYMENT_ENV_FILE="$W2/deployment.env" init_deployment_env >/dev/null
 assert_contains "$W2/deployment.env" "SAKURA_DEPLOY_MODE=image" "S2: image 模式写 image"
 assert_contains "$W2/deployment.env" "SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest" "S2: image 模式写实际镜像值（默认 latest）"
+assert_contains "$W2/deployment.env" "COMPOSE_PROJECT_NAME=sakura-ai" "S2: image 模式固定生产 Compose 项目名"
 assert_not_contains "$W2/deployment.env" 'SAKURA_AI_IMAGE=${' "S2: 不写 shell 表达式"
 password_w2=$(sed -n 's/^SAKURA_DB_PASSWORD=//p' "$W2/deployment.env")
 [[ "$password_w2" =~ ^[0-9a-f]{64}$ ]] && report 0 "S2: image 模式生成 64 位十六进制数据库密码" || report 1 "S2: 数据库密码格式错误"
@@ -43,17 +44,24 @@ assert_contains "$W2b/deployment.env" "SAKURA_AI_IMAGE=ghcr.io/sakura520222/saku
 
 # 场景 3：已有状态不覆盖（即使模式不同）
 W3=$(mktemp -d)
-printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=custom:preserved\nSAKURA_DB_PASSWORD=%064d\n' 0 > "$W3/deployment.env"
+printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=custom:preserved\nCOMPOSE_PROJECT_NAME=sakura-ai\nSAKURA_DB_PASSWORD=%064d\n' 0 > "$W3/deployment.env"
 prod=false DEPLOY_DIR="$W3" DEPLOYMENT_ENV_FILE="$W3/deployment.env" init_deployment_env >/dev/null
 assert_contains "$W3/deployment.env" "custom:preserved" "S3: 已有状态不被覆盖"
 assert_contains "$W3/deployment.env" "SAKURA_DEPLOY_MODE=image" "S3: 已有 mode 不被改回 source"
 
-# 场景 3b：既有 image 状态缺 secret 时 fail-closed，绝不猜测已有 mysql_data 密码
+# 场景 3b：不完整的 image 状态无兼容或补写路径
 W3b=$(mktemp -d)
 printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=custom:preserved\n' > "$W3b/deployment.env"
 prod=false DEPLOY_DIR="$W3b" DEPLOYMENT_ENV_FILE="$W3b/deployment.env" init_deployment_env >/dev/null 2>&1
-[ "$?" -ne 0 ] && report 0 "S3b: 既有生产状态缺密码时拒绝静默轮换" || report 1 "S3b: 缺密码状态未 fail-closed"
+[ "$?" -ne 0 ] && report 0 "S3b: 不完整生产状态直接无效" || report 1 "S3b: 不完整状态未 fail-closed"
 assert_not_contains "$W3b/deployment.env" "SAKURA_DB_PASSWORD=" "S3b: 未偷偷追加新密码"
+
+# 场景 3c：生产项目字段缺失时无补写兼容
+W3c=$(mktemp -d)
+printf 'SAKURA_DEPLOY_MODE=image\nSAKURA_AI_IMAGE=custom:preserved\nSAKURA_DB_PASSWORD=%064d\n' 0 > "$W3c/deployment.env"
+prod=false DEPLOY_DIR="$W3c" DEPLOYMENT_ENV_FILE="$W3c/deployment.env" init_deployment_env >/dev/null 2>&1
+[ "$?" -ne 0 ] && report 0 "S3c: 缺少固定项目名的生产状态直接无效" || report 1 "S3c: 缺少项目名的状态未 fail-closed"
+assert_not_contains "$W3c/deployment.env" "COMPOSE_PROJECT_NAME=" "S3c: 未补写兼容字段"
 
 # 场景 4：atomic write 不残留临时文件
 W4=$(mktemp -d)

--- a/tests/test_prod_compose_credentials.py
+++ b/tests/test_prod_compose_credentials.py
@@ -15,7 +15,9 @@ def _compose() -> dict:
 
 
 def test_web_and_mysql_use_the_same_required_secret_variable():
-    services = _compose()["services"]
+    compose = _compose()
+    assert compose["name"] == "sakura-ai"
+    services = compose["services"]
     web_environment = services["web"]["environment"]
     mysql_environment = services["mysql"]["environment"]
 

--- a/tests/test_prod_compose_credentials.py
+++ b/tests/test_prod_compose_credentials.py
@@ -16,7 +16,7 @@ def _compose() -> dict:
 
 def test_web_and_mysql_use_the_same_required_secret_variable():
     compose = _compose()
-    assert compose["name"] == "sakura-ai"
+    assert "name" not in compose
     services = compose["services"]
     web_environment = services["web"]["environment"]
     mysql_environment = services["mysql"]["environment"]

--- a/tests/test_start_sh_compose_mode.py
+++ b/tests/test_start_sh_compose_mode.py
@@ -11,11 +11,21 @@ import pytest
 ROOT = Path(__file__).parents[1]
 
 
-def _run_start_sh(mode: str | None, action: str) -> subprocess.CompletedProcess[str]:
+def _run_start_sh(
+    mode: str | None,
+    action: str,
+    *,
+    project: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     deployment_line = (
         f"printf 'SAKURA_DEPLOY_MODE=%s\\n' '{mode}' > \"$deployment_file\""
         if mode is not None
         else ": > \"$deployment_file\""
+    )
+    project_line = (
+        f"printf 'COMPOSE_PROJECT_NAME=%s\\n' '{project}' >> \"$deployment_file\""
+        if project is not None
+        else ":"
     )
     command = f"""
 set -u
@@ -25,6 +35,7 @@ case_dir=$(mktemp -d)
 trap 'rm -rf "$case_dir"' EXIT
 deployment_file="$case_dir/deployment.env"
 {deployment_line}
+{project_line}
 export UPDATER_DEPLOYMENT_ENV_FILE="$deployment_file"
 export UPDATER_STATE_DIR="$case_dir/updater"
 export UPDATER_BINARY="$case_dir/updater/sakura-ai-updater"
@@ -59,7 +70,7 @@ updater_backend() {{
 
 @pytest.mark.parametrize("action", ["ensure_updater_running", "cmd_updater start"])
 def test_image_mode_routes_updater_to_production_compose(action: str):
-    result = _run_start_sh("image", action)
+    result = _run_start_sh("image", action, project="sakura-ai")
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "--compose-file docker/docker-compose.prod.yml" in result.stdout
@@ -67,30 +78,30 @@ def test_image_mode_routes_updater_to_production_compose(action: str):
 
 
 @pytest.mark.parametrize("action", ["ensure_updater_running", "cmd_updater start"])
-@pytest.mark.parametrize("mode", ["source", None, "unknown"])
-def test_non_image_mode_keeps_development_compose_with_compatibility_warning(
-    mode: str | None, action: str
-):
-    result = _run_start_sh(mode, action)
+def test_source_mode_routes_updater_to_development_compose(action: str):
+    result = _run_start_sh("source", action)
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "--compose-file docker/docker-compose.yml" in result.stdout
     assert "--compose-file docker/docker-compose.prod.yml" not in result.stdout
-    if mode == "source":
-        assert "using development compose" not in result.stdout.lower()
-    else:
-        assert "using development compose" in result.stdout.lower()
+
+
+@pytest.mark.parametrize("mode", [None, "unknown"])
+def test_invalid_deployment_mode_has_no_compose_fallback(mode: str | None):
+    result = _run_start_sh(mode, "select_compose_from_deployment_mode")
+
+    assert result.returncode != 0
+    assert "SAKURA_DEPLOY_MODE must be 'source' or 'image'" in result.stderr
 
 
 def test_mode_parser_does_not_source_or_evaluate_deployment_file():
     script = (ROOT / "start.sh").read_text(encoding="utf-8")
-    helper_start = script.index("read_deployment_mode()")
+    helper_start = script.index("read_deployment_value()")
     helper_end = script.index("\n}\n", helper_start) + 3
     helper = script[helper_start:helper_end]
 
     assert "source " not in helper
     assert "eval " not in helper
-    assert "SAKURA_DEPLOY_MODE=" in helper
 
 
 @pytest.mark.parametrize(
@@ -165,3 +176,101 @@ cmd_status
     assert result.returncode == 0, output + result.stderr.decode(errors="replace")
     assert "UNEXPECTED_BOOTSTRAP" not in output
     assert "等待应用健康后再恢复" in output
+
+
+@pytest.mark.parametrize(("action", "verb"), [("do_ps false", "ps"), ("do_down false", "down")])
+def test_service_commands_route_persisted_image_mode_to_fixed_project(
+    action: str,
+    verb: str,
+):
+    command = f"""
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+DEPLOYMENT_ENV_FILE="$case_dir/deployment.env"
+printf '%s\n' \
+    'SAKURA_DEPLOY_MODE=image' \
+    'COMPOSE_PROJECT_NAME=sakura-ai' \
+    'SAKURA_DB_PASSWORD={"0" * 64}' > "$DEPLOYMENT_ENV_FILE"
+docker() {{
+    if [[ "$1 $2" == 'compose version' ]]; then
+        return 0
+    fi
+    printf 'DOCKER:%s\n' "$*"
+}}
+{action}
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    output = result.stdout.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, output + result.stderr.decode(errors="replace")
+    assert "--project-name sakura-ai" in output
+    assert f"-f docker/docker-compose.prod.yml {verb}" in output
+
+
+def test_status_restarts_safe_installed_updater_without_application_health():
+    command = """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+is_running() { return 1; }
+get_phase() { printf 'none\n'; }
+get_result() { :; }
+updater_backend() { return 1; }
+updater_binary_is_safe() { return 0; }
+updater_health_payload() { printf 'UNEXPECTED_HEALTH\n'; return 1; }
+ensure_updater_running() { printf 'ENSURED\n'; return 0; }
+cmd_status
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    output = result.stdout.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, output + result.stderr.decode(errors="replace")
+    assert "ENSURED" in output
+    assert "UNEXPECTED_HEALTH" not in output
+
+
+def test_docker_compose_v1_is_rejected_with_clear_requirement():
+    command = """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+mkdir -p "$case_dir/bin"
+printf '#!/usr/bin/env sh\nexit 0\n' > "$case_dir/bin/docker-compose"
+chmod +x "$case_dir/bin/docker-compose"
+PATH="$case_dir/bin:$PATH"
+docker() { return 1; }
+compose_result="$(detect_compose)"
+printf 'RESULT=<%s>\n' "$compose_result"
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, output
+    assert "Docker Compose V2 is required" in output
+    assert "RESULT=<>" in output

--- a/tests/test_start_sh_compose_mode.py
+++ b/tests/test_start_sh_compose_mode.py
@@ -84,10 +84,84 @@ def test_non_image_mode_keeps_development_compose_with_compatibility_warning(
 
 def test_mode_parser_does_not_source_or_evaluate_deployment_file():
     script = (ROOT / "start.sh").read_text(encoding="utf-8")
-    helper_start = script.index("select_compose_from_deployment_mode()")
+    helper_start = script.index("read_deployment_mode()")
     helper_end = script.index("\n}\n", helper_start) + 3
     helper = script[helper_start:helper_end]
 
     assert "source " not in helper
     assert "eval " not in helper
     assert "SAKURA_DEPLOY_MODE=" in helper
+
+
+@pytest.mark.parametrize(
+    ("persisted_mode", "requested_prod", "expected"),
+    [
+        ("image", "false", True),
+        ("source", "false", False),
+        (None, "false", False),
+        ("source", "true", True),
+    ],
+)
+def test_start_mode_honors_persisted_image_deployment(
+    persisted_mode: str | None,
+    requested_prod: str,
+    expected: bool,
+):
+    deployment_line = (
+        f"printf 'SAKURA_DEPLOY_MODE=%s\\n' '{persisted_mode}' > \"$DEPLOYMENT_ENV_FILE\""
+        if persisted_mode is not None
+        else ": > \"$DEPLOYMENT_ENV_FILE\""
+    )
+    command = f"""
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+DEPLOYMENT_ENV_FILE="$case_dir/deployment.env"
+{deployment_line}
+should_use_production_mode {requested_prod}
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+
+    assert (result.returncode == 0) is expected
+
+
+def test_status_defers_updater_bootstrap_while_deployment_is_running():
+    command = """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+PID_FILE="$case_dir/build.pid"
+BUILD_LOG="$case_dir/build.log"
+printf '4242\n' > "$PID_FILE"
+: > "$BUILD_LOG"
+is_running() { return 0; }
+get_phase() { printf 'start\\n'; }
+updater_backend() { return 1; }
+ensure_updater_running() { printf 'UNEXPECTED_BOOTSTRAP\\n'; return 1; }
+tail() { :; }
+cmd_status
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    output = result.stdout.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, output + result.stderr.decode(errors="replace")
+    assert "UNEXPECTED_BOOTSTRAP" not in output
+    assert "等待应用健康后再恢复" in output

--- a/updater/src/sakura_ai_updater/adapters/image.py
+++ b/updater/src/sakura_ai_updater/adapters/image.py
@@ -13,6 +13,7 @@ import asyncio
 import inspect
 import json
 import os
+import re
 import tempfile
 import time
 from collections.abc import Iterable
@@ -76,6 +77,37 @@ class HealthCheckVersionMismatch(HealthCheckError):
         )
         self.expected = expected
         self.actual = actual
+
+
+_COMPOSE_PROJECT_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_PRODUCTION_COMPOSE_PROJECT = "sakura-ai"
+
+
+def _read_compose_project_name(path: str) -> str:
+    """Read a persisted Compose project without evaluating the env file."""
+
+    try:
+        lines = Path(path).read_text(encoding="utf-8").splitlines()
+    except (FileNotFoundError, OSError, UnicodeDecodeError) as exc:
+        raise ImageAdapterError(
+            f"cannot read deployment state for Compose project: {path!r}"
+        ) from exc
+    project: str | None = None
+    for line in lines:
+        if line.startswith("COMPOSE_PROJECT_NAME="):
+            project = line.split("=", 1)[1]
+    if project is None:
+        raise ImageAdapterError("missing COMPOSE_PROJECT_NAME in deployment state")
+    if not _COMPOSE_PROJECT_RE.fullmatch(project):
+        raise ImageAdapterError(
+            f"invalid COMPOSE_PROJECT_NAME in deployment state: {project!r}"
+        )
+    if project != _PRODUCTION_COMPOSE_PROJECT:
+        raise ImageAdapterError(
+            "unsupported COMPOSE_PROJECT_NAME in deployment state: "
+            f"{project!r}; expected {_PRODUCTION_COMPOSE_PROJECT!r}"
+        )
+    return project
 
 
 def _fsync_parent(path: str | os.PathLike[str]) -> None:
@@ -313,18 +345,14 @@ class ImageAdapter:
         # This write is deliberately after ``pull`` (the orchestrator calls
         # those methods as separate state-machine steps).
         await asyncio.to_thread(write_deployment_env, self.deployment_env, target_image)
-        await self._run_command(
-            [
-                "docker",
-                "compose",
-                "--env-file",
-                self.deployment_env,
-                "-f",
-                self.compose_file,
-                "up",
-                "-d",
-            ]
+        compose_argv = ["docker", "compose", "--env-file", self.deployment_env]
+        project = await asyncio.to_thread(
+            _read_compose_project_name,
+            self.deployment_env,
         )
+        compose_argv.extend(["--project-name", project])
+        compose_argv.extend(["-f", self.compose_file, "up", "-d"])
+        await self._run_command(compose_argv)
 
     async def inspect_running_digest(self) -> str:
         """Return the immutable digest captured by the running container."""

--- a/updater/tests/test_image_adapter.py
+++ b/updater/tests/test_image_adapter.py
@@ -6,6 +6,7 @@ import pytest
 from sakura_ai_updater.adapters.image import (
     HealthCheckVersionMismatch,
     ImageAdapter,
+    ImageAdapterError,
     ImageCommandError,
 )
 
@@ -48,7 +49,10 @@ async def test_pull_failure_does_not_touch_deployment_env(tmp_path, monkeypatch)
 @pytest.mark.asyncio
 async def test_activate_writes_env_and_uses_explicit_compose_env_file(tmp_path, monkeypatch):
     env = tmp_path / "deployment.env"
-    env.write_text("SAKURA_AI_IMAGE=old:image\nOTHER=keep\n", encoding="utf-8")
+    env.write_text(
+        "SAKURA_AI_IMAGE=old:image\nCOMPOSE_PROJECT_NAME=sakura-ai\nOTHER=keep\n",
+        encoding="utf-8",
+    )
     calls: list[tuple[str, ...]] = []
 
     async def fake_exec(*argv, **kwargs):
@@ -65,12 +69,77 @@ async def test_activate_writes_env_and_uses_explicit_compose_env_file(tmp_path, 
             "compose",
             "--env-file",
             str(env),
+            "--project-name",
+            "sakura-ai",
             "-f",
             "/srv/docker-compose.prod.yml",
             "up",
             "-d",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_invalid_persisted_compose_project(tmp_path, monkeypatch):
+    env = tmp_path / "deployment.env"
+    env.write_text(
+        "SAKURA_AI_IMAGE=old:image\nCOMPOSE_PROJECT_NAME=../../unsafe\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_exec(*argv, **kwargs):
+        calls.append(tuple(argv))
+        return _Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    adapter = ImageAdapter("/srv/docker-compose.prod.yml", str(env))
+
+    with pytest.raises(ImageAdapterError, match="invalid COMPOSE_PROJECT_NAME"):
+        await adapter.activate("ghcr.io/example/app:v3.1.0")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_activate_requires_persisted_compose_project(tmp_path, monkeypatch):
+    env = tmp_path / "deployment.env"
+    env.write_text("SAKURA_AI_IMAGE=old:image\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_exec(*argv, **kwargs):
+        calls.append(tuple(argv))
+        return _Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    adapter = ImageAdapter("/srv/docker-compose.prod.yml", str(env))
+
+    with pytest.raises(ImageAdapterError, match="missing COMPOSE_PROJECT_NAME"):
+        await adapter.activate("ghcr.io/example/app:v3.1.0")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_noncanonical_compose_project(tmp_path, monkeypatch):
+    env = tmp_path / "deployment.env"
+    env.write_text(
+        "SAKURA_AI_IMAGE=old:image\nCOMPOSE_PROJECT_NAME=docker\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_exec(*argv, **kwargs):
+        calls.append(tuple(argv))
+        return _Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    adapter = ImageAdapter("/srv/docker-compose.prod.yml", str(env))
+
+    with pytest.raises(ImageAdapterError, match="unsupported COMPOSE_PROJECT_NAME"):
+        await adapter.activate("ghcr.io/example/app:v3.1.0")
+
+    assert calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- persist the strict production Compose project contract as `COMPOSE_PROJECT_NAME=sakura-ai`
- pass `--project-name sakura-ai` through start, status, stop, and Host Updater activation paths
- route `--ps`, `--down`, and menu service operations through the persisted image deployment mode
- restart an already-installed safe updater even while the application health endpoint is unavailable
- require Docker Compose V2 and remove the incompatible Compose-file top-level `name` field

## 3.0.0 deployment scope

This release is a new 3.0.0 deployment contract. It intentionally does not detect, migrate, reuse, amend, or delete resources from earlier directory-derived `docker_*` projects. Incomplete deployment state, a missing project field, or any project name other than `sakura-ai` fails closed without a compatibility fallback.

## Validation

- `.venv\Scripts\python.exe -m pytest -q`: 1814 passed, 10 skipped
- `.venv\Scripts\python.exe -m pytest updater/tests -q`: 205 passed, 8 skipped
- targeted Compose/start/updater tests: 29 passed
- `bash tests/test_init_deployment_env.sh`: 16 passed, 0 failed
- `bash tests/test_start_sh_updater.sh`: 64 passed, 0 failed
- `.venv\Scripts\python.exe run_ruff.py --check`: passed
- `bash -n start.sh`: passed
- `git diff --check`: passed

## Deployment impact

- all new image deployments use only the `sakura-ai` Compose project
- `deployment.env` must contain the complete 3.0.0 state, including `COMPOSE_PROJECT_NAME=sakura-ai`
- `docker-compose` V1 is unsupported because Host Updater activation requires Compose V2
- no database migration or legacy deployment compatibility is included