### PR TITLE
docs(updater): document post-update synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ sudo ./start.sh --prod
 
 `/opt/sakura-ai` 及其中的 Compose 定义由 root 管理，避免持久运行的 root updater 执行普通用户可篡改的部署文件。启动脚本会把固定的 `sakura-ai` Compose 项目名写入部署状态，并在每次 Compose 操作中显式传入，持久化卷不会因配置文件位于 `docker/` 目录而落入通用的 `docker_*` 命名空间。该入口会生成并保护部署状态、启动全部容器，并为当前实际运行版本下载、校验和启动 Host Updater。系统会自动检查新版本；实际更新仍由超级管理员在 WebUI 版本管理器中手动确认触发，不会无人值守安装。macOS、Windows 和仅容器部署当前不支持 Host Updater，详见[部署指南](docs/DEPLOYMENT.md)。
 
+> **WebUI 更新后的 Updater 同步：** WebUI 当前只更新 Sakura AI 应用镜像，不会替换宿主机上的 Host Updater；就绪项“Updater 文件可用”仅表示目标 Release 包含对应二进制与校验文件。应用更新完成并确认 `/health` 已返回新版本后，在 `/opt/sakura-ai` 执行以下命令，使 Updater 与当前应用 Release 保持一致：
+>
+> ```bash
+> sudo ./start.sh updater stop
+> sudo ./start.sh updater install
+> sudo ./start.sh updater start
+> sudo ./start.sh updater status
+> ```
+>
+> `install` 严格绑定当前已健康运行的 Sakura AI 版本，因此必须在应用更新成功后执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
+
 **仅 Web 镜像**（MySQL/Redis 自备）：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ sudo ./start.sh --prod
 > sudo ./start.sh updater status
 > ```
 >
-> `install` 严格绑定当前已健康运行的 Sakura AI 版本，因此必须在应用更新成功后执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
+> `install` 会按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行 `install`。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -180,7 +180,7 @@ sudo ./start.sh --prod
 > sudo ./start.sh updater status
 > ```
 >
-> `install` is strictly bound to the currently healthy Sakura AI version, so run it only after the application update has completed. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
+> `install` selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not run `install` if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
 
 **Web image only** (bring your own MySQL/Redis):
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -171,6 +171,17 @@ sudo ./start.sh --prod
 
 `/opt/sakura-ai` and its Compose definition are managed by root so the persistent root updater never executes deployment files that an unprivileged account can replace. The launcher persists the fixed `sakura-ai` Compose project and passes it explicitly to every Compose operation, so placing the file under `docker/` cannot put persistent volumes in the generic `docker_*` namespace. This entry point creates and protects the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the version that is actually running. New releases are checked automatically, but installation is only started after a super administrator confirms it in the WebUI Version Manager. macOS, Windows, and container-only deployments do not currently support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md).
 
+> **Synchronizing Host Updater after a WebUI update:** The WebUI currently updates only the Sakura AI application image; it does not replace the Host Updater binary on the host. The readiness item “Updater asset available” only confirms that the target Release contains the architecture-specific binary and checksum file. After the application update succeeds and `/health` reports the new version, run the following commands in `/opt/sakura-ai` to align Host Updater with the running application Release:
+>
+> ```bash
+> sudo ./start.sh updater stop
+> sudo ./start.sh updater install
+> sudo ./start.sh updater start
+> sudo ./start.sh updater status
+> ```
+>
+> `install` is strictly bound to the currently healthy Sakura AI version, so run it only after the application update has completed. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
+
 **Web image only** (bring your own MySQL/Redis):
 
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -283,6 +283,32 @@ Host updater 是一个独立的 Linux 宿主守护进程。Backend 会定期检�
 
 action 默认为 `status`，即 `./start.sh updater` 等价于 `./start.sh updater status`。
 
+### WebUI 更新后同步 Host Updater
+
+WebUI 版本管理器当前负责更新 Sakura AI 应用镜像，不会替换或重启宿主机上的 Host Updater。预检中的“Updater 文件可用”只验证目标 Release 包含当前架构对应的 updater binary 与 `SHA256SUMS`，不代表更新任务会安装该 binary。因此，WebUI 更新应用成功后，正在运行的 updater 仍是更新前的版本。
+
+等待 WebUI 更新任务成功，并确认应用健康接口已经返回目标版本：
+
+```bash
+cd /opt/sakura-ai
+curl --fail --silent --show-error http://localhost:8000/health
+```
+
+然后停止旧 daemon，安装与当前已健康运行应用版本严格对应的 updater，再启动并验证：
+
+```bash
+sudo ./start.sh updater stop
+sudo ./start.sh updater install
+sudo ./start.sh updater start
+sudo ./start.sh updater status
+
+sudo curl --fail --silent --show-error \
+  --unix-socket /run/sakura-ai/updater.sock \
+  http://updater/v1/health
+```
+
+`install` 不会下载 `latest` updater，而是解析当前部署的具体 Sakura AI 版本并下载同一 Release 的架构资产。因此命令顺序必须是“先完成应用更新并确认健康，再安装 updater”。这套操作只同步管理员已经在 WebUI 确认过的 Release，不会启用定时任务或无人值守更新。
+
 ### 生产首次安装
 
 生产环境的 updater 二进制路径为 `.deploy/updater/sakura-ai-updater`。首次执行 `install` 时，即使宿主机没有 Python 且该 binary 尚不存在，也会由 `start.sh` 完成 binary acquisition；生产路径不依赖宿主机 Python。install 和 start 操作需要 root 权限，因为需要创建固定 GID 9472 的系统组和 `/run/sakura-ai` 运行时目录：
@@ -307,7 +333,15 @@ sudo ./start.sh updater start     # 启动守护进程
 - 下载、checksum、chmod、临时文件 fsync 或临时文件安全检查等 pre-commit 失败时，旧 binary 保持 byte-for-byte unchanged。
 - atomic rename 之后，如果目录 metadata fsync 或 final safety confirmation 失败，则不得声称旧 binary 未变，必须提示新 inode 可能已经安装，且不会继续调用 backend install。只有 post-commit 检查成功后才完成 backend bootstrap。
 
-如果 daemon 在安装前已经运行，替换 binary 不会自动重启正在运行的进程。安装成功后请显式执行：
+Linux 原子替换 binary 后，已经运行的 daemon 会继续使用旧 inode，不会自动切换到新版本。重复安装时推荐先停止 daemon，再安装和启动：
+
+```bash
+sudo ./start.sh updater stop
+sudo ./start.sh updater install
+sudo ./start.sh updater start
+```
+
+如果已经在 daemon 运行期间执行了 `install`，则至少需要显式重启：
 
 ```bash
 sudo ./start.sh updater stop

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -294,7 +294,7 @@ cd /opt/sakura-ai
 curl --fail --silent --show-error http://localhost:8000/health
 ```
 
-然后停止旧 daemon，安装与当前已健康运行应用版本严格对应的 updater，再启动并验证：
+只有人工确认上述响应中的 `version` 等于 WebUI 更新的目标版本后，才能停止旧 daemon、安装 updater，再启动并验证：
 
 ```bash
 sudo ./start.sh updater stop
@@ -307,7 +307,7 @@ sudo curl --fail --silent --show-error \
   http://updater/v1/health
 ```
 
-`install` 不会下载 `latest` updater，而是解析当前部署的具体 Sakura AI 版本并下载同一 Release 的架构资产。因此命令顺序必须是“先完成应用更新并确认健康，再安装 updater”。这套操作只同步管理员已经在 WebUI 确认过的 Release，不会启用定时任务或无人值守更新。
+`install` 不会下载 `latest` updater，而是根据部署状态解析具体 Sakura AI 版本并下载同一 Release 的架构资产。它本身**不提供应用健康门禁**：当 `deployment.env` 已包含具体的 `SAKURA_AI_IMAGE=:vX.Y.Z` 时，安装器可以直接采用该版本，无需查询 `/health`；即使应用停止、启动失败或报告其他版本，也不会因此自动拒绝安装。因此，“`/health` 成功返回预期目标版本”是管理员必须手动完成的前置检查，而不是安装器保证。命令顺序必须是“先完成应用更新并人工确认健康，再安装 updater”；健康检查失败、不可用或版本不符时请勿继续。这套操作只同步管理员已经在 WebUI 确认过的 Release，不会启用定时任务或无人值守更新。
 
 ### 生产首次安装
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 | 文档 | 说明 |
 |---|---|
-| [部署指南](DEPLOYMENT.md) | Docker 镜像、源码部署、GitHub App、数据库、Setup Wizard、Host Updater 自动更新 |
+| [部署指南](DEPLOYMENT.md) | Docker 镜像、源码部署、GitHub App、数据库、Setup Wizard、WebUI 应用更新与 Host Updater 管理 |
 | [配置参考](CONFIGURATION.md) | 全部配置项的位置、键名与说明 |
 | [技术架构](ARCHITECTURE.md) | 整体架构图、技术栈、代码结构、客户端、交互式知识图谱 |
 

--- a/tests/test_deployment_documentation.py
+++ b/tests/test_deployment_documentation.py
@@ -26,3 +26,14 @@ def test_deployment_guide_documents_manual_update_and_trusted_root_path() -> Non
     assert "逐级 `lstat` 并 fail-closed" in guide
     assert "sudo ./start.sh updater start" in guide
     assert "Host Updater 当前仅支持 Linux `amd64`/`arm64` 宿主机" in guide
+
+
+def test_updater_sync_documents_health_as_a_manual_prerequisite() -> None:
+    readme_zh = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_en = (ROOT / "README_EN.md").read_text(encoding="utf-8")
+    guide = (ROOT / "docs" / "DEPLOYMENT.md").read_text(encoding="utf-8")
+
+    assert "它本身不会强制检查应用健康状态" in readme_zh
+    assert "mandatory manual prerequisite" in readme_en
+    assert "它本身**不提供应用健康门禁**" in guide
+    assert "无需查询 `/health`" in guide


### PR DESCRIPTION
## Summary

- clarify in both READMEs that WebUI updates the Sakura AI application image but does not replace the host updater binary
- document the required post-update sequence: stop, install, start, and status
- explain that the updater asset readiness gate verifies Release assets only
- add application and Unix socket health verification to the deployment guide
- replace the misleading documentation-index wording about automatic Host Updater updates

## Validation

- python -m pytest tests/test_deployment_documentation.py tests/test_start_sh_updater_args.py -q: 3 passed
- git diff --check: passed
- UTF-8 decoding, NUL, and final-newline checks: passed

## Deployment impact

Documentation only. No application, updater, Compose, database, legacy-project, volume, or migration behavior changes.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**：本次 PR 主要更新了项目文档，补充了关于后更新同步（post-update synchronization）的说明，并新增了相应的部署文档测试。共涉及 5 个文件，增加 69 行，删除 2 行。

**主要改动列表**：
1. **文档更新**：
    - `README.md` 和 `README_EN.md`：各微调 1 行，可能修正了表述或格式。
    - `docs/DEPLOYMENT.md`：更新了 2 行，删除了 2 行，对部署说明进行了调整和细化。
2. **新增测试**：
    - `tests/test_deployment_documentation.py`：新增 11 行，这是一个全新的测试文件，用于验证部署文档的正确性。

**影响范围**：变更集中在文档和测试层。文档更新进一步完善了部署指南，帮助用户理解更新后的同步流程；新增的测试则从自动化角度验证了文档的有效性，提升了项目的可维护性和可靠性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_deployment_documentation.py"]
```

<!-- sakura-ai-depgraph-end -->