### PR TITLE
fix(security): hide internal error details from API error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-3.0.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
+[![Version](https://img.shields.io/badge/Version-3.0.2-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
 [![CI](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.14+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-3.0.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
+[![Version](https://img.shields.io/badge/Version-3.0.2-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
 [![CI](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.14+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,3 @@
 """Sakura AI Backend"""
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -381,7 +381,8 @@ async def api_passkey_options(request: Request, body: dict):
         try:
             data = await begin_authentication(session, user_id, request_origin(request))
         except WebAuthnError as exc:
-            return error_response(str(exc), status_code=400)
+            logger.warning("Passkey 开始认证失败 / begin authentication failed: {}", exc)
+            return error_response("Passkey 认证失败，请重试", status_code=400)
     return success_response(data=data)
 
 

--- a/backend/api/v1/config.py
+++ b/backend/api/v1/config.py
@@ -295,13 +295,12 @@ async def save_ai_bindings(
     if not isinstance(body.bindings, dict):
         return error_response("bindings 必须是对象")
     accounts = await account_store.list_accounts()
-    try:
-        bindings = account_store.validate_role_bindings_payload(
-            body.bindings,
-            {account.id for account in accounts},
-        )
-    except ValueError as exc:
-        return error_response(str(exc))
+    bindings, error_message = account_store.validate_role_bindings_payload(
+        body.bindings,
+        {account.id for account in accounts},
+    )
+    if error_message:
+        return error_response(error_message)
     await account_store.save_role_bindings(bindings)
     logger.info(f"AI 角色绑定已更新 / role bindings saved, by={user['sub']}")
     normalized = {role: binding.to_dict() for role, binding in bindings.items()}

--- a/backend/api/v1/issues.py
+++ b/backend/api/v1/issues.py
@@ -3,6 +3,7 @@
 import json
 
 from fastapi import APIRouter, Depends, Query
+from loguru import logger
 from sqlalchemy import desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -176,5 +177,6 @@ async def reanalyze_issue(
 
         task_id = await submit_issue_analysis_task(issue_info)
         return success_response(data={"task_id": task_id})
-    except Exception as e:
-        return error_response(str(e), status_code=500)
+    except Exception:
+        logger.error("提交 Issue 分析任务失败 / submit issue analysis failed", exc_info=True)
+        return error_response("提交分析任务失败，请稍后重试", status_code=500)

--- a/backend/api/v1/issues.py
+++ b/backend/api/v1/issues.py
@@ -178,5 +178,5 @@ async def reanalyze_issue(
         task_id = await submit_issue_analysis_task(issue_info)
         return success_response(data={"task_id": task_id})
     except Exception:
-        logger.error("提交 Issue 分析任务失败 / submit issue analysis failed", exc_info=True)
+        logger.exception("提交 Issue 分析任务失败 / submit issue analysis failed")
         return error_response("提交分析任务失败，请稍后重试", status_code=500)

--- a/backend/api/v1/setup.py
+++ b/backend/api/v1/setup.py
@@ -1,6 +1,7 @@
 """API v1 Setup Wizard 端点（免认证，仅在 bootstrap 模式下可用）"""
 
 from fastapi import APIRouter, Request
+from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 from backend.api.v1.deps import limiter
@@ -173,8 +174,9 @@ async def save_step(body: SaveStepRequest):
             data={"saved_count": saved},
             message=f"已保存 {saved} 项配置",
         )
-    except Exception as e:
-        return error_response(f"保存失败: {e}", status_code=500)
+    except Exception:
+        logger.error("Setup 配置保存失败 / setup save failed", exc_info=True)
+        return error_response("配置保存失败，请稍后重试", status_code=500)
 
 
 @router.post("/complete")

--- a/backend/api/v1/setup.py
+++ b/backend/api/v1/setup.py
@@ -175,7 +175,7 @@ async def save_step(body: SaveStepRequest):
             message=f"已保存 {saved} 项配置",
         )
     except Exception:
-        logger.error("Setup 配置保存失败 / setup save failed", exc_info=True)
+        logger.exception("Setup 配置保存失败 / setup save failed")
         return error_response("配置保存失败，请稍后重试", status_code=500)
 
 

--- a/backend/api/v1/user_config.py
+++ b/backend/api/v1/user_config.py
@@ -92,8 +92,8 @@ async def update_user_config(
         await db.commit()
     except ValueError:
         await db.rollback()
-        logger.warning("用户配置更新校验失败 / user config validation failed", exc_info=True)
-        return error_response("配置数据无效，请检查后重试")
+        logger.opt(exception=True).warning("用户配置更新校验失败 / user config validation failed")
+        return error_response(f"配置项 {key} 的值不合法，请从可选项中选择")
     except Exception as e:
         await db.rollback()
         logger.error(f"更新用户配置失败: {e}", exc_info=True)

--- a/backend/api/v1/user_config.py
+++ b/backend/api/v1/user_config.py
@@ -94,9 +94,9 @@ async def update_user_config(
         await db.rollback()
         logger.opt(exception=True).warning("用户配置更新校验失败 / user config validation failed")
         return error_response(f"配置项 {key} 的值不合法，请从可选项中选择")
-    except Exception as e:
+    except Exception:
         await db.rollback()
-        logger.error(f"更新用户配置失败: {e}", exc_info=True)
+        logger.exception("更新用户配置失败 / user config update failed")
         return error_response("更新用户配置失败")
 
     invalidate_user_dynamic_config_cache(user_id, updated_keys)

--- a/backend/api/v1/user_config.py
+++ b/backend/api/v1/user_config.py
@@ -90,9 +90,10 @@ async def update_user_config(
             updated_keys.append(key)
 
         await db.commit()
-    except ValueError as e:
+    except ValueError:
         await db.rollback()
-        return error_response(str(e))
+        logger.warning("用户配置更新校验失败 / user config validation failed", exc_info=True)
+        return error_response("配置数据无效，请检查后重试")
     except Exception as e:
         await db.rollback()
         logger.error(f"更新用户配置失败: {e}", exc_info=True)

--- a/backend/core/ai_protocol/account_store.py
+++ b/backend/core/ai_protocol/account_store.py
@@ -187,13 +187,17 @@ def _role_binding_from_dict(data: dict[str, Any]) -> RoleBindingConfig | None:
 def validate_role_bindings_payload(
     payload: dict[str, Any],
     account_ids: set[str],
-) -> dict[str, RoleBindingConfig]:
+) -> tuple[dict[str, RoleBindingConfig], str | None]:
     """Validate and normalize API-supplied role bindings.
 
     Bindings are security-sensitive configuration: accepting a dangling account
     reference makes the saved role silently unusable and can unexpectedly alter
     its fallback behaviour.  Keep the accepted shape aligned with the runtime
     resolver and reject malformed or unknown references before persistence.
+
+    Returns ``(bindings, None)`` on success or ``({}, error_message)`` when the
+    payload is rejected. ``error_message`` is a controlled, user-facing string
+    so callers can surface it directly without leaking exception internals.
     """
     supported_roles = {"main", "summary", "agent_team"}
     result: dict[str, RoleBindingConfig] = {}
@@ -201,27 +205,27 @@ def validate_role_bindings_payload(
     for raw_role, raw_binding in payload.items():
         role = str(raw_role)
         if role not in supported_roles:
-            raise ValueError(f"不支持的 AI 角色: {role}")
+            return {}, f"不支持的 AI 角色: {role}"
         if not isinstance(raw_binding, dict):
-            raise ValueError(f"角色 {role} 的绑定必须是对象")
+            return {}, f"角色 {role} 的绑定必须是对象"
 
         primary = raw_binding.get("primary")
         fallback = raw_binding.get("fallback", [])
         if not isinstance(primary, dict):
-            raise ValueError(f"角色 {role} 缺少有效的 primary 绑定")
+            return {}, f"角色 {role} 缺少有效的 primary 绑定"
         if not isinstance(fallback, list) or any(
             not isinstance(item, dict) for item in fallback
         ):
-            raise ValueError(f"角色 {role} 的 fallback 必须是对象列表")
+            return {}, f"角色 {role} 的 fallback 必须是对象列表"
 
         binding = _role_binding_from_dict(raw_binding)
         if binding is None:
-            raise ValueError(f"角色 {role} 的绑定格式无效")
+            return {}, f"角色 {role} 的绑定格式无效"
 
         assignments = [binding.primary, *binding.fallback]
         for assignment in assignments:
             if not assignment.account or not assignment.model:
-                raise ValueError(f"角色 {role} 的账号和模型不能为空")
+                return {}, f"角色 {role} 的账号和模型不能为空"
 
             follows_main = (
                 assignment.account == "main" or assignment.model == "follow"
@@ -230,17 +234,18 @@ def validate_role_bindings_payload(
                 if role == "main" or not (
                     assignment.account == "main" and assignment.model == "follow"
                 ):
-                    raise ValueError(f"角色 {role} 的跟随绑定无效")
+                    return {}, f"角色 {role} 的跟随绑定无效"
                 continue
 
             if assignment.account not in account_ids:
-                raise ValueError(
-                    f"角色 {role} 引用了不存在的 AI 账号: {assignment.account}"
+                return (
+                    {},
+                    f"角色 {role} 引用了不存在的 AI 账号: {assignment.account}",
                 )
 
         result[role] = binding
 
-    return result
+    return result, None
 
 
 # =============================================================================

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -771,7 +771,7 @@ async def insert_default_configs_async():
         raise RuntimeError("异步会话工厂未初始化,请先调用 init_async_db()")
 
     default_configs = [
-        AppConfig(key_name="app_version", key_value="3.0.1", description="应用版本号"),
+        AppConfig(key_name="app_version", key_value="3.0.2", description="应用版本号"),
         AppConfig(
             key_name="max_concurrent_reviews",
             key_value="5",
@@ -917,7 +917,7 @@ def init_database(database_url: str):
 
             default_configs = [
                 AppConfig(
-                    key_name="app_version", key_value="3.0.1", description="应用版本号"
+                    key_name="app_version", key_value="3.0.2", description="应用版本号"
                 ),
                 AppConfig(
                     key_name="max_concurrent_reviews",

--- a/backend/webui/routes/vector_db.py
+++ b/backend/webui/routes/vector_db.py
@@ -364,9 +364,10 @@ async def test_db_connection(
             "success": result.get("success", False),
             "message": result.get("message", ""),
         }
-    except Exception as e:
-        logger.error("测试数据库连接失败: {}", e)
-        return {"success": False, "message": str(e)}
+    except Exception:
+        # 不向外部暴露异常详情，避免泄漏内部实现（堆栈/SQL/路径等）
+        logger.error("测试数据库连接失败 / database connection test failed", exc_info=True)
+        return {"success": False, "message": "数据库连接测试失败，请检查连接配置"}
 
 
 # ========== POST: 测试 ChromaDB 连接 ==========
@@ -388,6 +389,7 @@ async def test_chromadb(
             "message": f"ChromaDB 连接正常，共有 {len(collections)} 个 Collection",
             "data": {"collection_count": len(collections)},
         }
-    except Exception as e:
-        logger.error("测试 ChromaDB 连接失败: {}", e)
-        return {"success": False, "message": str(e)}
+    except Exception:
+        # 不向外部暴露异常详情，避免泄漏内部实现（堆栈/SQL/路径等）
+        logger.error("测试 ChromaDB 连接失败 / chromadb connection test failed", exc_info=True)
+        return {"success": False, "message": "ChromaDB 连接测试失败，请检查服务状态"}

--- a/backend/webui/routes/vector_db.py
+++ b/backend/webui/routes/vector_db.py
@@ -366,7 +366,7 @@ async def test_db_connection(
         }
     except Exception:
         # 不向外部暴露异常详情，避免泄漏内部实现（堆栈/SQL/路径等）
-        logger.error("测试数据库连接失败 / database connection test failed", exc_info=True)
+        logger.exception("测试数据库连接失败 / database connection test failed")
         return {"success": False, "message": "数据库连接测试失败，请检查连接配置"}
 
 
@@ -391,5 +391,5 @@ async def test_chromadb(
         }
     except Exception:
         # 不向外部暴露异常详情，避免泄漏内部实现（堆栈/SQL/路径等）
-        logger.error("测试 ChromaDB 连接失败 / chromadb connection test failed", exc_info=True)
+        logger.exception("测试 ChromaDB 连接失败 / chromadb connection test failed")
         return {"success": False, "message": "ChromaDB 连接测试失败，请检查服务状态"}

--- a/tests/test_stack_trace_exposure.py
+++ b/tests/test_stack_trace_exposure.py
@@ -7,7 +7,7 @@
 
 import io
 import json
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from loguru import logger
@@ -118,3 +118,50 @@ async def test_chromadb_connection_failure_sanitizes_response_and_logs_traceback
     assert "Traceback" in log_output
     assert "RuntimeError" in log_output
     assert sensitive_detail in log_output
+
+
+@pytest.mark.asyncio
+async def test_user_config_unexpected_error_logs_traceback_and_sanitizes(
+    loguru_capture,
+):
+    """Exception（非 ValueError）路径：同样记录完整 traceback 并脱敏响应。
+
+    守护 user_config.py 同一函数内 except Exception 分支——该行原为
+    ``logger.error(..., exc_info=True)``（loguru 不生效），与紧邻的 ValueError 分支
+    属同一修复范围，不应遗漏。
+    """
+    from backend.api.v1.schemas import UserConfigUpdateRequest
+    from backend.api.v1.user_config import update_user_config
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=RuntimeError(
+            "db connection lost: pool exhausted, host=internal-db"
+        )
+    )
+
+    body = UserConfigUpdateRequest(configs={"output_language": "en"})
+
+    response = await update_user_config(
+        body,
+        user={"user_id": 1, "sub": "user-1"},
+        db=db,
+    )
+
+    data = json.loads(response.body)
+    log_output = loguru_capture.getvalue()
+
+    # 响应脱敏：固定通用消息，不含 DB 内部细节
+    assert response.status_code == 400
+    assert data["success"] is False
+    assert data["error"] == "更新用户配置失败"
+    assert "internal-db" not in data["error"]
+    assert "pool exhausted" not in data["error"]
+
+    # 异常路径触发资源清理
+    assert db.rollback.await_count == 1
+
+    # loguru 必须记录完整 traceback（回归守护点）
+    assert "Traceback" in log_output
+    assert "RuntimeError" in log_output
+    assert "db connection lost" in log_output

--- a/tests/test_stack_trace_exposure.py
+++ b/tests/test_stack_trace_exposure.py
@@ -1,0 +1,120 @@
+"""回归测试：异常路径不向外部响应泄漏堆栈/内部信息，但完整记录到日志。
+
+覆盖 CodeQL py/stack-trace-exposure（CWE-209）修复，并守护 loguru 日志契约——
+``logger.exception`` / ``logger.opt(exception=True).warning`` 必须在 except 块中保留
+完整 traceback；stdlib 风格的 ``exc_info=True`` 在 loguru 中不生效（会丢失堆栈）。
+"""
+
+import io
+import json
+from unittest.mock import Mock
+
+import pytest
+from loguru import logger
+
+
+class _FakeUserConfigDb:
+    """user_config 端点所需的最小 AsyncSession。
+
+    ValueError 在 db.execute 之前抛出（validate 阶段），因此只需 rollback。
+    """
+
+    def __init__(self):
+        self.rolled_back = False
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+@pytest.fixture
+def loguru_capture():
+    """捕获 loguru 日志到 StringIO，供断言 traceback 与消息内容。"""
+    buf = io.StringIO()
+    handler_id = logger.add(
+        buf,
+        format="{level}|{message}|{exception}",
+        level="DEBUG",
+        catch=False,
+    )
+    yield buf
+    logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_user_config_invalid_value_sanitizes_response_and_logs_traceback(
+    loguru_capture,
+):
+    """ValueError 路径：响应脱敏并含受控 key 名，日志保留完整 traceback。
+
+    覆盖 backend/api/v1/user_config.py 的 ``logger.opt(exception=True).warning`` 修复——
+    若回退为 ``exc_info=True``，loguru 不记录 traceback，本测试会失败。
+    """
+    from backend.api.v1.schemas import UserConfigUpdateRequest
+    from backend.api.v1.user_config import update_user_config
+
+    body = UserConfigUpdateRequest(configs={"output_language": "invalid-value"})
+    db = _FakeUserConfigDb()
+
+    response = await update_user_config(
+        body,
+        user={"user_id": 1, "sub": "user-1"},
+        db=db,
+    )
+
+    data = json.loads(response.body)
+    log_output = loguru_capture.getvalue()
+
+    # 响应脱敏：不含 exception 的精确校验消息，但含受控 key 名引导用户修正
+    assert response.status_code == 400
+    assert data["success"] is False
+    assert "output_language" in data["error"]
+    assert "仅允许为空、zh-CN 或 en" not in data["error"]
+
+    # 异常路径触发资源清理
+    assert db.rolled_back is True
+
+    # loguru 必须记录完整 traceback（回归守护点）
+    assert "Traceback" in log_output
+    assert "ValueError" in log_output
+    assert "output_language 仅允许为空、zh-CN 或 en" in log_output
+
+
+@pytest.mark.asyncio
+async def test_chromadb_connection_failure_sanitizes_response_and_logs_traceback(
+    monkeypatch,
+    loguru_capture,
+):
+    """Exception 路径：响应返回固定脱敏消息，日志保留含敏感细节的完整 traceback。
+
+    覆盖 backend/webui/routes/vector_db.py 的 ``logger.exception`` 修复（CodeQL 告警 37）——
+    若回退为 ``exc_info=True``，loguru 不记录 traceback，本测试会失败。
+    """
+    from backend.webui.routes import vector_db
+
+    sensitive_detail = "chromadb internal error: host=10.0.0.1 token=secret-token"
+    monkeypatch.setattr(
+        vector_db,
+        "get_vector_store",
+        Mock(side_effect=RuntimeError(sensitive_detail)),
+    )
+
+    result = await vector_db.test_chromadb(
+        request=None,
+        user={"sub": "admin"},
+        _csrf="token",
+        user_prefs={},
+    )
+
+    log_output = loguru_capture.getvalue()
+
+    # 响应脱敏：固定通用消息，不含任何内部细节
+    assert result["success"] is False
+    assert result["message"] == "ChromaDB 连接测试失败，请检查服务状态"
+    assert "secret-token" not in result["message"]
+    assert "10.0.0.1" not in result["message"]
+    assert "chromadb internal" not in result["message"]
+
+    # loguru 必须保留完整 traceback 与原始异常细节，供服务端排查
+    assert "Traceback" in log_output
+    assert "RuntimeError" in log_output
+    assert sensitive_detail in log_output


### PR DESCRIPTION
- Replace raw exception messages with generic user-friendly messages in auth, issues, setup, and user_config endpoints
- Add structured logging with exc_info for backend debugging
- Refactor validate_role_bindings_payload to return (bindings, error_message) tuple instead of raising ValueError

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本次为安全性修复，旨在统一隐藏 API 错误响应中的内部实现细节，防止敏感信息（如堆栈跟踪、内部路径）泄露。

**主要改动列表**
- **日志机制优化**：在 `user_config` 等模块将 `logger.error` 替换为 `logger.exception`，确保堆栈信息正确记录于后端日志，从根源阻断其进入 API 响应。
- **端点错误处理**：调整 `issues`、`setup`、`user_config` 等 API 及 `vector_db` 路由的异常捕获逻辑，统一对外返回脱敏错误。
- **安全测试扩充**：持续扩展 `test_stack_trace_exposure.py` 测试用例（新增 +48 行），进一步验证各端点堆栈信息不对外暴露。
- **底层与文档配合**：调整 `account_store`、`database` 等底层模块异常抛出机制，并同步更新 README。

**影响范围**
- **安全性**：显著提升防御能力，避免因异常直接抛出导致的内部信息泄露。
- **接口契约**：全局统一错误响应结构，调用方（前端/客户端）仅能获取脱敏后的通用错误提示，需排查是否存在强依赖原错误详情的逻辑。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/api/v1/user_config.py"]
    N2["backend/api/v1/issues.py"]
    N3["backend/api/v1/auth.py"]
    N4["backend/api/v1/config.py"]
    N5["backend/core/ai_protocol/account_store.py"]
    N6["backend/models/database.py"]
    N7["tests/test_stack_trace_exposure.py"]
    N3 --> N6
    N4 --> N5
    N4 --> N6
    N2 --> N6
    N1 --> N6
```

<!-- sakura-ai-depgraph-end -->