### PR TITLE
fix(docker): reuse published stable digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,9 @@ jobs:
     name: 构建并推送 ${{ inputs.channel }}
     runs-on: ubuntu-latest
     outputs:
-      digest: ${{ steps.build.outputs.digest }}   # 供 Docker Hub 按 digest 同步
+      # 稳定版本标签已存在时，materialize 会复用其不可变 digest；
+      # Docker Hub 必须同步最终发布 digest，而不是本次临时构建 digest。
+      digest: ${{ steps.materialize.outputs.digest }}
       immutable_tag: ${{ steps.tags.outputs.immutable_tag }}
     steps:
       - name: 检出代码（固定到 source_ref）
@@ -160,12 +162,26 @@ jobs:
           }
           SOURCE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           IMMUTABLE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.immutable_tag }}"
+          PUBLISHED_DIGEST="$DIGEST"
           existing_error=$(mktemp)
           if existing=$(crane digest "$IMMUTABLE" 2>"$existing_error"); then
-            if [ "$existing" != "$DIGEST" ]; then
-              echo "immutable tag already points to a different digest; refusing overwrite" >&2
+            [[ "$existing" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+              echo "existing immutable tag returned an invalid digest; refusing publication" >&2
               rm -f "$existing_error"
               exit 1
+            }
+            if [ "$existing" != "$DIGEST" ]; then
+              if [ "${{ inputs.channel }}" = "stable" ]; then
+                # A released SemVer tag is authoritative and immutable.  Main
+                # pushes still perform the requested build, but a repeated
+                # version must keep using the digest published previously.
+                echo "stable immutable tag already exists; reusing digest $existing"
+                PUBLISHED_DIGEST="$existing"
+              else
+                echo "development immutable tag already points to a different digest; refusing overwrite" >&2
+                rm -f "$existing_error"
+                exit 1
+              fi
             fi
           else
             # Only an explicit missing-manifest response permits first
@@ -213,6 +229,7 @@ jobs:
             echo "unsupported channel; refusing alias materialization" >&2
             exit 1
           fi
+          echo "digest=$PUBLISHED_DIGEST" >> "$GITHUB_OUTPUT"
 
   sync-dockerhub:
     name: 同步 Docker Hub（非阻塞）

--- a/tests/test_docker_channel_workflows.py
+++ b/tests/test_docker_channel_workflows.py
@@ -38,10 +38,24 @@ def test_reusable_publish_fails_closed_and_sets_build_identity():
     assert text.count("uses: imjasonh/setup-crane@v0.4") >= 2
     assert 'existing_error=$(mktemp)' in text
     assert 'unable to verify immutable tag; refusing publication' in text
+    assert 'existing immutable tag returned an invalid digest' in text
     assert 'crane copy "$SOURCE" "$IMMUTABLE"' in text
     assert "push-by-digest=true" in text
     assert "name-canonical=true" in text
     assert 'SOURCE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"' in text
+    assert "digest: ${{ steps.materialize.outputs.digest }}" in text
+    assert 'PUBLISHED_DIGEST="$DIGEST"' in text
+    assert 'PUBLISHED_DIGEST="$existing"' in text
+    assert 'echo "digest=$PUBLISHED_DIGEST" >> "$GITHUB_OUTPUT"' in text
+    assert "stable immutable tag already exists; reusing digest" in text
+    assert (
+        "development immutable tag already points to a different digest; "
+        "refusing overwrite"
+    ) in text
+    assert (
+        'echo "immutable tag already points to a different digest; refusing overwrite"'
+        not in text
+    )
     assert "BUILD_TAG=" not in text
     assert "build_tag=" not in text
     assert "crane copy \"$SOURCE\" \"docker.io/${IMAGE_NAME}:${{ needs.build-and-publish.outputs.immutable_tag }}\"" in text


### PR DESCRIPTION
## Summary

- keep running the multi-architecture image build for every stable release workflow invocation
- when an immutable stable version tag already exists with a different digest, preserve and reuse that published digest instead of failing or overwriting it
- expose the materialized digest as the reusable workflow job output so `latest` and Docker Hub synchronization use the same authoritative stable image
- keep development immutable-tag digest conflicts fail-closed

## Root cause

Run https://github.com/Sakura520222/Sakura-AI/actions/runs/31770171740 rebuilt `v3.1.0` and produced a new digest. The existing immutable `v3.1.0` tag pointed to the previously published digest, so the materialization guard aborted the workflow. Stable reruns should preserve the released version identity and continue with its existing digest.

## Validation

- `python -m pytest tests/test_docker_channel_workflows.py tests/test_release_workflows.py -q` — 10 passed
- `python -m pytest -q` — 1966 passed, 10 skipped
- `python run_ruff.py --check` — passed
- all `.github/workflows/*.yml` files parsed with PyYAML
- rendered materialization script passed `bash -n`
- `git diff --check` — passed

## Impact

- No database migration or schema change
- No application version change
- No deployment environment or secret change
- The newly built untagged digest is not allowed to replace an existing stable SemVer tag

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
修复 Docker 发布流程中的问题，实现了对已发布 stable digest 的复用，旨在优化构建效率。

**主要改动列表**
1. **核心修复**：更新 `.github/workflows/docker-publish.yml`，调整工作流逻辑以支持复用 stable digest。
2. **测试增强**：在 `tests/test_docker_channel_workflows.py` 中新增测试用例，确保 digest 复用逻辑的正确性。

**影响范围**
主要影响 Docker 镜像的 CI/CD 发布工作流及相关的自动化测试。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_docker_channel_workflows.py"]
```

<!-- sakura-ai-depgraph-end -->