### PR TITLE
fix(updater): recover development channel updates

### DIFF
--- a/backend/core/build_info.py
+++ b/backend/core/build_info.py
@@ -3,7 +3,9 @@
 The module deliberately has no dependency on deployment configuration.  In a
 source checkout the environment variables are absent and the returned
 ``channel`` is ``source``; an image build supplies the four ``SAKURA_BUILD_*``
-variables through the Dockerfile.
+variables through the Dockerfile. Image deployments also expose the exact
+``SAKURA_AI_IMAGE`` selected by deployment.env so health consumers can verify
+the running manifest digest rather than inferring identity from a revision.
 """
 
 from __future__ import annotations
@@ -14,6 +16,9 @@ import re
 from backend.core.time_service import format_rfc3339, parse_rfc3339
 
 _REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+_IMAGE_DIGEST_RE = re.compile(
+    r"^.+:[^@\s]+@(?P<digest>sha256:[0-9a-f]{64})$"
+)
 _CHANNELS = {"stable", "development"}
 
 
@@ -24,6 +29,13 @@ def _created(value: str | None) -> str | None:
         return format_rfc3339(parse_rfc3339(value))
     except ValueError:
         return None
+
+
+def _image_digest(value: str | None) -> str | None:
+    if not value:
+        return None
+    match = _IMAGE_DIGEST_RE.fullmatch(value.strip())
+    return match.group("digest") if match is not None else None
 
 
 def get_build_info() -> dict[str, str | None]:
@@ -38,6 +50,7 @@ def get_build_info() -> dict[str, str | None]:
         "channel": channel,
         "revision": revision,
         "created_at": created_at,
+        "digest": _image_digest(os.environ.get("SAKURA_AI_IMAGE")),
     }
 
 

--- a/backend/webui/templates/version_manager.html
+++ b/backend/webui/templates/version_manager.html
@@ -359,6 +359,7 @@ const VM_I18N = {
   progressFailedTitle: {{ _("version_manager.update_progress_failed_title") | tojson }},
   progressHealthMismatch: {{ _("version_manager.update_progress_health_mismatch") | tojson }},
   progressPollFailed: {{ _("version_manager.update_progress_poll_failed") | tojson }},
+  progressPollDeferred: {{ _("version_manager.update_progress_poll_deferred") | tojson }},
   unknownState: {{ _("version_manager.unknown_state") | tojson }},
   emptyJobResponse: {{ _("version_manager.empty_job_response") | tojson }},
   missingJobId: {{ _("version_manager.missing_job_id") | tojson }},
@@ -581,8 +582,9 @@ function hasExactDigestTarget(target) {
     && (target.channel !== 'development' || /^[0-9a-f]{40}$/.test(target.revision || '')));
 }
 
-function markProgressError(message, {allowRetry = false} = {}) {
-  if (progressJobId && sessionStorage.getItem(JOB_STORAGE_KEY) === progressJobId) {
+function markProgressError(message, {allowRetry = false, preserveJob = false} = {}) {
+  if (!preserveJob && progressJobId
+      && sessionStorage.getItem(JOB_STORAGE_KEY) === progressJobId) {
     clearPersistedJob();
   }
   progressTerminal = true;
@@ -879,6 +881,15 @@ async function pollJob(jobId) {
             return;
           }
           if (transientFor >= POLL_RECOVERY_TIMEOUT_MS) {
+            if (!hasExactDigestTarget(progressTarget)) {
+              // A job id written by an older page has no target digest. Do not
+              // infer success from the newly running build, and do not discard
+              // the only handle that can recover the authoritative job later.
+              const message = vmFormat(VM_I18N.progressPollDeferred, {error: vmUpdaterError(error)});
+              markProgressError(message, {preserveJob: true});
+              setStatus(message, 'error');
+              return;
+            }
             const message = vmFormat(VM_I18N.progressPollFailed, {error: vmUpdaterError(error)});
             markProgressError(message);
             setStatus(message, 'error');

--- a/backend/webui/templates/version_manager.html
+++ b/backend/webui/templates/version_manager.html
@@ -193,7 +193,11 @@
 // 只走 Backend proxy；浏览器永远不接触 UDS 或宿主 Docker。
 const CSRF_TOKEN = "{{ csrf_token }}";
 const CURRENT_BUILD_CHANNEL = {{ (version_info.build or {}).channel | tojson }};
+const CURRENT_BUILD_REVISION = {{ (version_info.build or {}).revision | tojson }};
+const CURRENT_BUILD_VERSION = {{ version_info.current_version | tojson }};
 const JOB_STORAGE_KEY = 'sakura-ai-update-job-id';
+const POLL_RECOVERY_TIMEOUT_MS = 120000;
+const HEALTH_RECOVERY_DELAY_MS = 5000;
 const recheckButton = document.getElementById('recheck-btn');
 const preflightButton = document.getElementById('preflight-btn');
 const updateButton = document.getElementById('update-btn');
@@ -225,6 +229,15 @@ function registryText(value) {
   return value === null || value === undefined || value === '' ? '—' : String(value);
 }
 
+function isCurrentRegistryImage(image) {
+  if (!image || image.channel !== CURRENT_BUILD_CHANNEL) return false;
+  if (image.channel === 'development') {
+    return Boolean(image.revision && CURRENT_BUILD_REVISION
+      && image.revision === CURRENT_BUILD_REVISION);
+  }
+  return image.channel === 'stable' && image.version === CURRENT_BUILD_VERSION;
+}
+
 function renderRegistryPanel(channel) {
   const panel = registryPanels[channel];
   while (panel.firstChild) panel.removeChild(panel.firstChild);
@@ -240,6 +253,7 @@ function renderRegistryPanel(channel) {
     return;
   }
   images.forEach((image) => {
+    const isCurrent = isCurrentRegistryImage(image);
     const row = document.createElement('article');
     row.className = 'mb-3 rounded-xl border border-gray-200 p-3 dark:border-gray-700';
     const title = document.createElement('div');
@@ -251,9 +265,11 @@ function renderRegistryPanel(channel) {
     const action = document.createElement('button');
     action.type = 'button';
     action.className = 'rounded-lg border px-2 py-1 text-xs disabled:opacity-50';
-    action.disabled = image.selectable !== true || registryCatalog.stale === true;
-    action.textContent = image.selectable ? VM_I18N.registrySelect : (image.legacy_reason || VM_I18N.registryNotSelectable);
-    if (image.selectable) action.addEventListener('click', () => {
+    action.disabled = isCurrent || image.selectable !== true || registryCatalog.stale === true;
+    action.textContent = isCurrent
+      ? VM_I18N.current
+      : image.selectable ? VM_I18N.registrySelect : (image.legacy_reason || VM_I18N.registryNotSelectable);
+    if (image.selectable && !isCurrent) action.addEventListener('click', () => {
       const candidate = {
         channel: image.channel, version: image.version, revision: image.revision,
         tag: image.canonical_tag, digest: image.digest
@@ -354,6 +370,7 @@ const VM_I18N = {
   registryUnavailable: {{ _("version_manager.registry_unavailable") | tojson }},
   registrySelected: {{ _("version_manager.registry_selected") | tojson }},
   registryDetails: {{ _("version_manager.registry_details") | tojson }},
+  current: {{ _("version_manager.current") | tojson }},
   developmentRisk: {{ _("version_manager.development_risk") | tojson }},
   channelSwitchRisk: {{ _("version_manager.channel_switch_risk") | tojson }},
   errorLabels: {
@@ -399,6 +416,7 @@ const VM_I18N = {
     protocol_compatible: {{ _("version_manager.check_protocol_compatible") | tojson }},
     target_newer: {{ _("version_manager.check_target_newer") | tojson }},
     min_upgrade_from: {{ _("version_manager.check_min_upgrade_from") | tojson }},
+    current_image_identity_valid: {{ _("version_manager.check_current_image_identity_valid") | tojson }},
     target_identity_valid: {{ _("version_manager.check_target_identity_valid") | tojson }},
     target_channel_head: {{ _("version_manager.check_target_channel_head") | tojson }},
     channel_switch_confirmed: {{ _("version_manager.check_channel_switch_confirmed") | tojson }},
@@ -431,6 +449,7 @@ const UPDATE_PROGRESS = Object.freeze({
 });
 let lastProgress = 0;
 let progressTargetVersion = '';
+let progressTarget = null;
 let progressJobId = '';
 let progressTerminal = false;
 let progressPreviousFocus = null;
@@ -483,6 +502,7 @@ function openProgressModal({jobId = '', targetVersion = '', initial = false} = {
     lastProgress = 0;
     progressJobId = '';
     progressTargetVersion = '';
+    progressTarget = null;
     setUpdateProgress(0);
   }
   progressJobId = jobId || progressJobId;
@@ -520,14 +540,19 @@ function markProgressError(message, {allowRetry = false} = {}) {
 }
 
 function isTransientPollError(error) {
-  // Fetch rejects with TypeError for connection loss. A 503 from the Backend
-  // proxy without a permanent updater code is also expected while the Web
-  // container or Host Updater restarts. All other HTTP/protocol failures are
-  // deterministic until user action.
+  // Fetch rejects with TypeError for connection loss. During activation the
+  // Web container and its reverse-proxy connection may briefly return an
+  // unstructured 500/502/503/504. Retry those only inside pollJob's bounded
+  // recovery window; typed configuration/protocol errors remain terminal.
   const errorCode = error && error.body && error.body.error;
+  const permanentCodes = new Set([
+    'job_not_found', 'protocol_error', 'updater_protocol_error',
+    'updater_not_ready', 'registry_unavailable', 'release_unavailable',
+    'channel_head_unavailable', 'stale_catalog'
+  ]);
   return Boolean(
     error && (
-      (error.status === 503 && (!errorCode || errorCode === 'updater_unavailable')) ||
+      ([500, 502, 503, 504].includes(error.status) && !permanentCodes.has(errorCode)) ||
       (error instanceof TypeError && typeof error.status !== 'number')
     )
   );
@@ -624,13 +649,18 @@ async function preflightRegistryTarget(target) {
   return readiness;
 }
 
-async function loadReadiness() {
+async function loadReadiness(attempt = 0) {
   if (!selectedRegistryTarget) currentChannelTarget = null;
   try {
     const data = await requestJson('/version/readiness', { method: 'POST', headers: {'X-CSRF-Token': CSRF_TOKEN, 'Accept': 'application/json'} });
     showReadiness(data);
     return data && data.data ? data.data : data;
   } catch (error) {
+    if (isTransientPollError(error) && attempt < 2) {
+      setStatus(VM_I18N.reconnecting, null);
+      await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)));
+      return loadReadiness(attempt + 1);
+    }
     if (error.status === 503 && error.body && error.body.error === 'updater_unavailable') {
       setStatus(VM_I18N.notConnected, 'error');
     } else {
@@ -727,6 +757,7 @@ async function pollJob(jobId) {
     updateButton.disabled = true;
     setStatus(vmFormat(VM_I18N.reconnectingJob, {job_id: jobId}), null);
     renderProgress({kind: 'reconnecting', message: VM_I18N.progressReconnecting});
+    let transientSince = null;
     while (sessionStorage.getItem(JOB_STORAGE_KEY) === jobId) {
       try {
         const body = await requestJson('/version/jobs/' + encodeURIComponent(jobId), {headers: {'Accept': 'application/json'}});
@@ -734,19 +765,21 @@ async function pollJob(jobId) {
         if (!job) throw new Error(VM_I18N.emptyJobResponse);
         if (job.target_version) {
           progressTargetVersion = job.target_version;
+          progressTarget = job.target_channel ? {
+            version: job.target_version,
+            channel: job.target_channel,
+            revision: job.target_revision
+          } : job.target_version;
           updateProgressTarget.textContent = vmFormat(VM_I18N.progressTarget, {version: progressTargetVersion});
         }
+        transientSince = null;
         setUpdateProgress(progressForJob(job));
         const state = vmStateLabel(job.state);
         setStatus(vmFormat(VM_I18N.updateStatus, {state: state}) + (job.step ? ' · ' + vmStepLabel(job.step) : ''), null);
         renderProgress({state: job.state, step: job.step});
         if (job.state === 'success' || job.state === 'complete') {
           setUpdateProgress(UPDATE_PROGRESS.success);
-          const target = job.target_channel ? {
-            version: job.target_version || progressTargetVersion,
-            channel: job.target_channel,
-            revision: job.target_revision
-          } : (job.target_version || progressTargetVersion);
+          const target = progressTarget || job.target_version || progressTargetVersion;
           if (target && await verifyHealth(target)) {
             sessionStorage.removeItem(JOB_STORAGE_KEY);
             progressTerminal = true;
@@ -774,6 +807,25 @@ async function pollJob(jobId) {
           // id and last progress value, and retry without marking the update failed.
           setStatus(VM_I18N.reconnecting, null);
           renderProgress({kind: 'reconnecting', message: VM_I18N.progressReconnecting});
+          transientSince = transientSince || Date.now();
+          const transientFor = Date.now() - transientSince;
+          if (transientFor >= HEALTH_RECOVERY_DELAY_MS
+              && progressTarget && await verifyHealth(progressTarget)) {
+            sessionStorage.removeItem(JOB_STORAGE_KEY);
+            progressTerminal = true;
+            setUpdateProgress(UPDATE_PROGRESS.success);
+            setStatus(vmFormat(VM_I18N.updateSuccess, {version: progressTargetVersion}), 'ok');
+            renderProgress({kind: 'success', message: VM_I18N.progressRefreshing});
+            updateButton.disabled = false;
+            scheduleRefresh();
+            return;
+          }
+          if (transientFor >= POLL_RECOVERY_TIMEOUT_MS) {
+            const message = vmFormat(VM_I18N.progressPollFailed, {error: vmUpdaterError(error)});
+            markProgressError(message);
+            setStatus(message, 'error');
+            return;
+          }
           await new Promise((resolve) => setTimeout(resolve, 2000));
           continue;
         }
@@ -851,6 +903,7 @@ updateButton.addEventListener('click', async function() {
   }
   updateButton.disabled = true;
   progressTargetVersion = target;
+  progressTarget = operationTarget || target;
   updateProgressTarget.textContent = vmFormat(VM_I18N.progressTarget, {version: target});
   try {
     const body = await requestJson('/version/update', {

--- a/backend/webui/templates/version_manager.html
+++ b/backend/webui/templates/version_manager.html
@@ -193,9 +193,10 @@
 // 只走 Backend proxy；浏览器永远不接触 UDS 或宿主 Docker。
 const CSRF_TOKEN = "{{ csrf_token }}";
 const CURRENT_BUILD_CHANNEL = {{ (version_info.build or {}).channel | tojson }};
-const CURRENT_BUILD_REVISION = {{ (version_info.build or {}).revision | tojson }};
+const CURRENT_BUILD_DIGEST = {{ (version_info.build or {}).digest | tojson }};
 const CURRENT_BUILD_VERSION = {{ version_info.current_version | tojson }};
 const JOB_STORAGE_KEY = 'sakura-ai-update-job-id';
+const JOB_TARGET_STORAGE_KEY = 'sakura-ai-update-job-target';
 const POLL_RECOVERY_TIMEOUT_MS = 120000;
 const HEALTH_RECOVERY_DELAY_MS = 5000;
 const recheckButton = document.getElementById('recheck-btn');
@@ -231,10 +232,11 @@ function registryText(value) {
 
 function isCurrentRegistryImage(image) {
   if (!image || image.channel !== CURRENT_BUILD_CHANNEL) return false;
-  if (image.channel === 'development') {
-    return Boolean(image.revision && CURRENT_BUILD_REVISION
-      && image.revision === CURRENT_BUILD_REVISION);
+  if (CURRENT_BUILD_DIGEST) {
+    return Boolean(image.digest && image.digest === CURRENT_BUILD_DIGEST);
   }
+  // Stable version tags are immutable. A development revision can be rebuilt
+  // to a new digest, so leave it selectable when exact digest proof is absent.
   return image.channel === 'stable' && image.version === CURRENT_BUILD_VERSION;
 }
 
@@ -529,9 +531,59 @@ function closeProgressModal() {
   progressPreviousFocus = null;
 }
 
+function normalizedProgressTarget(value) {
+  if (!value || typeof value !== 'object'
+      || typeof value.version !== 'string'
+      || !/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(value.version)) return null;
+  const target = {version: value.version};
+  if (value.channel === 'stable' || value.channel === 'development') {
+    target.channel = value.channel;
+  }
+  if (typeof value.revision === 'string'
+      && /^[0-9a-f]{40}$/.test(value.revision)) target.revision = value.revision;
+  if (typeof value.digest === 'string'
+      && /^sha256:[0-9a-f]{64}$/.test(value.digest)) {
+    target.digest = value.digest;
+  }
+  return target;
+}
+
+function persistJob(jobId, target) {
+  sessionStorage.setItem(JOB_STORAGE_KEY, jobId);
+  const normalized = normalizedProgressTarget(target);
+  if (normalized) {
+    sessionStorage.setItem(JOB_TARGET_STORAGE_KEY, JSON.stringify(normalized));
+  } else {
+    sessionStorage.removeItem(JOB_TARGET_STORAGE_KEY);
+  }
+}
+
+function restoreProgressTarget() {
+  try {
+    return normalizedProgressTarget(JSON.parse(
+      sessionStorage.getItem(JOB_TARGET_STORAGE_KEY) || 'null'
+    ));
+  } catch (_) {
+    sessionStorage.removeItem(JOB_TARGET_STORAGE_KEY);
+    return null;
+  }
+}
+
+function clearPersistedJob() {
+  sessionStorage.removeItem(JOB_STORAGE_KEY);
+  sessionStorage.removeItem(JOB_TARGET_STORAGE_KEY);
+}
+
+function hasExactDigestTarget(target) {
+  return Boolean(target && typeof target === 'object'
+    && (target.channel === 'stable' || target.channel === 'development')
+    && /^sha256:[0-9a-f]{64}$/.test(target.digest || '')
+    && (target.channel !== 'development' || /^[0-9a-f]{40}$/.test(target.revision || '')));
+}
+
 function markProgressError(message, {allowRetry = false} = {}) {
   if (progressJobId && sessionStorage.getItem(JOB_STORAGE_KEY) === progressJobId) {
-    sessionStorage.removeItem(JOB_STORAGE_KEY);
+    clearPersistedJob();
   }
   progressTerminal = true;
   renderProgress({kind: 'error', message});
@@ -741,9 +793,12 @@ async function verifyHealth(expected) {
     const target = typeof expected === 'string' ? {version: expected} : expected;
     const payload = body && body.data ? body.data : body;
     if (!payload || payload.version !== target.version) return false;
+    if (target.digest && (!payload.build || payload.build.digest !== target.digest)) return false;
     if (target.channel === 'stable' || target.channel === 'development') {
       if (!payload.build || payload.build.channel !== target.channel) return false;
-      return target.channel !== 'development' || payload.build.revision === target.revision;
+      if (target.channel === 'development'
+          && payload.build.revision !== target.revision) return false;
+      return true;
     }
     return true;
   } catch (_) { return false; }
@@ -768,8 +823,10 @@ async function pollJob(jobId) {
           progressTarget = job.target_channel ? {
             version: job.target_version,
             channel: job.target_channel,
-            revision: job.target_revision
+            revision: job.target_revision,
+            digest: job.target_digest
           } : job.target_version;
+          persistJob(jobId, progressTarget);
           updateProgressTarget.textContent = vmFormat(VM_I18N.progressTarget, {version: progressTargetVersion});
         }
         transientSince = null;
@@ -781,7 +838,7 @@ async function pollJob(jobId) {
           setUpdateProgress(UPDATE_PROGRESS.success);
           const target = progressTarget || job.target_version || progressTargetVersion;
           if (target && await verifyHealth(target)) {
-            sessionStorage.removeItem(JOB_STORAGE_KEY);
+            clearPersistedJob();
             progressTerminal = true;
             setStatus(vmFormat(VM_I18N.updateSuccess, {version: target.version || target}), 'ok');
             renderProgress({kind: 'success', message: VM_I18N.progressRefreshing});
@@ -810,8 +867,9 @@ async function pollJob(jobId) {
           transientSince = transientSince || Date.now();
           const transientFor = Date.now() - transientSince;
           if (transientFor >= HEALTH_RECOVERY_DELAY_MS
-              && progressTarget && await verifyHealth(progressTarget)) {
-            sessionStorage.removeItem(JOB_STORAGE_KEY);
+              && hasExactDigestTarget(progressTarget)
+              && await verifyHealth(progressTarget)) {
+            clearPersistedJob();
             progressTerminal = true;
             setUpdateProgress(UPDATE_PROGRESS.success);
             setStatus(vmFormat(VM_I18N.updateSuccess, {version: progressTargetVersion}), 'ok');
@@ -915,12 +973,12 @@ updateButton.addEventListener('click', async function() {
     const data = body && body.data ? body.data : body;
     if (!data.job_id) throw new Error(VM_I18N.missingJobId);
     progressJobId = data.job_id;
-    sessionStorage.setItem(JOB_STORAGE_KEY, data.job_id);
+    persistJob(data.job_id, progressTarget);
     await pollJob(data.job_id);
   } catch (error) {
     if (error.status === 409 && error.body && error.body.job_id) {
       progressJobId = error.body.job_id;
-      sessionStorage.setItem(JOB_STORAGE_KEY, error.body.job_id);
+      persistJob(error.body.job_id, progressTarget);
       await pollJob(error.body.job_id);
     } else {
       const message = vmFormat(VM_I18N.updateSubmitFailed, {error: (error.body && error.body.error) || error.message});
@@ -933,7 +991,10 @@ updateButton.addEventListener('click', async function() {
 // A page reload after Web container restart resumes the same host job.
 const persistedJobId = sessionStorage.getItem(JOB_STORAGE_KEY);
 if (persistedJobId) {
-  openProgressModal({jobId: persistedJobId});
+  progressTarget = restoreProgressTarget();
+  progressTargetVersion = progressTarget && progressTarget.version
+    ? progressTarget.version : '';
+  openProgressModal({jobId: persistedJobId, targetVersion: progressTargetVersion});
   pollJob(persistedJobId);
 }
 if (CURRENT_BUILD_CHANNEL === 'stable' || CURRENT_BUILD_CHANNEL === 'development') {

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1479,6 +1479,7 @@ version_manager:
   update_progress_failed_title: "Update did not complete"
   update_progress_health_mismatch: "The update job completed, but the health check did not confirm the target version; the page will not refresh automatically."
   update_progress_poll_failed: "Unable to continue tracking the update job: {error}"
+  update_progress_poll_deferred: "Unable to confirm the update result yet: {error}. The job has been preserved; refresh the page later to continue checking."
   unknown_state: "Unknown"
   empty_job_response: "The update job response was empty"
   missing_job_id: "The update response did not include a job ID"

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1511,6 +1511,7 @@ version_manager:
   check_protocol_compatible: "Protocol compatible"
   check_target_newer: "Target version is newer"
   check_min_upgrade_from: "Minimum upgrade version satisfied"
+  check_current_image_identity_valid: "Running image identity is valid"
   check_target_identity_valid: "Target image identity is valid"
   check_target_channel_head: "Target is the current channel head"
   check_channel_switch_confirmed: "Update channel switch confirmed"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1511,6 +1511,7 @@ version_manager:
   check_protocol_compatible: "协议兼容"
   check_target_newer: "目标版本更新"
   check_min_upgrade_from: "满足最低升级版本"
+  check_current_image_identity_valid: "当前运行镜像身份有效"
   check_target_identity_valid: "目标镜像身份有效"
   check_target_channel_head: "目标是当前通道最新版本"
   check_channel_switch_confirmed: "已确认切换更新通道"

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1479,6 +1479,7 @@ version_manager:
   update_progress_failed_title: "更新未完成"
   update_progress_health_mismatch: "更新任务已完成，但健康检查未确认目标版本；页面不会自动刷新。"
   update_progress_poll_failed: "无法继续跟踪更新任务：{error}"
+  update_progress_poll_deferred: "暂时无法确认更新结果：{error}。任务信息已保留，请稍后刷新页面继续检查。"
   unknown_state: "未知"
   empty_job_response: "更新任务响应为空"
   missing_job_id: "更新响应缺少任务 ID"

--- a/start.sh
+++ b/start.sh
@@ -191,7 +191,8 @@ init_deployment_env() {
 # Host Updater daemon management
 # ============================================================
 
-UPDATER_STATE_DIR="$DEPLOY_DIR/updater"
+UPDATER_PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATER_STATE_DIR="${UPDATER_STATE_DIR:-$UPDATER_PROJECT_ROOT/$DEPLOY_DIR/updater}"
 UPDATER_BINARY="$UPDATER_STATE_DIR/sakura-ai-updater"
 UPDATER_SOCKET_PATH="/run/sakura-ai/updater.sock"
 UPDATER_DEPLOYMENT_ENV_FILE="${UPDATER_DEPLOYMENT_ENV_FILE:-$DEPLOYMENT_ENV_FILE}"
@@ -328,6 +329,18 @@ updater_health_payload() {
         --connect-timeout 2 --max-time 5 \
         --header 'Accept: application/json' \
         "$UPDATER_HEALTH_URL"
+}
+
+# Probe the Host Updater itself. This is deliberately separate from the
+# application /health check above: a live UDS listener without matching daemon
+# metadata indicates a checkout-replacement orphan and must block a duplicate
+# start instead of racing to unlink or bind the same socket.
+updater_socket_health_payload() {
+    curl --fail --silent --show-error \
+        --connect-timeout 2 --max-time 5 \
+        --unix-socket "$UPDATER_SOCKET_PATH" \
+        --header 'Accept: application/json' \
+        http://localhost/v1/health
 }
 
 resolve_running_image_version() {
@@ -868,6 +881,11 @@ ensure_updater_running() {
         --state-dir "$UPDATER_STATE_DIR" \
         --socket-path "$UPDATER_SOCKET_PATH" >/dev/null 2>&1; then
         return 0
+    fi
+    if updater_socket_health_payload >/dev/null 2>&1; then
+        fail "updater socket is live but daemon metadata is missing or stale; refusing duplicate start" >&2
+        fail "stop the verified listener process, then run: sudo ./start.sh updater install && sudo ./start.sh updater start" >&2
+        return 1
     fi
     warn "updater daemon 未运行，正在拉起..."
 

--- a/start.sh
+++ b/start.sh
@@ -18,6 +18,8 @@
 
 set -euo pipefail
 
+UPDATER_PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # ============================================================
 # 配置
 # ============================================================
@@ -191,12 +193,13 @@ init_deployment_env() {
 # Host Updater daemon management
 # ============================================================
 
-UPDATER_PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UPDATER_STATE_DIR="${UPDATER_STATE_DIR:-$UPDATER_PROJECT_ROOT/$DEPLOY_DIR/updater}"
 UPDATER_BINARY="$UPDATER_STATE_DIR/sakura-ai-updater"
 UPDATER_SOCKET_PATH="/run/sakura-ai/updater.sock"
-UPDATER_DEPLOYMENT_ENV_FILE="${UPDATER_DEPLOYMENT_ENV_FILE:-$DEPLOYMENT_ENV_FILE}"
-UPDATER_BACKEND_VERSION_FILE="${UPDATER_BACKEND_VERSION_FILE:-backend/__init__.py}"
+UPDATER_SOURCE_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.yml"
+UPDATER_PROD_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.prod.yml"
+UPDATER_DEPLOYMENT_ENV_FILE="${UPDATER_DEPLOYMENT_ENV_FILE:-$UPDATER_PROJECT_ROOT/$DEPLOYMENT_ENV_FILE}"
+UPDATER_BACKEND_VERSION_FILE="${UPDATER_BACKEND_VERSION_FILE:-$UPDATER_PROJECT_ROOT/backend/__init__.py}"
 UPDATER_RELEASE_BASE_URL="https://github.com/Sakura520222/Sakura-AI/releases/download"
 UPDATER_HEALTH_URL="${UPDATER_HEALTH_URL:-http://localhost:8000/health}"
 
@@ -269,11 +272,11 @@ select_compose_from_deployment_mode() {
 
     case "$mode" in
         image)
-            COMPOSE_FILE="$PROD_COMPOSE_FILE"
+            COMPOSE_FILE="$UPDATER_PROD_COMPOSE_FILE"
             select_production_compose_project "$UPDATER_DEPLOYMENT_ENV_FILE"
             ;;
         source)
-            COMPOSE_FILE="docker/docker-compose.yml"
+            COMPOSE_FILE="$UPDATER_SOURCE_COMPOSE_FILE"
             COMPOSE_PROJECT=""
             ;;
         *)

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -11,12 +11,14 @@ def test_build_info_defaults_to_safe_source_identity(monkeypatch):
         "SAKURA_BUILD_CHANNEL",
         "SAKURA_BUILD_REVISION",
         "SAKURA_BUILD_CREATED",
+        "SAKURA_AI_IMAGE",
     ):
         monkeypatch.delenv(key, raising=False)
     assert get_build_info() == {
         "channel": "source",
         "revision": None,
         "created_at": None,
+        "digest": None,
     }
 
 
@@ -24,10 +26,16 @@ def test_build_info_normalizes_image_identity(monkeypatch):
     monkeypatch.setenv("SAKURA_BUILD_CHANNEL", "development")
     monkeypatch.setenv("SAKURA_BUILD_REVISION", "a" * 40)
     monkeypatch.setenv("SAKURA_BUILD_CREATED", "2026-08-13T04:00:00+08:00")
+    digest = "sha256:" + "b" * 64
+    monkeypatch.setenv(
+        "SAKURA_AI_IMAGE",
+        f"ghcr.io/sakura520222/sakura-ai:dev-build@{digest}",
+    )
     assert get_build_info() == {
         "channel": "development",
         "revision": "a" * 40,
         "created_at": "2026-08-12T20:00:00.000000Z",
+        "digest": digest,
     }
 
 
@@ -35,10 +43,12 @@ def test_build_info_rejects_untrusted_values(monkeypatch):
     monkeypatch.setenv("SAKURA_BUILD_CHANNEL", "edge")
     monkeypatch.setenv("SAKURA_BUILD_REVISION", "short")
     monkeypatch.setenv("SAKURA_BUILD_CREATED", "not-a-timestamp")
+    monkeypatch.setenv("SAKURA_AI_IMAGE", "ghcr.io/example/app:latest")
     assert get_build_info() == {
         "channel": "source",
         "revision": None,
         "created_at": None,
+        "digest": None,
     }
 
 
@@ -47,12 +57,18 @@ async def test_health_preserves_top_level_version_and_exposes_build(monkeypatch)
     monkeypatch.setenv("SAKURA_BUILD_CHANNEL", "stable")
     monkeypatch.setenv("SAKURA_BUILD_REVISION", "c" * 40)
     monkeypatch.setenv("SAKURA_BUILD_CREATED", "2026-08-13T04:00:00Z")
+    digest = "sha256:" + "e" * 64
+    monkeypatch.setenv(
+        "SAKURA_AI_IMAGE",
+        f"ghcr.io/sakura520222/sakura-ai:v3.1.1@{digest}",
+    )
     payload = await health()
     assert payload["version"]
     assert payload["build"] == {
         "channel": "stable",
         "revision": "c" * 40,
         "created_at": "2026-08-13T04:00:00.000000Z",
+        "digest": digest,
     }
 
 
@@ -62,3 +78,17 @@ def test_build_info_rejects_non_rfc3339_created_at(monkeypatch):
     monkeypatch.setenv("SAKURA_BUILD_CREATED", "2026-08-13 04:00:00+00:00")
 
     assert get_build_info()["created_at"] is None
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "ghcr.io/sakura520222/sakura-ai@sha256:" + "a" * 64,
+        "ghcr.io/sakura520222/sakura-ai:dev@sha256:short",
+        "ghcr.io/sakura520222/sakura-ai:dev@sha256:" + "A" * 64,
+        "ghcr.io/sakura520222/sakura-ai:dev",
+    ],
+)
+def test_build_info_rejects_unpinned_or_malformed_image_digest(monkeypatch, image):
+    monkeypatch.setenv("SAKURA_AI_IMAGE", image)
+    assert get_build_info()["digest"] is None

--- a/tests/test_start_sh_compose_mode.py
+++ b/tests/test_start_sh_compose_mode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -73,8 +74,8 @@ def test_image_mode_routes_updater_to_production_compose(action: str):
     result = _run_start_sh("image", action, project="sakura-ai")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "--compose-file docker/docker-compose.prod.yml" in result.stdout
-    assert "--compose-file docker/docker-compose.yml" not in result.stdout
+    assert "/docker/docker-compose.prod.yml --deployment-env" in result.stdout
+    assert "/docker/docker-compose.yml --deployment-env" not in result.stdout
 
 
 @pytest.mark.parametrize("action", ["ensure_updater_running", "cmd_updater start"])
@@ -82,8 +83,8 @@ def test_source_mode_routes_updater_to_development_compose(action: str):
     result = _run_start_sh("source", action)
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "--compose-file docker/docker-compose.yml" in result.stdout
-    assert "--compose-file docker/docker-compose.prod.yml" not in result.stdout
+    assert "/docker/docker-compose.yml --deployment-env" in result.stdout
+    assert "/docker/docker-compose.prod.yml --deployment-env" not in result.stdout
 
 
 @pytest.mark.parametrize("mode", [None, "unknown"])
@@ -122,6 +123,36 @@ ensure_updater_running
     assert "UNEXPECTED_BINARY_CHECK" not in stdout
     assert "BACKEND:install" not in stdout
     assert "BACKEND:start" not in stdout
+
+
+def test_updater_runtime_inputs_are_anchored_when_script_is_called_elsewhere(tmp_path):
+    project = tmp_path / "project"
+    caller = tmp_path / "caller"
+    project.mkdir()
+    caller.mkdir()
+    shutil.copyfile(ROOT / "start.sh", project / "start.sh")
+    command = """
+set -u
+export _START_SH_SOURCED=1
+source ../project/start.sh
+printf 'SOURCE=%s\n' "$UPDATER_SOURCE_COMPOSE_FILE"
+printf 'PROD=%s\n' "$UPDATER_PROD_COMPOSE_FILE"
+printf 'ENV=%s\n' "$UPDATER_DEPLOYMENT_ENV_FILE"
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=caller,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    assert result.returncode == 0, stdout + result.stderr.decode("utf-8", errors="replace")
+    assert "/docker/docker-compose.yml" in stdout
+    assert "/docker/docker-compose.prod.yml" in stdout
+    assert "/.deploy/deployment.env" in stdout
+    assert "/caller/" not in stdout
 
 
 def test_mode_parser_does_not_source_or_evaluate_deployment_file():

--- a/tests/test_start_sh_compose_mode.py
+++ b/tests/test_start_sh_compose_mode.py
@@ -94,6 +94,36 @@ def test_invalid_deployment_mode_has_no_compose_fallback(mode: str | None):
     assert "SAKURA_DEPLOY_MODE must be 'source' or 'image'" in result.stderr
 
 
+def test_live_unmanaged_socket_blocks_duplicate_updater_start():
+    command = """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_backend() {
+    printf 'BACKEND:%s\n' "$*"
+    return 1
+}
+updater_socket_health_payload() { printf '{}\n'; }
+updater_binary_is_safe() { printf 'UNEXPECTED_BINARY_CHECK\n'; return 0; }
+ensure_updater_running
+"""
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert result.returncode != 0
+    assert "refusing duplicate start" in stderr
+    assert "UNEXPECTED_BINARY_CHECK" not in stdout
+    assert "BACKEND:install" not in stdout
+    assert "BACKEND:start" not in stdout
+
+
 def test_mode_parser_does_not_source_or_evaluate_deployment_file():
     script = (ROOT / "start.sh").read_text(encoding="utf-8")
     helper_start = script.index("read_deployment_value()")

--- a/tests/test_start_sh_updater_args.py
+++ b/tests/test_start_sh_updater_args.py
@@ -8,3 +8,6 @@ def test_updater_lifecycle_forwards_host_paths_without_update_commands():
     # Lifecycle wiring only; orchestration must remain in the host updater.
     assert "start.sh update apply" not in script
     assert "start.sh update check" not in script
+    assert 'UPDATER_PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in script
+    assert "updater_socket_health_payload" in script
+    assert "refusing duplicate start" in script

--- a/tests/test_start_sh_updater_args.py
+++ b/tests/test_start_sh_updater_args.py
@@ -9,5 +9,8 @@ def test_updater_lifecycle_forwards_host_paths_without_update_commands():
     assert "start.sh update apply" not in script
     assert "start.sh update check" not in script
     assert 'UPDATER_PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in script
+    assert 'UPDATER_SOURCE_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.yml"' in script
+    assert 'UPDATER_PROD_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.prod.yml"' in script
+    assert '$UPDATER_PROJECT_ROOT/$DEPLOYMENT_ENV_FILE' in script
     assert "updater_socket_health_payload" in script
     assert "refusing duplicate start" in script

--- a/tests/test_version_manager_template.py
+++ b/tests/test_version_manager_template.py
@@ -83,7 +83,7 @@ def test_version_manager_has_accessible_monotonic_progress_modal_and_refresh_gat
         assert f"{state}:" in template or f"{state}]" in template
 
     health_check = template.index("await verifyHealth(target)")
-    clear_job = template.index("sessionStorage.removeItem(JOB_STORAGE_KEY)", health_check)
+    clear_job = template.index("clearPersistedJob();", health_check)
     reload_page = template.index("scheduleRefresh();", health_check)
     assert health_check < clear_job < reload_page
 
@@ -109,7 +109,9 @@ def test_polling_retries_bounded_restart_errors_and_recovers_stale_jobs():
     assert "POLL_RECOVERY_TIMEOUT_MS" in template
     assert "transientFor >= POLL_RECOVERY_TIMEOUT_MS" in template
     assert "transientFor >= HEALTH_RECOVERY_DELAY_MS" in template
-    assert "progressTarget && await verifyHealth(progressTarget)" in template
+    assert "hasExactDigestTarget(progressTarget)" in template
+    assert "await verifyHealth(progressTarget)" in template
+    assert "payload.build.digest !== target.digest" in template
     assert "error instanceof TypeError" in template
     assert "if (isTransientPollError(error))" in template
     assert "continue;" in template
@@ -124,12 +126,28 @@ def test_polling_retries_bounded_restart_errors_and_recovers_stale_jobs():
 
 def test_registry_catalog_disables_the_exact_running_build():
     template = Path("backend/webui/templates/version_manager.html").read_text(encoding="utf-8")
-    assert "const CURRENT_BUILD_REVISION" in template
+    assert "const CURRENT_BUILD_DIGEST" in template
     assert "const CURRENT_BUILD_VERSION" in template
     assert "function isCurrentRegistryImage(image)" in template
-    assert "image.revision === CURRENT_BUILD_REVISION" in template
+    assert "image.digest === CURRENT_BUILD_DIGEST" in template
+    assert "CURRENT_BUILD_REVISION" not in template
+    assert "image.revision ===" not in template
     assert "image.version === CURRENT_BUILD_VERSION" in template
     assert "action.disabled = isCurrent ||" in template
+
+
+def test_persisted_job_recovery_keeps_exact_target_digest_across_reload():
+    template = Path("backend/webui/templates/version_manager.html").read_text(encoding="utf-8")
+    assert "const JOB_TARGET_STORAGE_KEY" in template
+    assert "function normalizedProgressTarget(value)" in template
+    assert "function persistJob(jobId, target)" in template
+    assert "JSON.stringify(normalized)" in template
+    assert "function restoreProgressTarget()" in template
+    assert "progressTarget = restoreProgressTarget();" in template
+    assert "digest: job.target_digest" in template
+    assert "persistJob(data.job_id, progressTarget);" in template
+    assert "persistJob(error.body.job_id, progressTarget);" in template
+    assert "function clearPersistedJob()" in template
 
 
 def test_modal_errors_require_callers_to_choose_whether_retry_is_allowed():

--- a/tests/test_version_manager_template.py
+++ b/tests/test_version_manager_template.py
@@ -116,6 +116,12 @@ def test_polling_retries_bounded_restart_errors_and_recovers_stale_jobs():
     assert "if (isTransientPollError(error))" in template
     assert "continue;" in template
 
+    timeout = template.index("transientFor >= POLL_RECOVERY_TIMEOUT_MS")
+    legacy = template.index("!hasExactDigestTarget(progressTarget)", timeout)
+    preserve = template.index("markProgressError(message, {preserveJob: true});", legacy)
+    bounded_failure = template.index("markProgressError(message);", preserve)
+    assert timeout < legacy < preserve < bounded_failure
+
     permanent_error = template.index("const message = vmFormat(VM_I18N.progressPollFailed")
     terminal = template.index("markProgressError(message);", permanent_error)
     stale = template.index("error.status === 404", terminal)
@@ -155,7 +161,8 @@ def test_modal_errors_require_callers_to_choose_whether_retry_is_allowed():
     start = template.index("function markProgressError(")
     end = template.index("function isTransientPollError(", start)
     function = template[start:end]
-    assert "{allowRetry = false} = {}" in function
+    assert "{allowRetry = false, preserveJob = false} = {}" in function
+    assert "!preserveJob && progressJobId" in function
     assert "updateButton.disabled = !allowRetry" in function
     assert "updateButton.disabled = false" not in function
 

--- a/tests/test_version_manager_template.py
+++ b/tests/test_version_manager_template.py
@@ -102,11 +102,14 @@ def test_version_manager_failure_path_is_closeable_without_refresh():
     assert template.index("markProgressError(") < template.index("scheduleRefresh();")
 
 
-def test_polling_retries_only_transient_errors_and_recovers_stale_jobs():
+def test_polling_retries_bounded_restart_errors_and_recovers_stale_jobs():
     template = Path("backend/webui/templates/version_manager.html").read_text(encoding="utf-8")
     assert "function isTransientPollError(error)" in template
-    assert "error.status === 503" in template
-    assert "errorCode === 'updater_unavailable'" in template
+    assert "[500, 502, 503, 504].includes(error.status)" in template
+    assert "POLL_RECOVERY_TIMEOUT_MS" in template
+    assert "transientFor >= POLL_RECOVERY_TIMEOUT_MS" in template
+    assert "transientFor >= HEALTH_RECOVERY_DELAY_MS" in template
+    assert "progressTarget && await verifyHealth(progressTarget)" in template
     assert "error instanceof TypeError" in template
     assert "if (isTransientPollError(error))" in template
     assert "continue;" in template
@@ -117,6 +120,16 @@ def test_polling_retries_only_transient_errors_and_recovers_stale_jobs():
     readiness = template.index("await loadReadiness();", stale)
     stop = template.index("return;", readiness)
     assert permanent_error < terminal < stale < readiness < stop
+
+
+def test_registry_catalog_disables_the_exact_running_build():
+    template = Path("backend/webui/templates/version_manager.html").read_text(encoding="utf-8")
+    assert "const CURRENT_BUILD_REVISION" in template
+    assert "const CURRENT_BUILD_VERSION" in template
+    assert "function isCurrentRegistryImage(image)" in template
+    assert "image.revision === CURRENT_BUILD_REVISION" in template
+    assert "image.version === CURRENT_BUILD_VERSION" in template
+    assert "action.disabled = isCurrent ||" in template
 
 
 def test_modal_errors_require_callers_to_choose_whether_retry_is_allowed():

--- a/updater/src/sakura_ai_updater/backends/daemon.py
+++ b/updater/src/sakura_ai_updater/backends/daemon.py
@@ -186,20 +186,27 @@ class DaemonBackend:
         compose_file: str | None = None,
         deployment_env: str | None = None,
     ):
-        self.state_dir = state_dir
-        self.socket_path = socket_path
-        self.binary_path = binary_path or os.path.join(state_dir, DEFAULT_BINARY_NAME)
+        # The daemon may outlive a checkout replacement. Freeze every child
+        # filesystem argument before spawning so it never resolves state or
+        # deployment paths through a deleted inherited working directory.
+        self.state_dir = os.path.abspath(state_dir)
+        self.socket_path = os.path.abspath(socket_path)
+        self.binary_path = os.path.abspath(
+            binary_path or os.path.join(self.state_dir, DEFAULT_BINARY_NAME)
+        )
         self.startup_timeout = startup_timeout
         self.stop_timeout = stop_timeout
         self.poll_interval = poll_interval
-        self.run_dir = run_dir
+        self.run_dir = os.path.abspath(run_dir)
         self.gid = gid
         self.group = group
         # These paths are passed explicitly to the child daemon.  ``None`` keeps
         # backwards compatibility for callers that only exercise lifecycle
         # management; production bootstrap supplies absolute configured paths.
-        self.compose_file = compose_file
-        self.deployment_env = deployment_env
+        self.compose_file = os.path.abspath(compose_file) if compose_file is not None else None
+        self.deployment_env = (
+            os.path.abspath(deployment_env) if deployment_env is not None else None
+        )
         # Dev mode: socket 用当前用户 uid/gid（非 root 无法 chown 到 root:9472）
         if os.environ.get("SAKURA_UPDATER_DEV") == "1":
             self._socket_uid = getattr(os, "getuid", lambda: 0)()
@@ -597,6 +604,7 @@ class DaemonBackend:
             try:
                 child = subprocess.Popen(
                     argv,
+                    cwd=os.path.abspath(os.sep),
                     start_new_session=True,
                     shell=False,
                     stdin=subprocess.DEVNULL,

--- a/updater/src/sakura_ai_updater/deployment.py
+++ b/updater/src/sakura_ai_updater/deployment.py
@@ -233,27 +233,17 @@ class DeploymentStateProvider:
         *,
         expected_repository: str,
         expected_tag: str,
+        expected_digest: str | None = None,
     ) -> str:
-        """Select one manifest digest matching the current repository/tag.
+        """Select the registry manifest digest for the deployment image.
 
-        ``RepoTags`` proves that the inspected local image is the image named
-        by deployment.env.  ``RepoDigests`` is the registry identity used for
-        the immutable reference.  Multiple repositories are normal (mirrors),
-        but multiple different digests for the expected repository are
-        ambiguous and therefore fail closed.
+        A digest-pinned deployment is already named by immutable repository and
+        digest identity. Docker is allowed to omit the source tag from
+        ``RepoTags`` after pulling ``tag@digest``, so pinned refs are proven by
+        an exact matching ``RepoDigests`` entry. Mutable tag refs still require
+        both the expected ``RepoTags`` entry and one unambiguous repository
+        digest; they fail closed if either proof is missing.
         """
-
-        tags = metadata.get("RepoTags")
-        if not isinstance(tags, list):
-            raise DeploymentError("docker image metadata has no RepoTags")
-        normalized_tags = {
-            str(tag).strip().lower() for tag in tags if isinstance(tag, str)
-        }
-        if expected_tag.lower() not in normalized_tags:
-            raise DeploymentError(
-                f"running image is not tagged as the deployment image {expected_tag!r}"
-            )
-
         repo_digests = metadata.get("RepoDigests")
         if not isinstance(repo_digests, list):
             raise DeploymentError("docker image metadata has no RepoDigests")
@@ -269,6 +259,31 @@ class DeploymentStateProvider:
                     f"invalid registry digest for {expected_repository!r}: {digest!r}"
                 )
             candidates.add(digest.lower())
+
+        if expected_digest is not None:
+            normalized_expected = expected_digest.lower()
+            if not _REGISTRY_DIGEST_RE.fullmatch(normalized_expected):
+                raise DeploymentError(
+                    f"invalid pinned deployment digest: {expected_digest!r}"
+                )
+            if normalized_expected not in candidates:
+                raise DeploymentError(
+                    f"running repository digests do not match pinned deployment "
+                    f"digest {normalized_expected!r}"
+                )
+            return normalized_expected
+
+        tags = metadata.get("RepoTags")
+        if not isinstance(tags, list):
+            raise DeploymentError("docker image metadata has no RepoTags")
+        normalized_tags = {
+            str(tag).strip().lower() for tag in tags if isinstance(tag, str)
+        }
+        if expected_tag.lower() not in normalized_tags:
+            raise DeploymentError(
+                f"running image is not tagged as the deployment image {expected_tag!r}"
+            )
+
         if len(candidates) != 1:
             if not candidates:
                 raise DeploymentError(
@@ -301,12 +316,8 @@ class DeploymentStateProvider:
             metadata,
             expected_repository=expected_repository,
             expected_tag=expected_tag,
+            expected_digest=expected_digest,
         )
-        if expected_digest is not None and running_digest != expected_digest:
-            raise DeploymentError(
-                f"running manifest digest {running_digest!r} does not match pinned "
-                f"deployment digest {expected_digest!r}"
-            )
         return running_digest
 
     async def materialize_current_anchor(self) -> str:

--- a/updater/src/sakura_ai_updater/jobs.py
+++ b/updater/src/sakura_ai_updater/jobs.py
@@ -9,7 +9,7 @@ import uuid
 from typing import Any
 
 from sakura_ai_updater import PROTOCOL_VERSION
-from sakura_ai_updater.deployment import DeploymentStateProvider
+from sakura_ai_updater.deployment import DeploymentError, DeploymentStateProvider
 from sakura_ai_updater.job_logs import JobLogStore
 from sakura_ai_updater.registry import (
     DevelopmentTarget,
@@ -301,6 +301,35 @@ class JobOrchestrator:
         usage = await asyncio.to_thread(shutil.disk_usage, directory)
         return usage.free >= self.disk_space_threshold, usage.free
 
+    async def _current_state(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Read running image identity as a structured preflight gate.
+
+        Deployment identity failures are expected fail-closed readiness results,
+        not updater protocol crashes. This keeps the IPC response typed and
+        actionable instead of turning a local Docker metadata mismatch into an
+        opaque HTTP 500/Backend 502.
+        """
+
+        state_method = getattr(self.deployment, "current_state", None)
+        if state_method is None:
+            return {}, self._check("current_image_identity_valid", True)
+        try:
+            value = state_method()
+            state = await value if inspect.isawaitable(value) else value
+        except DeploymentError as exc:
+            return {}, self._check(
+                "current_image_identity_valid",
+                False,
+                str(exc),
+            )
+        if not isinstance(state, dict):
+            return {}, self._check(
+                "current_image_identity_valid",
+                False,
+                "current deployment state is malformed",
+            )
+        return state, self._check("current_image_identity_valid", True)
+
     async def preflight(
         self,
         target_version: str | dict[str, Any],
@@ -325,11 +354,8 @@ class JobOrchestrator:
                 self._check("target_identity_valid", True),
                 self._check("target_channel_head", True),
             ]
-            current_state = {}
-            state_method = getattr(self.deployment, "current_state", None)
-            if state_method is not None:
-                value = state_method()
-                current_state = await value if inspect.isawaitable(value) else value
+            current_state, identity_check = await self._current_state()
+            checks.append(identity_check)
             current_channel = current_state.get("current_channel") if isinstance(current_state, dict) else None
             current_digest = current_state.get("running_container_digest") if isinstance(current_state, dict) else None
             same_channel = current_channel == "development"
@@ -395,11 +421,7 @@ class JobOrchestrator:
             current_version = await self.deployment.resolve_current_version()
             min_version = _value(manifest, "min_upgrade_from", "0.0.0")
             mode = self.deployment.read_deploy_mode()
-            current_state = {}
-            state_method = getattr(self.deployment, "current_state", None)
-            if state_method is not None:
-                state_value = state_method()
-                current_state = await state_value if inspect.isawaitable(state_value) else state_value
+            current_state, identity_check = await self._current_state()
             current_channel = current_state.get("current_channel") if isinstance(current_state, dict) else None
             current_digest = current_state.get("running_container_digest") if isinstance(current_state, dict) else None
             requires_confirmation = current_channel != "stable"
@@ -412,6 +434,7 @@ class JobOrchestrator:
             checks: list[dict[str, Any]] = [
                 self._check("manifest_found", True),
                 self._check("manifest_valid", True),
+                identity_check,
                 self._check("deployment_mode_image", mode == "image", f"mode={mode!r}"),
                 self._check(
                     "protocol_compatible",
@@ -770,6 +793,32 @@ class JobOrchestrator:
             else:
                 await self.adapter.health_check(job.target_version)
             self._transition(job, "success", "complete")
+            completed_checks = [
+                {
+                    **item,
+                    "passed": False,
+                    "detail": "target digest is now running",
+                }
+                if item.get("name") in {"target_newer", "already_current"}
+                else dict(item)
+                for item in result["checks"]
+            ]
+            self._remember_readiness(
+                can_update=False,
+                checks=completed_checks,
+                target_version=job.target_version or "",
+                target_image=job.target_image or "",
+                channel=job.target_channel,
+                target_extra={
+                    key: value
+                    for key, value in {
+                        "revision": job.target_revision,
+                        "tag": job.target_tag,
+                        "digest": job.target_digest,
+                    }.items()
+                    if value is not None
+                },
+            )
             self._log(job, "update completed", step="complete")
             self._clear_active_gate(job)
         except asyncio.CancelledError:

--- a/updater/tests/test_daemon_backend.py
+++ b/updater/tests/test_daemon_backend.py
@@ -86,6 +86,7 @@ def _make_backend(tmp_path: Path, **kwargs) -> DaemonBackend:
         "state_dir": str(tmp_path / "state"),
         "socket_path": str(tmp_path / "updater.sock"),
         "binary_path": str(tmp_path / "sakura-ai-updater"),
+        "run_dir": str(tmp_path / "run"),
         "startup_timeout": 0.2,
         "stop_timeout": 0.2,
         "poll_interval": 0.01,
@@ -1269,6 +1270,7 @@ def test_start_binary_mode_passes_serve_args(tmp_path, monkeypatch):
     gid_idx = argv.index("--socket-gid")
     assert argv[gid_idx + 1] == str(daemon_mod.DEFAULT_GID)
     assert popen_kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert popen_kwargs["cwd"] == os.path.abspath(os.sep)
 
 
 def test_start_dev_mode_does_not_force_pyinstaller_reset(tmp_path, monkeypatch):
@@ -1290,3 +1292,4 @@ def test_start_dev_mode_does_not_force_pyinstaller_reset(tmp_path, monkeypatch):
     backend.start()
 
     assert "PYINSTALLER_RESET_ENVIRONMENT" not in popen_kwargs["env"]
+    assert popen_kwargs["cwd"] == os.path.abspath(os.sep)

--- a/updater/tests/test_daemon_serve_args.py
+++ b/updater/tests/test_daemon_serve_args.py
@@ -4,17 +4,43 @@ from sakura_ai_updater.backends.daemon import DaemonBackend
 
 
 def test_serve_args_append_compose_and_deployment_paths(tmp_path):
+    compose_file = str(tmp_path / "docker-compose.prod.yml")
+    deployment_env = str(tmp_path / "deployment.env")
     backend = DaemonBackend(
         state_dir=str(tmp_path / "state"),
         socket_path=str(tmp_path / "updater.sock"),
-        compose_file="/etc/sakura/docker-compose.prod.yml",
-        deployment_env="/etc/sakura/.deploy/deployment.env",
+        compose_file=compose_file,
+        deployment_env=deployment_env,
     )
     args = backend._serve_args()
     assert args[:2] == ["--serve", "--socket-path"]
     assert args[-4:] == [
         "--compose-file",
-        "/etc/sakura/docker-compose.prod.yml",
+        compose_file,
         "--deployment-env",
-        "/etc/sakura/.deploy/deployment.env",
+        deployment_env,
     ]
+
+
+def test_serve_args_freeze_relative_paths_before_checkout_replacement(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    backend = DaemonBackend(
+        state_dir=".deploy/updater",
+        socket_path="run/updater.sock",
+        compose_file="docker/docker-compose.prod.yml",
+        deployment_env=".deploy/deployment.env",
+    )
+    args = backend._serve_args()
+    assert backend.state_dir == str(tmp_path / ".deploy" / "updater")
+    assert backend.socket_path == str(tmp_path / "run" / "updater.sock")
+    assert args[args.index("--lock-path") + 1] == str(
+        tmp_path / ".deploy" / "updater" / "updater.lock"
+    )
+    assert args[args.index("--compose-file") + 1] == str(
+        tmp_path / "docker" / "docker-compose.prod.yml"
+    )
+    assert args[args.index("--deployment-env") + 1] == str(
+        tmp_path / ".deploy" / "deployment.env"
+    )

--- a/updater/tests/test_deployment.py
+++ b/updater/tests/test_deployment.py
@@ -290,8 +290,46 @@ async def test_pinned_digest_must_match_running_manifest(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-    with pytest.raises(DeploymentError, match="does not match pinned"):
+    with pytest.raises(DeploymentError, match="do not match pinned"):
         await DeploymentStateProvider(str(env)).capture_from_digest()
+
+
+@pytest.mark.asyncio
+async def test_pinned_digest_does_not_require_docker_to_retain_source_tag(
+    tmp_path, monkeypatch
+):
+    """Docker may expose only repository@digest after pulling tag@digest."""
+
+    digest = "sha256:" + "a" * 64
+    image_id = "sha256:" + "b" * 64
+    env = tmp_path / "deployment.env"
+    env.write_text(
+        f"SAKURA_AI_IMAGE=ghcr.io/example/app:dev-build@{digest}\n",
+        encoding="utf-8",
+    )
+
+    async def fake_exec(*argv, **kwargs):
+        command = tuple(argv)
+        if command == ("docker", "inspect", "--format={{.Image}}", "sakura-ai"):
+            return _Process(image_id.encode() + b"\n")
+        assert command == (
+            "docker",
+            "image",
+            "inspect",
+            "--format={{json .}}",
+            image_id,
+        )
+        return _Process(
+            json.dumps(
+                {
+                    "RepoTags": [f"ghcr.io/example/app@{digest}"],
+                    "RepoDigests": [f"ghcr.io/example/app@{digest}"],
+                }
+            ).encode()
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await DeploymentStateProvider(str(env)).capture_from_digest() == digest
 
 
 def test_select_registry_digest_ignores_other_repository_entries():

--- a/updater/tests/test_development_contract.py
+++ b/updater/tests/test_development_contract.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 from sakura_ai_updater.adapters.image import HealthCheckVersionMismatch, ImageAdapter
+from sakura_ai_updater.deployment import DeploymentError
 from sakura_ai_updater.jobs import JobOrchestrator
 from sakura_ai_updater.state import load_state
 
@@ -131,6 +132,11 @@ class _UnknownChannelDeployment(_Deployment):
         return {}
 
 
+class _InvalidImageIdentityDeployment(_Deployment):
+    async def current_state(self):
+        raise DeploymentError("running image has no matching repository digest")
+
+
 @pytest.mark.asyncio
 async def test_same_development_digest_is_not_updateable(monkeypatch, tmp_path):
     async def verify(self, target):
@@ -146,6 +152,34 @@ async def test_same_development_digest_is_not_updateable(monkeypatch, tmp_path):
     ).preflight(_target())
     assert result["can_update"] is False
     assert any(item["name"] == "target_newer" and not item["passed"] for item in result["checks"])
+
+
+@pytest.mark.asyncio
+async def test_deployment_identity_error_is_a_failed_check_not_protocol_error(
+    monkeypatch, tmp_path
+):
+    async def verify(self, target):
+        return target
+
+    monkeypatch.setattr("sakura_ai_updater.jobs.RegistryClient.verify_target", verify)
+    result = await JobOrchestrator(
+        str(tmp_path / "state.json"),
+        _Adapter(),
+        object(),
+        _InvalidImageIdentityDeployment(),
+        disk_space_threshold=1,
+    ).preflight(_target(), confirm_channel_switch=True)
+
+    identity = next(
+        item for item in result["checks"]
+        if item["name"] == "current_image_identity_valid"
+    )
+    assert result["can_update"] is False
+    assert identity == {
+        "name": "current_image_identity_valid",
+        "passed": False,
+        "detail": "running image has no matching repository digest",
+    }
 
 
 @pytest.mark.asyncio

--- a/updater/tests/test_jobs.py
+++ b/updater/tests/test_jobs.py
@@ -134,6 +134,10 @@ async def test_update_success_clears_active_gate(tmp_path):
     assert store.current_job.started_at and store.current_job.started_at.endswith("Z")
     assert store.current_job.updated_at and store.current_job.updated_at.endswith("Z")
     assert [call[0] for call in adapter.calls] == ["preflight", "preflight", "pull", "activate", "health"]
+    assert orchestrator.readiness_snapshot is not None
+    assert orchestrator.readiness_snapshot["update_ready"] is False
+    assert orchestrator.readiness_snapshot["readiness"]["target_newer"] is False
+    assert orchestrator.readiness_snapshot["target"]["version"] == "3.1.0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- accept Docker runtime identity for digest-pinned `tag@digest` deployments even when Docker does not retain the source tag in `RepoTags`
- return running-image identity failures as structured fail-closed preflight checks instead of opaque updater HTTP 500 / Backend 502 responses
- clear stale update availability after a successful channel switch and disable the exact running image in the GHCR catalog
- preserve accepted update jobs across bounded Web/reverse-proxy 500/502/503/504 restart windows, with channel/version/revision health verification before refresh
- normalize Host Updater child paths to absolute paths, detach its cwd from the checkout, and refuse duplicate startup when a live Unix socket has lost daemon metadata

## Root cause

A development image is activated as an immutable `repository:dev-tag@sha256:...` reference. Docker may later report only `repository@sha256:...` for that local image. The updater previously required the original development tag to remain in `RepoTags`, so every current-channel readiness request raised an internal error after a successful switch. Separately, Web container restart responses were treated as terminal polling failures, and updater readiness retained the pre-update `target_newer=true` snapshot.

## Validation

- `python -m pytest -q` — 2009 passed, 10 skipped
- `python -m pytest updater/tests -q` — 246 passed, 8 skipped
- `python run_ruff.py --check` — passed
- `bash tests/test_start_sh_updater.sh` — 64 passed
- `bash -n start.sh` — passed
- `git diff --check` — passed

## Deployment impact

- No database migration or database compatibility work is required.
- Publish/install the Host Updater asset built from this hotfix together with the application release.
- Future updater children use absolute state/Compose/deployment paths and a stable root cwd.
- If an existing host already has a live updater socket whose daemon metadata was deleted with an old checkout, startup now fails closed instead of spawning a competing daemon. Stop only the verified listener PID, then run `sudo ./start.sh updater install` followed by `sudo ./start.sh updater start`.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本 PR 修复了开发频道更新失效问题，通过镜像摘要验证机制确保更新可靠性，并解决了遗留更新任务的兼容性问题。

**主要改动**
- **核心修复**：增强 `build_info.py` 支持镜像摘要验证；修复 WebUI 以保留遗留更新任务，确保流程兼容。
- **前端优化**：调整版本管理页面模板（`version_manager.html`）逻辑，并新增相关中英文翻译。
- **脚本与测试**：优化启动脚本（`start.sh`）参数处理，新增及完善多项测试用例以提升代码健壮性。

**影响范围**
主要影响系统更新模块、版本管理界面、启动流程及多语言支持。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/core/build_info.py"]
    N2["tests/test_build_info.py"]
    N3["updater/src/sakura_ai_updater/backends/daemon.py"]
    N4["updater/src/sakura_ai_updater/deployment.py"]
    N5["updater/src/sakura_ai_updater/jobs.py"]
    N6["updater/tests/test_daemon_backend.py"]
    N7["updater/tests/test_daemon_serve_args.py"]
    N8["updater/tests/test_deployment.py"]
    N9["updater/tests/test_development_contract.py"]
    N10["updater/tests/test_jobs.py"]
    N11["tests/test_version_manager_template.py"]
    N2 --> N1
    N5 --> N3
    N5 --> N4
    N6 --> N3
    N7 --> N3
    N8 --> N4
    N9 --> N4
    N9 --> N5
    N10 --> N5
```

<!-- sakura-ai-depgraph-end -->