### PR TITLE
docs: update README to version 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [English](README_EN.md) | **中文**
 
-[![Version](https://img.shields.io/badge/Version-3.1.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
+[![Version](https://img.shields.io/badge/Version-3.1.2-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
 [![CI](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.14+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
@@ -169,18 +169,22 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`sudo ./start.sh --prod` 会自动生成部署状态、启动全部容器，并为当前版本下载、校验和启动 Host Updater。新版本会自动检查，但更新需超级管理员在 WebUI 版本管理器中手动确认，不会无人值守安装。macOS、Windows 和仅容器部署不支持 Host Updater；部署目录、Compose 项目名与安全校验等细节详见[部署指南](docs/DEPLOYMENT.md)。
+`sudo ./start.sh --prod` 会自动生成部署状态、通过 Docker 原生动态进度条拉取镜像、启动全部容器，并为当前版本下载、校验和启动 Host Updater。按 `Ctrl+C` 只退出进度查看，后台部署仍会继续。新版本会自动检查，但更新需超级管理员在 WebUI 版本管理器中手动确认，不会无人值守安装。macOS、Windows 和仅容器部署不支持 Host Updater；部署目录、Compose 项目名与安全校验等细节详见[部署指南](docs/DEPLOYMENT.md)。
 
 > **WebUI 更新后的 Updater 同步：** WebUI 当前只更新 Sakura AI 应用镜像，不会替换宿主机上的 Host Updater；就绪项“Updater 文件可用”仅表示目标 Release 包含对应二进制与校验文件。应用更新完成并确认 `/health` 已返回新版本后，在 `/opt/sakura-ai` 执行以下命令，使 Updater 与当前应用 Release 保持一致：
 >
 > ```bash
-> sudo ./start.sh updater stop
-> sudo ./start.sh updater install
-> sudo ./start.sh updater start
-> sudo ./start.sh updater status
+> sudo ./start.sh updater reinstall
 > ```
 >
-> `install` 会按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行 `install`。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
+> `reinstall` 会拒绝与仍在后台运行的部署或活动更新任务竞态，随后依次停止、安装、启动并输出新状态。安装器按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
+
+卸载默认保留数据库等 Docker 数据卷；只有显式 `--purge` 才会删除数据卷和 `.deploy` 部署状态：
+
+```bash
+sudo ./start.sh uninstall          # 保留数据，可重新部署
+sudo ./start.sh uninstall --purge  # 永久删除数据库/缓存卷与部署状态
+```
 
 **仅 Web 镜像**（MySQL/Redis 自备）：
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ sudo ./start.sh --prod
 > sudo ./start.sh updater reinstall
 > ```
 >
-> `reinstall` 会拒绝与仍在后台运行的部署或活动更新任务竞态，随后依次停止、安装、启动并输出新状态。安装器按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
+> `reinstall` 会先通过 updater 内部锁原子关闭新任务提交并确认没有活动任务，再依次停止、安装、启动并输出新状态；安装失败时会尝试恢复原有 daemon。旧版 updater 若不支持原子维护门禁，命令会 fail-closed，并要求管理员先显式停止旧 daemon。安装器按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
 
 卸载默认保留数据库等 Docker 数据卷；只有显式 `--purge` 才会删除数据卷和 `.deploy` 部署状态：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 
 **English** | [中文](README.md)
 
-[![Version](https://img.shields.io/badge/Version-3.1.1-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
+[![Version](https://img.shields.io/badge/Version-3.1.2-blue.svg)](https://github.com/Sakura520222/Sakura-AI/releases)
 [![CI](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/Sakura520222/Sakura-AI/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.14+-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-Latest-green.svg)](https://fastapi.tiangolo.com/)
@@ -169,18 +169,22 @@ cd /opt/sakura-ai
 sudo ./start.sh --prod
 ```
 
-`sudo ./start.sh --prod` generates the deployment state, starts all containers, and downloads, verifies, and starts the Host Updater for the running version. New releases are checked automatically, but installation requires manual confirmation by a super administrator in the WebUI Version Manager. macOS, Windows, and container-only deployments do not support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md) for deployment directory, Compose project name, and security checks.
+`sudo ./start.sh --prod` generates the deployment state, pulls images with Docker's native dynamic progress renderer, starts all containers, and downloads, verifies, and starts the Host Updater for the running version. Pressing `Ctrl+C` only detaches the progress view; deployment continues in the background. New releases are checked automatically, but installation requires manual confirmation by a super administrator in the WebUI Version Manager. macOS, Windows, and container-only deployments do not support the Host Updater; see the [Deployment Guide](docs/DEPLOYMENT.md) for deployment directory, Compose project name, and security checks.
 
 > **Synchronizing Host Updater after a WebUI update:** The WebUI currently updates only the Sakura AI application image; it does not replace the Host Updater binary on the host. The readiness item “Updater asset available” only confirms that the target Release contains the architecture-specific binary and checksum file. After the application update succeeds and `/health` reports the new version, run the following commands in `/opt/sakura-ai` to align Host Updater with the running application Release:
 >
 > ```bash
-> sudo ./start.sh updater stop
-> sudo ./start.sh updater install
-> sudo ./start.sh updater start
-> sudo ./start.sh updater status
+> sudo ./start.sh updater reinstall
 > ```
 >
-> `install` selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not run `install` if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
+> `reinstall` refuses to race a deployment that is still running in the background or an active update job, then stops, installs, starts, and reports the new daemon state in order. The installer selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not continue if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
+
+Uninstall preserves Docker data volumes by default. Only explicit `--purge` removes the volumes and `.deploy` state:
+
+```bash
+sudo ./start.sh uninstall          # Preserve data for a later redeployment
+sudo ./start.sh uninstall --purge  # Permanently delete database/cache volumes and deployment state
+```
 
 **Web image only** (bring your own MySQL/Redis):
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -177,7 +177,7 @@ sudo ./start.sh --prod
 > sudo ./start.sh updater reinstall
 > ```
 >
-> `reinstall` refuses to race a deployment that is still running in the background or an active update job, then stops, installs, starts, and reports the new daemon state in order. The installer selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not continue if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
+> `reinstall` first uses the updater's internal lock to atomically close new submissions and prove that no job is active, then stops, installs, starts, and reports the new daemon state; if installation fails, it attempts to restore the existing daemon. If an older updater does not support the atomic maintenance gate, the command fails closed and requires the administrator to stop that legacy daemon explicitly first. The installer selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not continue if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
 
 Uninstall preserves Docker data volumes by default. Only explicit `--purge` removes the volumes and `.deploy` state:
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,3 @@
 """Sakura AI Backend"""
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -798,7 +798,7 @@ async def insert_default_configs_async():
         raise RuntimeError("异步会话工厂未初始化,请先调用 init_async_db()")
 
     default_configs = [
-        AppConfig(key_name="app_version", key_value="3.1.1", description="应用版本号"),
+        AppConfig(key_name="app_version", key_value="3.1.2", description="应用版本号"),
         AppConfig(
             key_name="max_concurrent_reviews",
             key_value="5",
@@ -944,7 +944,7 @@ def init_database(database_url: str):
 
             default_configs = [
                 AppConfig(
-                    key_name="app_version", key_value="3.1.1", description="应用版本号"
+                    key_name="app_version", key_value="3.1.2", description="应用版本号"
                 ),
                 AppConfig(
                     key_name="max_concurrent_reviews",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -350,7 +350,8 @@ Host updater 是一个独立的 Linux 宿主守护进程。Backend 会定期检�
 
 action 默认为 `status`，即 `./start.sh updater` 等价于 `./start.sh updater status`。
 
-- `reinstall` 是推荐的同步命令：先确认没有后台部署和活动更新任务，再停止已验证的 daemon、原子安装对应 Release 的 binary、重新启动并输出状态。这样可避免后台 `start.sh --prod` 在手工 `stop/install/start` 之间重新拉起 daemon 的竞态。
+- `reinstall` 是推荐的同步命令：先确认没有后台部署，再通过 updater 内部锁原子关闭新任务提交并确认没有活动任务，然后停止已验证的 daemon、原子安装对应 Release 的 binary、重新启动并输出状态。安装或校验失败时会尝试用保留的安全 binary 恢复原 daemon。这样既避免检查任务与停止 daemon 之间的竞态，也避免后台 `start.sh --prod` 在手工 `stop/install/start` 之间重新拉起 daemon。
+- 不支持 `/v1/lifecycle/prepare-stop` 的旧 daemon 无法提供原子任务门禁，`reinstall` 会 fail-closed。升级这类旧版本时，应先在 WebUI 确认没有活动任务，再显式执行 `sudo ./start.sh updater stop`，随后执行 `install` 和 `start`；新 daemon 启动后即可使用一体化 `reinstall`。
 - `uninstall` 只删除已验证 updater 的 binary、daemon metadata、日志、锁和任务状态；若 socket 仍由无法验证身份的监听者占用，会 fail-closed 并要求管理员先检查监听进程，不会盲目 kill。
 
 ### WebUI 更新后同步 Host Updater

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -345,10 +345,13 @@ Host updater 是一个独立的 Linux 宿主守护进程。Backend 会定期检�
 通过 `start.sh` 脚本管理 updater 守护进程：
 
 ```bash
-./start.sh updater install|start|stop|status
+./start.sh updater install|reinstall|uninstall|start|stop|status
 ```
 
 action 默认为 `status`，即 `./start.sh updater` 等价于 `./start.sh updater status`。
+
+- `reinstall` 是推荐的同步命令：先确认没有后台部署和活动更新任务，再停止已验证的 daemon、原子安装对应 Release 的 binary、重新启动并输出状态。这样可避免后台 `start.sh --prod` 在手工 `stop/install/start` 之间重新拉起 daemon 的竞态。
+- `uninstall` 只删除已验证 updater 的 binary、daemon metadata、日志、锁和任务状态；若 socket 仍由无法验证身份的监听者占用，会 fail-closed 并要求管理员先检查监听进程，不会盲目 kill。
 
 ### WebUI 更新后同步 Host Updater
 
@@ -361,13 +364,10 @@ cd /opt/sakura-ai
 curl --fail --silent --show-error http://localhost:8000/health
 ```
 
-只有人工确认上述响应中的 `version` 等于 WebUI 更新的目标版本后，才能停止旧 daemon、安装 updater，再启动并验证：
+只有人工确认上述响应中的 `version` 等于 WebUI 更新的目标版本后，才能重新安装 updater：
 
 ```bash
-sudo ./start.sh updater stop
-sudo ./start.sh updater install
-sudo ./start.sh updater start
-sudo ./start.sh updater status
+sudo ./start.sh updater reinstall
 
 sudo curl --fail --silent --show-error \
   --unix-socket /run/sakura-ai/updater.sock \
@@ -400,12 +400,10 @@ sudo ./start.sh updater start     # 启动守护进程
 - 下载、checksum、chmod、临时文件 fsync 或临时文件安全检查等 pre-commit 失败时，旧 binary 保持 byte-for-byte unchanged。
 - atomic rename 之后，如果目录 metadata fsync 或 final safety confirmation 失败，则不得声称旧 binary 未变，必须提示新 inode 可能已经安装，且不会继续调用 backend install。只有 post-commit 检查成功后才完成 backend bootstrap。
 
-Linux 原子替换 binary 后，已经运行的 daemon 会继续使用旧 inode，不会自动切换到新版本。重复安装时推荐先停止 daemon，再安装和启动：
+Linux 原子替换 binary 后，已经运行的 daemon 会继续使用旧 inode，不会自动切换到新版本。重复安装时推荐使用带竞态门禁的一体化命令：
 
 ```bash
-sudo ./start.sh updater stop
-sudo ./start.sh updater install
-sudo ./start.sh updater start
+sudo ./start.sh updater reinstall
 ```
 
 如果已经在 daemon 运行期间执行了 `install`，则至少需要显式重启：
@@ -429,6 +427,27 @@ SAKURA_UPDATER_DEV=1 SAKURA_UPDATER_PYTHON=/path/to/python ./start.sh updater st
 - 生产部署必须位于 root-owned、group/other 不可写的目录链中；推荐固定使用 `/opt/sakura-ai`。updater 启动时会对 binary、Compose 和 `deployment.env` 逐级 `lstat` 并 fail-closed，拒绝 symlink、非 root owner、共享写权限或非 `0600` 的部署状态
 - updater 不依赖 systemd 或 cron 自启；宿主机重启后，在 `/opt/sakura-ai` 运行 `sudo ./start.sh updater start`，或再次执行 `sudo ./start.sh --prod`。`start` 会重新创建 tmpfs 中消失的 `/run/sakura-ai` 后再拉起 daemon；这只恢复更新服务，不会自动安装应用更新
 
+## 十、卸载
+
+默认卸载会停止仍在后台运行的部署 runner，确认没有活动 updater 更新任务，删除 Compose 容器/网络并卸载 Host Updater，但保留 MySQL、Redis、配置、ChromaDB、日志、工作区和 Skills 等 Docker 数据卷，同时保留 `.deploy/deployment.env`，方便以后用原密码和原数据重新部署：
+
+```bash
+cd /opt/sakura-ai
+sudo ./start.sh uninstall
+```
+
+命令会要求输入 `UNINSTALL`。自动化环境必须显式传入 `--yes`，不会因为 stdin 非交互而默认确认。
+
+完全清理必须显式使用 `--purge` 并输入 `PURGE SAKURA-AI`：
+
+```bash
+sudo ./start.sh uninstall --purge
+```
+
+`--purge` 会永久删除 Compose 数据卷（包括 MySQL/Redis 数据）以及 `.deploy` 部署状态，无法由脚本恢复。项目源码、脚本和宿主机 bind-mount 目录不会自动递归删除；脚本会输出项目路径，管理员检查后再自行处理。可审计的非交互清理需要同时提供 `--purge --yes`。
+
+生产部署的镜像拉取在后台 runner 中使用 Docker Compose 原生 TTY 进度渲染器。`Ctrl+C` 只退出 `tail` 查看，拉取与启动继续运行；重新连接后可用 `./start.sh --attach` 继续查看，或用 `./start.sh --status` 查看当前 `pull/start/health` 阶段。若宿主 Compose 版本不支持 `--progress`，脚本会明确警告并回退到普通拉取输出。
+
 ---
 
-*最后更新：2026-8-13 · 发现错误？[提 Issue](https://github.com/Sakura520222/Sakura-AI/issues)*
+*最后更新：2026-8-15 · 发现错误？[提 Issue](https://github.com/Sakura520222/Sakura-AI/issues)*

--- a/start.sh
+++ b/start.sh
@@ -35,6 +35,7 @@ BUILD_LOG="$DEPLOY_DIR/build.log"
 PHASE_FILE="$DEPLOY_DIR/phase"         # 当前阶段: preflight / build / pip / pull / start / health / done
 PHASE_RESULT="$DEPLOY_DIR/phase_result" # 上一阶段结果: ok / fail
 PID_FILE="$DEPLOY_DIR/build.pid"
+RUNNER_IDENTITY_FILE="$DEPLOY_DIR/build-runner.identity"
 HASH_FILE="$DEPLOY_DIR/requirements.hash"
 DOCKERFILE_HASH_FILE="$DEPLOY_DIR/dockerfile.hash"
 HEALTH_TIMEOUT=90
@@ -64,8 +65,105 @@ set_phase() {
 get_phase()  { cat "$PHASE_FILE" 2>/dev/null || echo "none"; }
 get_result() { cat "$PHASE_RESULT" 2>/dev/null || echo ""; }
 
+runner_pid_file_path() {
+    if [[ "$PID_FILE" == /* ]]; then
+        printf '%s\n' "$PID_FILE"
+    else
+        printf '%s/%s\n' "$UPDATER_PROJECT_ROOT" "$PID_FILE"
+    fi
+}
+
+runner_identity_file_path() {
+    if [[ "$RUNNER_IDENTITY_FILE" == /* ]]; then
+        printf '%s\n' "$RUNNER_IDENTITY_FILE"
+    else
+        printf '%s/%s\n' "$UPDATER_PROJECT_ROOT" "$RUNNER_IDENTITY_FILE"
+    fi
+}
+
+runner_read_pid() {
+    local pid pid_file
+    pid_file=$(runner_pid_file_path) || return 1
+    [[ -f "$pid_file" ]] || return 1
+    pid=$(cat "$pid_file" 2>/dev/null) || return 1
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$pid"
+}
+
+runner_pid_is_live() {
+    local pid
+    pid=$(runner_read_pid) || return 1
+    kill -0 "$pid" 2>/dev/null
+}
+
+runner_process_starttime() {
+    local pid="$1" stat_line fields
+    [[ -r "/proc/$pid/stat" ]] || return 1
+    IFS= read -r stat_line < "/proc/$pid/stat" || return 1
+    [[ "$stat_line" == *") "* ]] || return 1
+    fields="${stat_line##*) }"
+    # After pid/comm, field 3 is the first token; starttime is field 22.
+    set -- $fields
+    [[ $# -ge 20 && "${20}" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "${20}"
+}
+
+runner_process_command_matches() {
+    local pid="$1" expected_runner="$2" arg
+    local -a argv=()
+    [[ -r "/proc/$pid/cmdline" ]] || return 1
+    while IFS= read -r -d '' arg; do
+        argv+=("$arg")
+    done < "/proc/$pid/cmdline"
+    [[ ${#argv[@]} -ge 2 ]] || return 1
+    [[ "${argv[0]##*/}" == "bash" && "${argv[1]}" == "$expected_runner" ]]
+}
+
+runner_identity_matches() {
+    local pid expected_starttime expected_runner current_starttime identity_file
+    pid=$(runner_read_pid) || return 1
+    identity_file=$(runner_identity_file_path) || return 1
+    [[ -f "$identity_file" ]] || return 1
+    {
+        IFS= read -r expected_starttime
+        IFS= read -r expected_runner
+    } < "$identity_file" || return 1
+    [[ "$expected_starttime" =~ ^[0-9]+$ && -n "$expected_runner" ]] || return 1
+    current_starttime=$(runner_process_starttime "$pid") || return 1
+    [[ "$current_starttime" == "$expected_starttime" ]] || return 1
+    runner_process_command_matches "$pid" "$expected_runner"
+}
+
+runner_write_identity() {
+    local pid="$1" expected_runner="$2" starttime="" identity_file tmp attempts=0
+    # setsid/nohup exec into bash asynchronously. Wait only for the exact child
+    # identity; a dead or different PID never gets recorded as the runner.
+    while [[ "$attempts" -lt 50 ]]; do
+        if starttime=$(runner_process_starttime "$pid") \
+            && runner_process_command_matches "$pid" "$expected_runner"; then
+            break
+        fi
+        kill -0 "$pid" 2>/dev/null || return 1
+        sleep 0.02
+        attempts=$((attempts + 1))
+    done
+    [[ -n "$starttime" && "$attempts" -lt 50 ]] || return 1
+    identity_file=$(runner_identity_file_path) || return 1
+    tmp="$identity_file.tmp.$$"
+    if ! printf '%s\n%s\n' "$starttime" "$expected_runner" > "$tmp"; then
+        rm -f -- "$tmp"
+        return 1
+    fi
+    mv -f -- "$tmp" "$identity_file"
+    runner_identity_matches
+}
+
+clear_runner_identity() {
+    rm -f -- "$(runner_pid_file_path)" "$(runner_identity_file_path)"
+}
+
 is_running() {
-    [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
+    runner_identity_matches
 }
 
 wait_for_pid() {
@@ -355,20 +453,25 @@ updater_health_payload() {
 # application /health check above: a live UDS listener without matching daemon
 # metadata indicates a checkout-replacement orphan and must block a duplicate
 # start instead of racing to unlink or bind the same socket.
-updater_socket_health_payload() {
-    curl --fail --silent --show-error \
+# Lifecycle safety needs a transport probe, not a health check. Any listener
+# that completes an HTTP exchange is live even when it returns 404 or 500.
+updater_socket_listener_responds() {
+    local http_status curl_rc=0
+    if http_status=$(curl --silent --show-error \
         --connect-timeout 2 --max-time 5 \
+        --output /dev/null --write-out '%{http_code}' \
         --unix-socket "$UPDATER_SOCKET_PATH" \
         --header 'Accept: application/json' \
-        http://localhost/v1/health
-}
-
-updater_socket_status_payload() {
-    curl --fail --silent --show-error \
-        --connect-timeout 2 --max-time 5 \
-        --unix-socket "$UPDATER_SOCKET_PATH" \
-        --header 'Accept: application/json' \
-        http://localhost/v1/status
+        http://localhost/v1/health); then
+        [[ "$http_status" =~ ^[0-9]{3}$ && "$http_status" != "000" ]]
+        return $?
+    else
+        curl_rc=$?
+    fi
+    # curl 7 is a failed connect (no listener/stale socket). Once a connection
+    # was accepted, malformed, reset, empty, or timed-out HTTP is still proof
+    # of a live listener and lifecycle operations must fail closed.
+    [[ "$curl_rc" -ne 7 ]]
 }
 
 updater_require_root() {
@@ -381,13 +484,7 @@ updater_require_root() {
 }
 
 updater_deployment_is_running() {
-    local pid_file="$PID_FILE" pid
-    if [[ "$pid_file" != /* ]]; then
-        pid_file="$UPDATER_PROJECT_ROOT/$pid_file"
-    fi
-    [[ -f "$pid_file" ]] || return 1
-    pid=$(cat "$pid_file" 2>/dev/null) || return 1
-    [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null
+    runner_identity_matches
 }
 
 updater_require_idle_deployment() {
@@ -396,20 +493,40 @@ updater_require_idle_deployment() {
         fail "wait for ./start.sh --status to finish, or explicitly stop it with ./start.sh --stop" >&2
         return 1
     fi
+    if runner_pid_is_live; then
+        fail "build.pid refers to a live process whose runner identity cannot be verified" >&2
+        fail "refusing updater lifecycle changes without matching starttime and command metadata" >&2
+        return 1
+    fi
 }
 
-updater_require_no_active_job() {
-    local payload
-    if ! updater_socket_health_payload >/dev/null 2>&1; then
+updater_prepare_stop() {
+    if ! updater_socket_listener_responds; then
         return 0
     fi
-    if ! payload=$(updater_socket_status_payload 2>/dev/null); then
-        fail "updater is live but its job state cannot be inspected; refusing lifecycle change" >&2
+    if curl --fail --silent --show-error \
+        --connect-timeout 2 --max-time 5 \
+        --request POST \
+        --unix-socket "$UPDATER_SOCKET_PATH" \
+        --header 'Accept: application/json' \
+        http://localhost/v1/lifecycle/prepare-stop >/dev/null; then
+        return 0
+    fi
+    if updater_socket_listener_responds; then
+        fail "updater refused the atomic lifecycle gate; an update may be active or the daemon is incompatible" >&2
+        fail "wait for active updates to finish; older daemons must be stopped explicitly before replacement" >&2
         return 1
     fi
-    if [[ "$payload" =~ \"has_active_job\"[[:space:]]*:[[:space:]]*true ]]; then
-        fail "an updater job is active; wait for it to finish before reinstalling or uninstalling" >&2
-        return 1
+}
+
+updater_cancel_stop() {
+    if updater_socket_listener_responds; then
+        curl --fail --silent --show-error \
+            --connect-timeout 2 --max-time 5 \
+            --request POST \
+            --unix-socket "$UPDATER_SOCKET_PATH" \
+            --header 'Accept: application/json' \
+            http://localhost/v1/lifecycle/cancel-stop >/dev/null 2>&1 || true
     fi
 }
 
@@ -971,11 +1088,15 @@ stop_verified_updater() {
         updater_backend stop \
             --state-dir "$UPDATER_STATE_DIR" \
             --socket-path "$UPDATER_SOCKET_PATH" || return $?
+    elif [[ "${SAKURA_UPDATER_DEV:-0}" == "1" ]] && ! updater_path_exists "$binary"; then
+        updater_backend stop \
+            --state-dir "$UPDATER_STATE_DIR" \
+            --socket-path "$UPDATER_SOCKET_PATH" || return $?
     elif updater_path_exists "$binary"; then
         fail "refusing to execute unsafe updater binary while stopping: $binary" >&2
         return 126
     fi
-    if updater_socket_health_payload >/dev/null 2>&1; then
+    if updater_socket_listener_responds; then
         fail "updater socket is still live after stop; refusing to replace or remove files" >&2
         fail "inspect the verified listener with: sudo ss -xlpn | grep -F '$UPDATER_SOCKET_PATH'" >&2
         return 1
@@ -983,12 +1104,38 @@ stop_verified_updater() {
 }
 
 cmd_updater_reinstall() {
+    local was_running=0 install_rc=0 start_rc=0 stop_rc=0
     updater_require_root || return $?
     updater_require_idle_deployment || return $?
-    updater_require_no_active_job || return $?
-    stop_verified_updater || return $?
-    cmd_updater_install || return $?
-    ensure_updater_running || return $?
+    if updater_socket_listener_responds; then
+        was_running=1
+    fi
+    updater_prepare_stop || return $?
+    if stop_verified_updater; then
+        :
+    else
+        stop_rc=$?
+        updater_cancel_stop
+        return "$stop_rc"
+    fi
+    if cmd_updater_install; then
+        :
+    else
+        install_rc=$?
+        if [[ "$was_running" -eq 1 ]]; then
+            warn "updater reinstallation failed; restarting the preserved installed binary" >&2
+            if ! ensure_updater_running; then
+                fail "updater reinstallation failed and the preserved daemon could not be restarted" >&2
+            fi
+        fi
+        return "$install_rc"
+    fi
+    if ensure_updater_running; then
+        :
+    else
+        start_rc=$?
+        return "$start_rc"
+    fi
     ok "updater 已重新安装并启动"
     updater_backend status \
         --state-dir "$UPDATER_STATE_DIR" \
@@ -996,16 +1143,23 @@ cmd_updater_reinstall() {
 }
 
 cmd_updater_uninstall() {
+    local stop_rc=0
     local binary="${UPDATER_BINARY:-$UPDATER_STATE_DIR/sakura-ai-updater}"
     updater_require_root || return $?
     updater_require_idle_deployment || return $?
-    updater_require_no_active_job || return $?
     updater_existing_state_dir_is_safe || return $?
     if [[ "$binary" != "$UPDATER_STATE_DIR/sakura-ai-updater" ]]; then
         fail "refusing unexpected updater binary path during uninstall: $binary" >&2
         return 1
     fi
-    stop_verified_updater || return $?
+    updater_prepare_stop || return $?
+    if stop_verified_updater; then
+        :
+    else
+        stop_rc=$?
+        updater_cancel_stop
+        return "$stop_rc"
+    fi
 
     # Only exact, updater-owned paths under the verified state directory are removed.
     rm -f -- \
@@ -1029,7 +1183,7 @@ ensure_updater_running() {
         --socket-path "$UPDATER_SOCKET_PATH" >/dev/null 2>&1; then
         return 0
     fi
-    if updater_socket_health_payload >/dev/null 2>&1; then
+    if updater_socket_listener_responds; then
         fail "updater socket is live but daemon metadata is missing or stale; refusing duplicate start" >&2
         fail "stop the verified listener process, then run: sudo ./start.sh updater install && sudo ./start.sh updater start" >&2
         return 1
@@ -1141,9 +1295,13 @@ detect_compose() {
 # ============================================================
 
 cmd_status() {
-    local build_active=0
+    local build_active=0 runner_verified=0
     if is_running; then
         build_active=1
+        runner_verified=1
+    elif runner_pid_is_live; then
+        build_active=1
+        warn "build.pid is live but runner identity is unverified; lifecycle signals are disabled"
     fi
 
     # updater daemon 状态快照。构建仍在运行或应用尚未健康时只报告状态，不提前
@@ -1176,7 +1334,7 @@ cmd_status() {
 
     if [[ "$build_active" -eq 1 ]]; then
         local pid
-        pid=$(cat "$PID_FILE")
+        pid=$(runner_read_pid)
         local phase
         phase=$(get_phase)
         echo ""
@@ -1188,6 +1346,9 @@ cmd_status() {
         echo "──────────────────────────"
         echo ""
         echo "💡 使用 ./start.sh --attach 查看完整实时日志"
+        if [[ "$runner_verified" -ne 1 ]]; then
+            warn "该进程缺少匹配的 starttime/command 元数据；请人工检查，脚本不会向其发送信号"
+        fi
     else
         local phase result
         phase=$(get_phase)
@@ -1211,6 +1372,10 @@ cmd_status() {
 
 cmd_attach() {
     if ! is_running; then
+        if runner_pid_is_live; then
+            fail "build.pid refers to a live process whose runner identity cannot be verified"
+            exit 1
+        fi
         fail "没有正在进行的构建进程"
         exit 1
     fi
@@ -1226,20 +1391,30 @@ cmd_attach() {
 
 cmd_stop() {
     if ! is_running; then
+        if runner_pid_is_live; then
+            fail "build.pid refers to a live process whose runner identity cannot be verified"
+            exit 1
+        fi
         fail "没有正在进行的构建进程"
         exit 1
     fi
     local pid
-    pid=$(cat "$PID_FILE")
+    pid=$(runner_read_pid)
     warn "正在终止构建进程 (PID: $pid)..."
-    kill "$pid" 2>/dev/null || true
-    # Also kill the entire process group
-    kill -- -"$pid" 2>/dev/null || true
+    runner_identity_matches || {
+        fail "refusing to signal an unverified build runner"
+        exit 1
+    }
+    # Signal the process group first while the verified session leader exists;
+    # signalling the leader first could let it exit before its children receive TERM.
+    kill -TERM -- -"$pid" 2>/dev/null || true
+    runner_identity_matches && kill -TERM "$pid" 2>/dev/null || true
     sleep 1
-    if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null || true
+    if runner_identity_matches; then
+        kill -KILL -- -"$pid" 2>/dev/null || true
+        runner_identity_matches && kill -KILL "$pid" 2>/dev/null || true
     fi
-    rm -f "$PID_FILE"
+    clear_runner_identity
     ok "已终止"
 }
 
@@ -1366,7 +1541,7 @@ build_runner() {
         fi
         set_phase "start"
         info "启动服务..."
-        if $COMPOSE up -d --pull never >> "$BUILD_LOG" 2>&1; then
+        if $COMPOSE up -d >> "$BUILD_LOG" 2>&1; then
             ok "服务已启动"
         else
             set_phase "start" "fail"
@@ -1414,7 +1589,7 @@ build_runner() {
     $COMPOSE ps >> "$BUILD_LOG" 2>&1 || true
     echo "" >> "$BUILD_LOG"
 
-    rm -f "$PID_FILE"
+    clear_runner_identity
 }
 
 # ============================================================
@@ -1527,27 +1702,29 @@ confirm_sakura_uninstall() {
 }
 
 stop_deployment_for_uninstall() {
-    local pid_file="$PID_FILE" pid elapsed=0
-    if [[ "$pid_file" != /* ]]; then
-        pid_file="$UPDATER_PROJECT_ROOT/$pid_file"
-    fi
+    local pid elapsed=0
     if ! updater_deployment_is_running; then
-        rm -f -- "$pid_file"
+        if runner_pid_is_live; then
+            fail "refusing to signal live PID from build.pid without verified runner identity" >&2
+            return 1
+        fi
+        clear_runner_identity
         return 0
     fi
-    pid=$(cat "$pid_file")
+    pid=$(runner_read_pid) || return 1
     warn "正在停止后台部署进程 (PID: $pid)..."
-    kill "$pid" 2>/dev/null || true
-    kill -- -"$pid" 2>/dev/null || true
-    while kill -0 "$pid" 2>/dev/null && [[ "$elapsed" -lt 10 ]]; do
+    runner_identity_matches || return 1
+    kill -TERM -- -"$pid" 2>/dev/null || true
+    runner_identity_matches && kill -TERM "$pid" 2>/dev/null || true
+    while runner_identity_matches && [[ "$elapsed" -lt 10 ]]; do
         sleep 1
         elapsed=$((elapsed + 1))
     done
-    if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null || true
-        kill -9 -- -"$pid" 2>/dev/null || true
+    if runner_identity_matches; then
+        kill -KILL -- -"$pid" 2>/dev/null || true
+        runner_identity_matches && kill -KILL "$pid" 2>/dev/null || true
     fi
-    rm -f -- "$pid_file"
+    clear_runner_identity
 }
 
 sakura_compose_uninstall() {
@@ -1605,7 +1782,6 @@ cmd_uninstall() {
     updater_require_root || return $?
     confirm_sakura_uninstall "$purge" "$assume_yes" || return $?
     stop_deployment_for_uninstall || return $?
-    updater_require_no_active_job || return $?
 
     info "正在删除 Sakura AI Compose 服务..."
     sakura_compose_uninstall "$purge" || return $?
@@ -1679,7 +1855,7 @@ do_start() {
     # If a build is already running, attach to it
     if is_running; then
         local pid
-        pid=$(cat "$PID_FILE")
+        pid=$(runner_read_pid)
         warn "构建进程已在运行 (PID: $pid)"
         echo ""
         info "附加到日志 (Ctrl+C 退出查看，不会中断构建)..."
@@ -1688,6 +1864,11 @@ do_start() {
         tail -f "$BUILD_LOG" || true
         trap - INT
         exit 0
+    fi
+    if runner_pid_is_live; then
+        fail "build.pid refers to a live process whose runner identity cannot be verified"
+        fail "refusing to start a second deployment runner; inspect PID $(runner_read_pid) manually"
+        exit 1
     fi
 
     # If previous run completed successfully, do a clean start
@@ -1718,6 +1899,7 @@ set -euo pipefail
 export _START_SH_SOURCED=1
 cd "${abs_script_dir}"
 source "${abs_script_dir}/start.sh"
+trap 'clear_runner_identity' EXIT
 export prod="${prod}"
 build_runner "${rebuild}" "${prod}"
 RUNNER_EOF
@@ -1728,7 +1910,14 @@ RUNNER_EOF
     #   nohup  → ignore SIGHUP when SSH disconnects
     setsid nohup bash "$runner_script" >> "$BUILD_LOG" 2>&1 &
     local bg_pid=$!
-    echo "$bg_pid" > "$PID_FILE"
+    echo "$bg_pid" > "$(runner_pid_file_path)"
+    if ! runner_write_identity "$bg_pid" "$runner_script"; then
+        fail "后台构建进程身份记录失败；拒绝留下不可验证的 runner"
+        kill -TERM -- -"$bg_pid" 2>/dev/null || true
+        kill -TERM "$bg_pid" 2>/dev/null || true
+        clear_runner_identity
+        return 1
+    fi
 
     disown "$bg_pid" 2>/dev/null || true
 

--- a/start.sh
+++ b/start.sh
@@ -13,7 +13,9 @@
 #   ./start.sh --stop         # 停止正在进行的构建
 #   ./start.sh --ps           # 查看服务容器状态
 #   ./start.sh --down         # 停止服务
-#   ./start.sh updater [action]  # 管理 host updater daemon（install/start/stop/status）
+#   ./start.sh uninstall      # 卸载服务（默认保留 Docker 数据卷）
+#   ./start.sh uninstall --purge  # 同时删除 Docker 数据卷和 .deploy 状态
+#   ./start.sh updater [action]  # 管理 host updater daemon（含 reinstall/uninstall）
 #   ./start.sh --help         # 显示帮助
 
 set -euo pipefail
@@ -30,7 +32,7 @@ COMPOSE_PROJECT=""
 DEFAULT_PROD_COMPOSE_PROJECT="sakura-ai"
 DEPLOY_DIR=".deploy"
 BUILD_LOG="$DEPLOY_DIR/build.log"
-PHASE_FILE="$DEPLOY_DIR/phase"         # 当前阶段: preflight / build / pip / start / health / done
+PHASE_FILE="$DEPLOY_DIR/phase"         # 当前阶段: preflight / build / pip / pull / start / health / done
 PHASE_RESULT="$DEPLOY_DIR/phase_result" # 上一阶段结果: ok / fail
 PID_FILE="$DEPLOY_DIR/build.pid"
 HASH_FILE="$DEPLOY_DIR/requirements.hash"
@@ -78,6 +80,21 @@ wait_for_pid() {
     echo ""
     wait "$pid"
     return $?
+}
+
+compose_pull_with_native_progress() {
+    local compose_help=""
+    # The deployment runner is detached, so Compose would normally downgrade to
+    # noisy plain layer logs. Force its native TTY renderer; tail/--attach passes
+    # the control stream to the administrator's terminal while the pull itself
+    # remains owned by the background runner after Ctrl+C or SSH disconnect.
+    compose_help=$(docker compose --help 2>/dev/null || true)
+    if [[ "$compose_help" == *--progress* ]]; then
+        $COMPOSE --ansi always --progress tty pull
+    else
+        warn "当前 Docker Compose 不支持原生 TTY 进度条，回退到普通拉取输出"
+        $COMPOSE pull
+    fi
 }
 
 # ============================================================
@@ -344,6 +361,56 @@ updater_socket_health_payload() {
         --unix-socket "$UPDATER_SOCKET_PATH" \
         --header 'Accept: application/json' \
         http://localhost/v1/health
+}
+
+updater_socket_status_payload() {
+    curl --fail --silent --show-error \
+        --connect-timeout 2 --max-time 5 \
+        --unix-socket "$UPDATER_SOCKET_PATH" \
+        --header 'Accept: application/json' \
+        http://localhost/v1/status
+}
+
+updater_require_root() {
+    local uid
+    uid=$(updater_current_uid) || return 1
+    if [[ "$uid" != "0" ]]; then
+        fail "updater lifecycle operation requires root" >&2
+        return 1
+    fi
+}
+
+updater_deployment_is_running() {
+    local pid_file="$PID_FILE" pid
+    if [[ "$pid_file" != /* ]]; then
+        pid_file="$UPDATER_PROJECT_ROOT/$pid_file"
+    fi
+    [[ -f "$pid_file" ]] || return 1
+    pid=$(cat "$pid_file" 2>/dev/null) || return 1
+    [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null
+}
+
+updater_require_idle_deployment() {
+    if updater_deployment_is_running; then
+        fail "deployment is still running in the background; updater lifecycle changes are blocked" >&2
+        fail "wait for ./start.sh --status to finish, or explicitly stop it with ./start.sh --stop" >&2
+        return 1
+    fi
+}
+
+updater_require_no_active_job() {
+    local payload
+    if ! updater_socket_health_payload >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! payload=$(updater_socket_status_payload 2>/dev/null); then
+        fail "updater is live but its job state cannot be inspected; refusing lifecycle change" >&2
+        return 1
+    fi
+    if [[ "$payload" =~ \"has_active_job\"[[:space:]]*:[[:space:]]*true ]]; then
+        fail "an updater job is active; wait for it to finish before reinstalling or uninstalling" >&2
+        return 1
+    fi
 }
 
 resolve_running_image_version() {
@@ -879,6 +946,83 @@ cmd_updater_install() {
     fi
 }
 
+updater_existing_state_dir_is_safe() {
+    local state_dir="$UPDATER_STATE_DIR" owner
+    if ! updater_path_exists "$state_dir"; then
+        return 0
+    fi
+    if updater_path_is_symlink "$state_dir" || [[ ! -d "$state_dir" ]]; then
+        fail "refusing unsafe updater state directory: $state_dir" >&2
+        return 1
+    fi
+    if ! owner=$(updater_directory_owner_uid "$state_dir") || [[ "$owner" != "0" ]]; then
+        fail "refusing non-root updater state directory: $state_dir" >&2
+        return 1
+    fi
+    if ! updater_directory_is_safe "$state_dir" 0; then
+        fail "refusing group/other-writable updater state directory: $state_dir" >&2
+        return 1
+    fi
+}
+
+stop_verified_updater() {
+    local binary="${UPDATER_BINARY:-$UPDATER_STATE_DIR/sakura-ai-updater}"
+    if updater_binary_is_safe "$binary"; then
+        updater_backend stop \
+            --state-dir "$UPDATER_STATE_DIR" \
+            --socket-path "$UPDATER_SOCKET_PATH" || return $?
+    elif updater_path_exists "$binary"; then
+        fail "refusing to execute unsafe updater binary while stopping: $binary" >&2
+        return 126
+    fi
+    if updater_socket_health_payload >/dev/null 2>&1; then
+        fail "updater socket is still live after stop; refusing to replace or remove files" >&2
+        fail "inspect the verified listener with: sudo ss -xlpn | grep -F '$UPDATER_SOCKET_PATH'" >&2
+        return 1
+    fi
+}
+
+cmd_updater_reinstall() {
+    updater_require_root || return $?
+    updater_require_idle_deployment || return $?
+    updater_require_no_active_job || return $?
+    stop_verified_updater || return $?
+    cmd_updater_install || return $?
+    ensure_updater_running || return $?
+    ok "updater 已重新安装并启动"
+    updater_backend status \
+        --state-dir "$UPDATER_STATE_DIR" \
+        --socket-path "$UPDATER_SOCKET_PATH"
+}
+
+cmd_updater_uninstall() {
+    local binary="${UPDATER_BINARY:-$UPDATER_STATE_DIR/sakura-ai-updater}"
+    updater_require_root || return $?
+    updater_require_idle_deployment || return $?
+    updater_require_no_active_job || return $?
+    updater_existing_state_dir_is_safe || return $?
+    if [[ "$binary" != "$UPDATER_STATE_DIR/sakura-ai-updater" ]]; then
+        fail "refusing unexpected updater binary path during uninstall: $binary" >&2
+        return 1
+    fi
+    stop_verified_updater || return $?
+
+    # Only exact, updater-owned paths under the verified state directory are removed.
+    rm -f -- \
+        "$binary" \
+        "$UPDATER_STATE_DIR/daemon-meta.json" \
+        "$UPDATER_STATE_DIR/updater.log" \
+        "$UPDATER_STATE_DIR/updater.lock" \
+        "$UPDATER_STATE_DIR/update-state.json" \
+        "$UPDATER_STATE_DIR/install.lock"
+    rm -rf -- "$UPDATER_STATE_DIR/tmp"
+    rmdir -- "$UPDATER_STATE_DIR" 2>/dev/null || true
+    if [[ -S "$UPDATER_SOCKET_PATH" || -L "$UPDATER_SOCKET_PATH" ]]; then
+        rm -f -- "$UPDATER_SOCKET_PATH"
+    fi
+    ok "updater 已卸载"
+}
+
 ensure_updater_running() {
     if updater_backend is-running \
         --state-dir "$UPDATER_STATE_DIR" \
@@ -947,6 +1091,12 @@ cmd_updater() {
         install)
             cmd_updater_install "$@"
             ;;
+        reinstall)
+            cmd_updater_reinstall "$@"
+            ;;
+        uninstall)
+            cmd_updater_uninstall "$@"
+            ;;
         start)
             ensure_updater_running "$@"
             ;;
@@ -957,7 +1107,7 @@ cmd_updater() {
             ;;
         *)
             fail "未知 updater 子命令: $action"
-            echo "用法: ./start.sh updater [install|start|stop|status|is-running]" >&2
+            echo "用法: ./start.sh updater [install|reinstall|uninstall|start|stop|status|is-running]" >&2
             return 1
             ;;
     esac
@@ -1206,11 +1356,17 @@ build_runner() {
             info "--rebuild 生产模式：重新拉取最新镜像"
         fi
         # 不写本地哈希：镜像版本由 GHCR 发布管理，本地 requirements/Dockerfile 哈希无意义
-        set_phase "start"
         info "停止现有容器..."
         $COMPOSE down >> "$BUILD_LOG" 2>&1 || true
-        info "启动服务（拉取最新镜像）..."
-        if $COMPOSE up -d --pull always >> "$BUILD_LOG" 2>&1; then
+        set_phase "pull"
+        info "拉取最新镜像（Docker 原生进度条）..."
+        if ! compose_pull_with_native_progress; then
+            set_phase "pull" "fail"
+            return 1
+        fi
+        set_phase "start"
+        info "启动服务..."
+        if $COMPOSE up -d --pull never >> "$BUILD_LOG" 2>&1; then
             ok "服务已启动"
         else
             set_phase "start" "fail"
@@ -1279,6 +1435,7 @@ show_menu() {
     echo -e "  ${BOLD}[7]${RESET} 停止服务"
     echo -e "  ${BOLD}[8]${RESET} 生产镜像部署 (--prod)"
     echo -e "  ${BOLD}[9]${RESET} Updater daemon 管理"
+    echo -e "  ${BOLD}[10]${RESET} 卸载 Sakura AI"
     echo -e "  ${BOLD}[0]${RESET} 退出"
     echo ""
 
@@ -1294,13 +1451,14 @@ show_menu() {
         7) do_down        ;;
         8) do_start false true ;;
         9) do_updater_menu ;;
+        10) cmd_uninstall ;;
         0) info "已退出" ; exit 0 ;;
         *) warn "无效选项: $choice" ; exit 1 ;;
     esac
 }
 
 # Updater daemon 管理子菜单（host updater CLI 的交互入口）
-# 复用 cmd_updater：install/start/stop/status 对应底层同名子命令。
+# 复用 cmd_updater：包括 install/reinstall/uninstall 与 daemon 生命周期操作。
 do_updater_menu() {
     echo ""
     echo -e "${BOLD}Updater daemon 管理${RESET}"
@@ -1310,6 +1468,8 @@ do_updater_menu() {
     echo -e "  ${BOLD}[2]${RESET} 启动 updater daemon"
     echo -e "  ${BOLD}[3]${RESET} 停止 updater daemon"
     echo -e "  ${BOLD}[4]${RESET} 查看 updater daemon 状态"
+    echo -e "  ${BOLD}[5]${RESET} 重新安装并启动 updater"
+    echo -e "  ${BOLD}[6]${RESET} 卸载 updater"
     echo -e "  ${BOLD}[0]${RESET} 返回"
     echo ""
 
@@ -1320,6 +1480,8 @@ do_updater_menu() {
         2) cmd_updater start  ;;
         3) cmd_updater stop   ;;
         4) cmd_updater status ;;
+        5) cmd_updater reinstall ;;
+        6) cmd_updater uninstall ;;
         0) return 0 ;;
         *) warn "无效选项: $choice" ; return 1 ;;
     esac
@@ -1337,6 +1499,124 @@ do_ps() {
     fi
     echo ""
     $compose_cmd ps
+}
+
+confirm_sakura_uninstall() {
+    local purge="$1" assume_yes="$2" expected answer
+    if [[ "$assume_yes" == "true" ]]; then
+        return 0
+    fi
+    if [[ ! -t 0 ]]; then
+        fail "uninstall confirmation requires an interactive terminal; pass --yes for automation" >&2
+        return 1
+    fi
+    echo ""
+    warn "即将停止并删除 Sakura AI 容器、网络和 Host Updater。"
+    if [[ "$purge" == "true" ]]; then
+        warn "--purge 还会永久删除 Compose 数据卷（包括 MySQL/Redis）和 .deploy 状态。"
+        expected="PURGE SAKURA-AI"
+    else
+        info "Docker 数据卷和 .deploy/deployment.env 将保留，可供以后重新部署。"
+        expected="UNINSTALL"
+    fi
+    read -r -p "输入 '$expected' 继续: " answer
+    if [[ "$answer" != "$expected" ]]; then
+        fail "确认内容不匹配，已取消卸载" >&2
+        return 1
+    fi
+}
+
+stop_deployment_for_uninstall() {
+    local pid_file="$PID_FILE" pid elapsed=0
+    if [[ "$pid_file" != /* ]]; then
+        pid_file="$UPDATER_PROJECT_ROOT/$pid_file"
+    fi
+    if ! updater_deployment_is_running; then
+        rm -f -- "$pid_file"
+        return 0
+    fi
+    pid=$(cat "$pid_file")
+    warn "正在停止后台部署进程 (PID: $pid)..."
+    kill "$pid" 2>/dev/null || true
+    kill -- -"$pid" 2>/dev/null || true
+    while kill -0 "$pid" 2>/dev/null && [[ "$elapsed" -lt 10 ]]; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+        kill -9 -- -"$pid" 2>/dev/null || true
+    fi
+    rm -f -- "$pid_file"
+}
+
+sakura_compose_uninstall() {
+    local purge="$1"
+    local -a compose_cmd=(docker compose)
+    command -v docker >/dev/null 2>&1 || {
+        fail "Docker 未安装，无法卸载 Compose 服务" >&2
+        return 1
+    }
+    docker compose version >/dev/null 2>&1 || {
+        fail "Docker Compose V2 未安装" >&2
+        return 1
+    }
+    select_compose_from_deployment_mode || return $?
+    if [[ -f "$UPDATER_DEPLOYMENT_ENV_FILE" ]]; then
+        compose_cmd+=(--env-file "$UPDATER_DEPLOYMENT_ENV_FILE")
+    fi
+    if [[ -n "$COMPOSE_PROJECT" ]]; then
+        compose_cmd+=(--project-name "$COMPOSE_PROJECT")
+    fi
+    compose_cmd+=(-f "$COMPOSE_FILE" down --remove-orphans)
+    if [[ "$purge" == "true" ]]; then
+        compose_cmd+=(--volumes)
+    fi
+    "${compose_cmd[@]}"
+}
+
+purge_sakura_deployment_state() {
+    local target="$UPDATER_PROJECT_ROOT/$DEPLOY_DIR"
+    local expected="$UPDATER_PROJECT_ROOT/.deploy"
+    if [[ "$target" != "$expected" || "$target" == "/" || "$target" == "$UPDATER_PROJECT_ROOT" ]]; then
+        fail "refusing unsafe deployment state target: $target" >&2
+        return 1
+    fi
+    if updater_path_is_symlink "$target"; then
+        fail "refusing symlinked deployment state target: $target" >&2
+        return 1
+    fi
+    rm -rf -- "$target"
+}
+
+cmd_uninstall() {
+    local purge=false assume_yes=false arg
+    for arg in "$@"; do
+        case "$arg" in
+            --purge) purge=true ;;
+            --yes) assume_yes=true ;;
+            *)
+                fail "未知卸载参数: $arg" >&2
+                echo "用法: ./start.sh uninstall [--purge] [--yes]" >&2
+                return 1
+                ;;
+        esac
+    done
+    updater_require_root || return $?
+    confirm_sakura_uninstall "$purge" "$assume_yes" || return $?
+    stop_deployment_for_uninstall || return $?
+    updater_require_no_active_job || return $?
+
+    info "正在删除 Sakura AI Compose 服务..."
+    sakura_compose_uninstall "$purge" || return $?
+    cmd_updater_uninstall || return $?
+    if [[ "$purge" == "true" ]]; then
+        purge_sakura_deployment_state || return $?
+        ok "Sakura AI 已完全卸载；Compose 数据卷和部署状态已删除"
+    else
+        ok "Sakura AI 已卸载；Docker 数据卷和部署状态已保留"
+    fi
+    info "项目源码/脚本目录未删除，可手动检查后移除: $UPDATER_PROJECT_ROOT"
 }
 
 do_down() {
@@ -1470,6 +1750,12 @@ RUNNER_EOF
 }
 
 main() {
+    if [[ "${1:-}" == "uninstall" ]]; then
+        shift
+        cmd_uninstall "$@"
+        exit $?
+    fi
+
     # updater 子命令（位置参数，优先于 flag 解析）
     if [[ "${1:-}" == "updater" ]]; then
         shift
@@ -1503,7 +1789,8 @@ main() {
                 echo "  --ps        查看服务容器状态"
                 echo "  --down      停止服务"
                 echo "  --help      显示帮助"
-                echo "  updater [action]  管理 host updater daemon（生产 install/start 需 root；action 默认 status）"
+                echo "  uninstall [--purge] [--yes]  卸载服务；默认保留数据，--purge 删除数据卷"
+                echo "  updater [action]  管理 host updater daemon（含 reinstall/uninstall；生产操作需 root）"
                 echo ""
                 echo "断线续跑:"
                 echo "  构建过程在后台运行，SSH 断开不会中断。"

--- a/tests/test_start_sh_compose_mode.py
+++ b/tests/test_start_sh_compose_mode.py
@@ -104,7 +104,7 @@ updater_backend() {
     printf 'BACKEND:%s\n' "$*"
     return 1
 }
-updater_socket_health_payload() { printf '{}\n'; }
+updater_socket_listener_responds() { return 0; }
 updater_binary_is_safe() { printf 'UNEXPECTED_BINARY_CHECK\n'; return 0; }
 ensure_updater_running
 """

--- a/tests/test_start_sh_lifecycle.py
+++ b/tests/test_start_sh_lifecycle.py
@@ -1,0 +1,252 @@
+"""Behavioral contracts for start.sh lifecycle and uninstall commands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def _run_bash(command: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["bash"],
+        cwd=ROOT,
+        env={**os.environ, "TERM": "dumb"},
+        input=command.encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+    return subprocess.CompletedProcess(
+        result.args,
+        result.returncode,
+        result.stdout.decode("utf-8", errors="replace"),
+        result.stderr.decode("utf-8", errors="replace"),
+    )
+
+
+def test_updater_reinstall_is_ordered_stop_install_start_status():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_require_root() { printf 'ROOT\n'; }
+updater_require_idle_deployment() { printf 'IDLE\n'; }
+updater_require_no_active_job() { printf 'NO_JOB\n'; }
+stop_verified_updater() { printf 'STOP\n'; }
+cmd_updater_install() { printf 'INSTALL\n'; }
+ensure_updater_running() { printf 'START\n'; }
+updater_backend() { printf 'STATUS:%s\n' "$*"; }
+cmd_updater_reinstall
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    markers = ["ROOT", "IDLE", "NO_JOB", "STOP", "INSTALL", "START", "STATUS:status"]
+    positions = [result.stdout.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+def test_updater_reinstall_refuses_background_deployment_before_stop():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_require_root() { :; }
+updater_deployment_is_running() { return 0; }
+stop_verified_updater() { printf 'UNEXPECTED_STOP\n'; }
+cmd_updater_install() { printf 'UNEXPECTED_INSTALL\n'; }
+cmd_updater_reinstall
+"""
+    )
+
+    assert result.returncode != 0
+    assert "deployment is still running in the background" in result.stderr
+    assert "UNEXPECTED" not in result.stdout
+
+
+def test_updater_lifecycle_refuses_an_active_update_job():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_require_root() { :; }
+updater_require_idle_deployment() { :; }
+updater_socket_health_payload() { printf '{}\n'; }
+updater_socket_status_payload() { printf '{"data":{"has_active_job": true}}\n'; }
+stop_verified_updater() { printf 'UNEXPECTED_STOP\n'; }
+cmd_updater_reinstall
+"""
+    )
+
+    assert result.returncode != 0
+    assert "an updater job is active" in result.stderr
+    assert "UNEXPECTED_STOP" not in result.stdout
+
+
+def test_updater_uninstall_removes_only_managed_state_files():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+export UPDATER_STATE_DIR="$case_dir/updater"
+export UPDATER_BINARY="$UPDATER_STATE_DIR/sakura-ai-updater"
+mkdir -p "$UPDATER_STATE_DIR/tmp"
+touch "$UPDATER_BINARY" \
+  "$UPDATER_STATE_DIR/daemon-meta.json" \
+  "$UPDATER_STATE_DIR/updater.log" \
+  "$UPDATER_STATE_DIR/updater.lock" \
+  "$UPDATER_STATE_DIR/update-state.json" \
+  "$UPDATER_STATE_DIR/install.lock" \
+  "$UPDATER_STATE_DIR/tmp/runtime"
+updater_require_root() { :; }
+updater_require_idle_deployment() { :; }
+updater_require_no_active_job() { :; }
+updater_existing_state_dir_is_safe() { :; }
+stop_verified_updater() { printf 'STOPPED\n'; }
+cmd_updater_uninstall
+[[ ! -e "$UPDATER_STATE_DIR" ]]
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "STOPPED" in result.stdout
+    assert "updater" in result.stdout
+
+
+def test_compose_uninstall_preserves_volumes_by_default_and_purges_explicitly():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+export UPDATER_DEPLOYMENT_ENV_FILE="$case_dir/deployment.env"
+touch "$UPDATER_DEPLOYMENT_ENV_FILE"
+docker() {
+  if [[ "$*" == 'compose version' ]]; then return 0; fi
+  printf 'DOCKER:%s\n' "$*"
+}
+select_compose_from_deployment_mode() {
+  COMPOSE_FILE='/opt/sakura-ai/docker/docker-compose.prod.yml'
+  COMPOSE_PROJECT='sakura-ai'
+}
+sakura_compose_uninstall false
+sakura_compose_uninstall true
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = [line for line in result.stdout.splitlines() if line.startswith("DOCKER:")]
+    assert len(calls) == 2
+    assert "down --remove-orphans" in calls[0]
+    assert "--volumes" not in calls[0]
+    assert "down --remove-orphans --volumes" in calls[1]
+    assert "--project-name sakura-ai" in calls[0]
+    assert "--env-file" in calls[0]
+
+
+def test_full_uninstall_default_preserves_state_and_purge_is_explicit():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_require_root() { printf 'ROOT\n'; }
+stop_deployment_for_uninstall() { printf 'STOP_DEPLOYMENT\n'; }
+updater_require_no_active_job() { printf 'NO_JOB\n'; }
+sakura_compose_uninstall() { printf 'COMPOSE_PURGE=%s\n' "$1"; }
+cmd_updater_uninstall() { printf 'REMOVE_UPDATER\n'; }
+purge_sakura_deployment_state() { printf 'PURGE_STATE\n'; }
+cmd_uninstall --yes
+printf '%s\n' '---'
+cmd_uninstall --purge --yes
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    default, purge = result.stdout.split("---", maxsplit=1)
+    assert "COMPOSE_PURGE=false" in default
+    assert "PURGE_STATE" not in default
+    assert "COMPOSE_PURGE=true" in purge
+    assert "PURGE_STATE" in purge
+
+
+def test_uninstall_never_assumes_confirmation_from_noninteractive_stdin():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+confirm_sakura_uninstall false false
+"""
+    )
+
+    assert result.returncode != 0
+    assert "pass --yes for automation" in result.stderr
+
+
+def test_purge_refuses_any_deployment_directory_other_than_project_dot_deploy():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+DEPLOY_DIR='../outside'
+purge_sakura_deployment_state
+"""
+    )
+
+    assert result.returncode != 0
+    assert "refusing unsafe deployment state target" in result.stderr
+
+
+def test_native_compose_pull_uses_tty_progress_and_has_safe_fallback():
+    supported = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+docker() { printf '%s\n' '--progress'; }
+compose_stub() { printf 'COMPOSE:%s\n' "$*"; }
+COMPOSE=compose_stub
+compose_pull_with_native_progress
+"""
+    )
+    assert supported.returncode == 0, supported.stdout + supported.stderr
+    assert "COMPOSE:--ansi always --progress tty pull" in supported.stdout
+
+    fallback = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+docker() { printf '%s\n' 'compose help without progress renderer'; }
+compose_stub() { printf 'COMPOSE:%s\n' "$*"; }
+COMPOSE=compose_stub
+compose_pull_with_native_progress
+"""
+    )
+    assert fallback.returncode == 0, fallback.stdout + fallback.stderr
+    assert "COMPOSE:pull" in fallback.stdout
+    assert "--progress tty" not in fallback.stdout
+
+
+def test_start_sh_help_documents_destructive_scope_and_lifecycle_commands():
+    result = _run_bash("bash ./start.sh --help")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "uninstall [--purge] [--yes]" in result.stdout
+    assert "reinstall/uninstall" in result.stdout
+
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    assert 'set_phase "pull"' in script
+    assert "$COMPOSE up -d --pull never" in script
+    assert "$COMPOSE up -d --pull always" not in script

--- a/tests/test_start_sh_lifecycle.py
+++ b/tests/test_start_sh_lifecycle.py
@@ -26,7 +26,7 @@ def _run_bash(command: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_updater_reinstall_is_ordered_stop_install_start_status():
+def test_updater_reinstall_is_ordered_prepare_stop_install_start_status():
     result = _run_bash(
         """
 set -u
@@ -34,7 +34,8 @@ export _START_SH_SOURCED=1
 source ./start.sh
 updater_require_root() { printf 'ROOT\n'; }
 updater_require_idle_deployment() { printf 'IDLE\n'; }
-updater_require_no_active_job() { printf 'NO_JOB\n'; }
+updater_socket_listener_responds() { return 0; }
+updater_prepare_stop() { printf 'PREPARE\n'; }
 stop_verified_updater() { printf 'STOP\n'; }
 cmd_updater_install() { printf 'INSTALL\n'; }
 ensure_updater_running() { printf 'START\n'; }
@@ -44,7 +45,7 @@ cmd_updater_reinstall
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    markers = ["ROOT", "IDLE", "NO_JOB", "STOP", "INSTALL", "START", "STATUS:status"]
+    markers = ["ROOT", "IDLE", "PREPARE", "STOP", "INSTALL", "START", "STATUS:status"]
     positions = [result.stdout.index(marker) for marker in markers]
     assert positions == sorted(positions)
 
@@ -68,7 +69,7 @@ cmd_updater_reinstall
     assert "UNEXPECTED" not in result.stdout
 
 
-def test_updater_lifecycle_refuses_an_active_update_job():
+def test_updater_lifecycle_refuses_when_atomic_stop_gate_is_rejected():
     result = _run_bash(
         """
 set -u
@@ -76,16 +77,104 @@ export _START_SH_SOURCED=1
 source ./start.sh
 updater_require_root() { :; }
 updater_require_idle_deployment() { :; }
-updater_socket_health_payload() { printf '{}\n'; }
-updater_socket_status_payload() { printf '{"data":{"has_active_job": true}}\n'; }
+updater_prepare_stop() { printf 'ACTIVE_JOB\n' >&2; return 1; }
 stop_verified_updater() { printf 'UNEXPECTED_STOP\n'; }
 cmd_updater_reinstall
 """
     )
 
     assert result.returncode != 0
-    assert "an updater job is active" in result.stderr
+    assert "ACTIVE_JOB" in result.stderr
     assert "UNEXPECTED_STOP" not in result.stdout
+
+
+def test_updater_reinstall_restarts_preserved_binary_after_install_failure():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+updater_require_root() { :; }
+updater_require_idle_deployment() { :; }
+updater_socket_listener_responds() { return 0; }
+updater_prepare_stop() { :; }
+stop_verified_updater() { printf 'STOP\n'; }
+cmd_updater_install() { printf 'INSTALL_FAIL\n'; return 23; }
+ensure_updater_running() { printf 'RESTORE_OLD\n'; }
+cmd_updater_reinstall
+"""
+    )
+
+    assert result.returncode == 23, result.stdout + result.stderr
+    assert "STOP" in result.stdout
+    assert "INSTALL_FAIL" in result.stdout
+    assert "RESTORE_OLD" in result.stdout
+
+
+def test_socket_probe_treats_http_500_as_a_live_listener():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+curl() { printf '500'; return 0; }
+updater_socket_listener_responds
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_socket_probe_treats_malformed_http_as_a_live_listener():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+curl() { return 52; }
+updater_socket_listener_responds
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_atomic_stop_gate_fails_closed_when_live_daemon_rejects_endpoint():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+curl() {
+  if [[ "$*" == *'/v1/lifecycle/prepare-stop'* ]]; then return 22; fi
+  printf '500'
+  return 0
+}
+updater_prepare_stop
+"""
+    )
+
+    assert result.returncode != 0
+    assert "refused the atomic lifecycle gate" in result.stderr
+
+
+def test_dev_mode_stop_uses_backend_when_binary_is_absent():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+export SAKURA_UPDATER_DEV=1
+updater_binary_is_safe() { return 1; }
+updater_path_exists() { return 1; }
+updater_backend() { printf 'BACKEND:%s\n' "$*"; }
+updater_socket_listener_responds() { return 1; }
+stop_verified_updater
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "BACKEND:stop" in result.stdout
 
 
 def test_updater_uninstall_removes_only_managed_state_files():
@@ -108,8 +197,8 @@ touch "$UPDATER_BINARY" \
   "$UPDATER_STATE_DIR/tmp/runtime"
 updater_require_root() { :; }
 updater_require_idle_deployment() { :; }
-updater_require_no_active_job() { :; }
 updater_existing_state_dir_is_safe() { :; }
+updater_prepare_stop() { :; }
 stop_verified_updater() { printf 'STOPPED\n'; }
 cmd_updater_uninstall
 [[ ! -e "$UPDATER_STATE_DIR" ]]
@@ -162,7 +251,6 @@ export _START_SH_SOURCED=1
 source ./start.sh
 updater_require_root() { printf 'ROOT\n'; }
 stop_deployment_for_uninstall() { printf 'STOP_DEPLOYMENT\n'; }
-updater_require_no_active_job() { printf 'NO_JOB\n'; }
 sakura_compose_uninstall() { printf 'COMPOSE_PURGE=%s\n' "$1"; }
 cmd_updater_uninstall() { printf 'REMOVE_UPDATER\n'; }
 purge_sakura_deployment_state() { printf 'PURGE_STATE\n'; }
@@ -248,5 +336,59 @@ def test_start_sh_help_documents_destructive_scope_and_lifecycle_commands():
 
     script = (ROOT / "start.sh").read_text(encoding="utf-8")
     assert 'set_phase "pull"' in script
-    assert "$COMPOSE up -d --pull never" in script
+    assert "$COMPOSE up -d --pull never" not in script
     assert "$COMPOSE up -d --pull always" not in script
+
+
+def test_uninstall_refuses_to_signal_live_pid_without_matching_runner_identity():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+PID_FILE="$case_dir/build.pid"
+RUNNER_IDENTITY_FILE="$case_dir/build-runner.identity"
+printf '4242\n' > "$PID_FILE"
+kill() {
+  if [[ "$1" == '-0' ]]; then return 0; fi
+  printf 'UNEXPECTED_SIGNAL:%s\n' "$*"
+  return 0
+}
+stop_deployment_for_uninstall
+"""
+    )
+
+    assert result.returncode != 0
+    assert "without verified runner identity" in result.stderr
+    assert "UNEXPECTED_SIGNAL" not in result.stdout
+
+
+def test_runner_identity_requires_matching_starttime_and_command():
+    result = _run_bash(
+        """
+set -u
+export _START_SH_SOURCED=1
+source ./start.sh
+case_dir=$(mktemp -d)
+trap 'rm -rf "$case_dir"' EXIT
+PID_FILE="$case_dir/build.pid"
+RUNNER_IDENTITY_FILE="$case_dir/build-runner.identity"
+printf '4242\n' > "$PID_FILE"
+printf '12345\n.deploy/_runner.sh\n' > "$RUNNER_IDENTITY_FILE"
+runner_process_starttime() { printf '%s\n' "${FAKE_STARTTIME:-12345}"; }
+runner_process_command_matches() {
+  [[ "$1" == '4242' && "$2" == '.deploy/_runner.sh' ]]
+}
+runner_identity_matches
+FAKE_STARTTIME=99999
+if runner_identity_matches; then
+  printf 'UNEXPECTED_MATCH\n'
+  exit 1
+fi
+"""
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "UNEXPECTED_MATCH" not in result.stdout

--- a/tests/test_start_sh_updater_args.py
+++ b/tests/test_start_sh_updater_args.py
@@ -12,5 +12,5 @@ def test_updater_lifecycle_forwards_host_paths_without_update_commands():
     assert 'UPDATER_SOURCE_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.yml"' in script
     assert 'UPDATER_PROD_COMPOSE_FILE="$UPDATER_PROJECT_ROOT/docker/docker-compose.prod.yml"' in script
     assert '$UPDATER_PROJECT_ROOT/$DEPLOYMENT_ENV_FILE' in script
-    assert "updater_socket_health_payload" in script
+    assert "updater_socket_listener_responds" in script
     assert "refusing duplicate start" in script

--- a/updater/pyproject.toml
+++ b/updater/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sakura-ai-updater"
-version = "0.1.2"
+version = "0.1.3"
 description = "Sakura AI Host Updater — independent update orchestrator (spec auto-update §4 ADR-1)"
 requires-python = ">=3.12"
 dependencies = [

--- a/updater/src/sakura_ai_updater/__init__.py
+++ b/updater/src/sakura_ai_updater/__init__.py
@@ -4,7 +4,7 @@
 Slice 3c 再 PyInstaller 打包为单二进制（spec §16.1）。
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # IPC 协议版本（spec §7.2 body envelope）。Slice 3a 实现 v1。
 PROTOCOL_VERSION = 1

--- a/updater/src/sakura_ai_updater/ipc.py
+++ b/updater/src/sakura_ai_updater/ipc.py
@@ -98,6 +98,8 @@ def _action_error(exc: Exception) -> JSONResponse:
             "update_in_progress",
             **({"job_id": details.pop("job_id")} if "job_id" in details else {}),
         )
+    if "maintenance" in name:
+        return _error_response(503, "updater_maintenance")
     if "targetnotfound" in name or name in {
         "releasenotfound",
         "releasenotfounderror",
@@ -285,6 +287,30 @@ def create_app(state_path: str, *, orchestrator: Any | None = None) -> FastAPI:
                 if target is not None:
                     data.setdefault("target", target)
             return envelope(data, status_code=202)
+        except Exception as exc:
+            return _action_error(exc)
+
+    @app.post("/v1/lifecycle/prepare-stop")
+    async def prepare_stop() -> JSONResponse:
+        """Atomically close update submission before host lifecycle changes."""
+
+        orchestrator_value = _orchestrator_or_error()
+        if isinstance(orchestrator_value, JSONResponse):
+            return orchestrator_value
+        try:
+            return envelope(_as_data(await orchestrator_value.prepare_stop()))
+        except Exception as exc:
+            return _action_error(exc)
+
+    @app.post("/v1/lifecycle/cancel-stop")
+    async def cancel_stop() -> JSONResponse:
+        """Undo a prepared stop if the host lifecycle operation aborts."""
+
+        orchestrator_value = _orchestrator_or_error()
+        if isinstance(orchestrator_value, JSONResponse):
+            return orchestrator_value
+        try:
+            return envelope(_as_data(await orchestrator_value.cancel_stop()))
         except Exception as exc:
             return _action_error(exc)
 

--- a/updater/src/sakura_ai_updater/jobs.py
+++ b/updater/src/sakura_ai_updater/jobs.py
@@ -65,6 +65,10 @@ class UpdateInProgressError(UpdateOrchestrationError):
         self.job_id = job_id
 
 
+class UpdaterMaintenanceError(UpdateOrchestrationError):
+    """The daemon is quiesced for a verified lifecycle operation."""
+
+
 class TargetNotFoundError(UpdateOrchestrationError):
     """The requested release/manifest does not exist."""
 
@@ -153,6 +157,7 @@ class JobOrchestrator:
         self.deployment = deployment
         self.disk_space_threshold = disk_space_threshold
         self._lock = asyncio.Lock()
+        self._accepting_updates = True
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._logs = JobLogStore(log_capacity)
         # ``/v1/status`` is intentionally a cheap, synchronous projection.  Keep
@@ -567,6 +572,29 @@ class JobOrchestrator:
             return job
         return None
 
+    async def prepare_stop(self) -> dict[str, bool]:
+        """Atomically reject new jobs after proving that no job is active.
+
+        Lifecycle callers must use this gate before signalling the daemon.  It
+        shares the destructive-update lock, so a submit either commits its
+        durable active job first (and this call fails) or observes maintenance
+        mode before it can commit a new job.
+        """
+
+        async with self._lock:
+            active = self._active_job()
+            if active is not None:
+                raise UpdateInProgressError(active.job_id)
+            self._accepting_updates = False
+            return {"prepared": True}
+
+    async def cancel_stop(self) -> dict[str, bool]:
+        """Re-open submissions when a prepared lifecycle operation aborts."""
+
+        async with self._lock:
+            self._accepting_updates = True
+            return {"prepared": False}
+
     async def submit_update(
         self,
         target_version: str | dict[str, Any] | None = None,
@@ -575,6 +603,8 @@ class JobOrchestrator:
     ) -> str:
         """Validate and enqueue one destructive update task."""
 
+        if not self._accepting_updates:
+            raise UpdaterMaintenanceError("updater is preparing to stop")
         if self._lock.locked():
             active = self._active_job()
             raise UpdateInProgressError(active.job_id if active else "unknown")
@@ -601,6 +631,8 @@ class JobOrchestrator:
         if not preflight["can_update"]:
             raise PreflightFailedError(preflight["checks"], preflight)
         async with self._lock:
+            if not self._accepting_updates:
+                raise UpdaterMaintenanceError("updater is preparing to stop")
             active = self._active_job()
             if active is not None:
                 raise UpdateInProgressError(active.job_id)

--- a/updater/tests/test_ipc.py
+++ b/updater/tests/test_ipc.py
@@ -85,6 +85,46 @@ def test_health_returns_envelope(tmp_path):
     assert r.json()["data"]["ok"] is True
 
 
+def test_lifecycle_gate_endpoints_delegate_to_orchestrator(tmp_path):
+    class _Orchestrator:
+        async def prepare_stop(self):
+            return {"prepared": True}
+
+        async def cancel_stop(self):
+            return {"prepared": False}
+
+    client = TestClient(
+        create_app(str(tmp_path / "update-state.json"), orchestrator=_Orchestrator())
+    )
+    prepared = client.post("/v1/lifecycle/prepare-stop")
+    cancelled = client.post("/v1/lifecycle/cancel-stop")
+
+    assert prepared.status_code == 200
+    assert prepared.json()["data"] == {"prepared": True}
+    assert cancelled.status_code == 200
+    assert cancelled.json()["data"] == {"prepared": False}
+
+
+def test_lifecycle_prepare_stop_maps_active_job_to_conflict(tmp_path):
+    class _Conflict(RuntimeError):
+        def __init__(self):
+            self.job_id = "upd_active"
+
+    _Conflict.__name__ = "UpdateInProgressError"
+
+    class _Orchestrator:
+        async def prepare_stop(self):
+            raise _Conflict()
+
+    client = TestClient(
+        create_app(str(tmp_path / "update-state.json"), orchestrator=_Orchestrator())
+    )
+    response = client.post("/v1/lifecycle/prepare-stop")
+
+    assert response.status_code == 409
+    assert response.json() == {"error": "update_in_progress", "job_id": "upd_active"}
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="UDS is POSIX-only")
 @pytest.mark.asyncio
 async def test_serve_over_prebound_uds(tmp_path):

--- a/updater/tests/test_jobs.py
+++ b/updater/tests/test_jobs.py
@@ -7,6 +7,7 @@ from sakura_ai_updater.jobs import (
     JobOrchestrator,
     PreflightFailedError,
     UpdateInProgressError,
+    UpdaterMaintenanceError,
 )
 from sakura_ai_updater.state import load_state, reconcile_interrupted_job
 
@@ -138,6 +139,55 @@ async def test_update_success_clears_active_gate(tmp_path):
     assert orchestrator.readiness_snapshot["update_ready"] is False
     assert orchestrator.readiness_snapshot["readiness"]["target_newer"] is False
     assert orchestrator.readiness_snapshot["target"]["version"] == "3.1.0"
+
+
+@pytest.mark.asyncio
+async def test_prepare_stop_atomically_blocks_submit_finishing_preflight(tmp_path):
+    orchestrator = JobOrchestrator(
+        str(tmp_path / "state.json"),
+        _Adapter(),
+        _Release(),
+        _Deployment(),
+        disk_space_threshold=1,
+    )
+    entered_preflight = asyncio.Event()
+    release_preflight = asyncio.Event()
+    original_preflight = orchestrator.preflight
+
+    async def blocked_preflight(*args, **kwargs):
+        entered_preflight.set()
+        await release_preflight.wait()
+        return await original_preflight(*args, **kwargs)
+
+    orchestrator.preflight = blocked_preflight
+    submit = asyncio.create_task(orchestrator.submit_update("3.1.0"))
+    await entered_preflight.wait()
+
+    assert await orchestrator.prepare_stop() == {"prepared": True}
+    release_preflight.set()
+    with pytest.raises(UpdaterMaintenanceError):
+        await submit
+    assert load_state(orchestrator.state_path).active_job_id is None
+
+    assert await orchestrator.cancel_stop() == {"prepared": False}
+    job_id = await orchestrator.submit_update("3.1.0")
+    await orchestrator.wait_for_job(job_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_stop_rejects_an_active_job_without_closing_gate(tmp_path):
+    adapter = _Adapter(cancel=True)
+    orchestrator = JobOrchestrator(
+        str(tmp_path / "state.json"),
+        adapter,
+        _Release(),
+        _Deployment(),
+        disk_space_threshold=1,
+    )
+    job_id = await orchestrator.submit_update("3.1.0")
+    with pytest.raises(UpdateInProgressError) as caught:
+        await orchestrator.prepare_stop()
+    assert caught.value.job_id == job_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Bump version badge to 3.1.2
- Update deployment notes to mention Docker's native dynamic progress renderer and Ctrl+C behavior
- Simplify Host Updater synchronization instructions by replacing separate steps with the unified `reinstall` command
- Add documentation for uninstall options, distinguishing between standard uninstall and `--purge`

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本次 PR 发布版本 3.1.2，主要包含启动脚本重构、Updater 逻辑增强及文档同步。

**主要改动**
1. **启动脚本优化**：大幅重写 `start.sh` 并新增生命周期测试，提升启动流程稳定性。
2. **Updater 增强**：新增原子维护门控机制及旧版本失效关闭逻辑，并拓展了 IPC 与作业处理功能。
3. **文档与版本同步**：更新中英文 README、部署文档及相关模块版本标识。

**影响范围**
项目启动流程、Updater 维护逻辑、自动化测试及说明文档。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["updater/src/sakura_ai_updater/__init__.py"]
    N2["updater/src/sakura_ai_updater/ipc.py"]
    N3["updater/src/sakura_ai_updater/jobs.py"]
    N4["updater/tests/test_ipc.py"]
    N5["updater/tests/test_jobs.py"]
    N6["tests/test_start_sh_compose_mode.py"]
    N7["tests/test_start_sh_lifecycle.py"]
    N8["tests/test_start_sh_updater_args.py"]
    N2 --> N1
    N3 --> N1
    N4 --> N1
    N4 --> N2
    N5 --> N3
```

<!-- sakura-ai-depgraph-end -->