### PR TITLE
fix: normalize API keys for model discovery (#502)

### DIFF
--- a/backend/api/v1/config.py
+++ b/backend/api/v1/config.py
@@ -192,8 +192,9 @@ async def save_ai_account(
     account_id = (body.id or "").strip()
     existing = await account_store.get_account(account_id) if account_id else None
 
-    # API key 处理：空或脱敏 → 保留原值 / keep existing when blank or masked
-    api_key = body.api_key
+    # API key 处理：空或脱敏 → 保留原值；新 key 去除首尾空白
+    # / keep existing when blank or masked; strip surrounding whitespace from new keys
+    api_key = body.api_key.strip()
     if (not api_key or "****" in api_key) and existing is not None:
         api_key = existing.api_key
 

--- a/backend/core/ai_protocol/account_probe.py
+++ b/backend/core/ai_protocol/account_probe.py
@@ -39,7 +39,7 @@ async def probe_account(
     返回结构：{success, message, models, provider, default_model, context_window_k}。
     与 setup_service.test_ai_api 对齐，便于前端复用。
     """
-    # 用户经常从网页/聊天工具复制令牌，首尾空白或换行不应参与鉴权。
+    # 去除首尾空白或换行
     api_key = api_key.strip()
 
     if not api_key and provider_id not in (

--- a/backend/core/ai_protocol/account_probe.py
+++ b/backend/core/ai_protocol/account_probe.py
@@ -39,6 +39,9 @@ async def probe_account(
     返回结构：{success, message, models, provider, default_model, context_window_k}。
     与 setup_service.test_ai_api 对齐，便于前端复用。
     """
+    # 用户经常从网页/聊天工具复制令牌，首尾空白或换行不应参与鉴权。
+    api_key = api_key.strip()
+
     if not api_key and provider_id not in (
         "ollama",
         "vllm",
@@ -86,7 +89,13 @@ async def probe_account(
         }
     except AIError as exc:
         if exc.category.value == "auth_invalid":
-            return {"success": False, "message": "API Key 无效"}
+            return {
+                "success": False,
+                "message": (
+                    "API 鉴权失败：上游拒绝了当前凭证，请检查 API Key 是否过期、"
+                    "令牌权限/渠道是否可用，以及 API Base URL 是否正确"
+                ),
+            }
         if exc.category.value == "network":
             return {
                 "success": False,

--- a/backend/core/ai_protocol/role_config.py
+++ b/backend/core/ai_protocol/role_config.py
@@ -319,7 +319,8 @@ def _build_candidate_from_account(
     return ResolvedModel(
         provider=decl,
         model=metadata,
-        credential=account.api_key,
+        # 去除首尾空白或换行
+        credential=(account.api_key or "").strip(),
         endpoint=endpoint,
         protocol=family,
         account_id=str(account.id) if getattr(account, "id", None) else None,

--- a/backend/core/setup_service.py
+++ b/backend/core/setup_service.py
@@ -246,6 +246,8 @@ class SetupService:
         与旧版一致以兼容现有前端：{success, message, models, provider,
         default_model, context_window_k}。
         """
+        # 去除首尾空白或换行
+        api_key = api_key.strip()
         if not api_key:
             return {"success": False, "message": "API Key 不能为空"}
 
@@ -304,7 +306,13 @@ class SetupService:
 
             if isinstance(e, AIError):
                 if e.category.value == "auth_invalid":
-                    return {"success": False, "message": "API Key 无效"}
+                    return {
+                        "success": False,
+                        "message": (
+                            "API 鉴权失败：上游拒绝了当前凭证，请检查 API Key 是否过期、"
+                            "令牌权限/渠道是否可用，以及 API Base URL 是否正确"
+                        ),
+                    }
                 if e.category.value == "network":
                     return {
                         "success": False,

--- a/tests/test_ai_account_catalog.py
+++ b/tests/test_ai_account_catalog.py
@@ -126,3 +126,93 @@ def test_provider_catalog_serializes_model_capabilities():
     assert claude["capabilities"]["vision"] is True
     assert gemini["capabilities"]["top_k"] is True
     assert gemini["context_window_tokens"] == 1_048_576
+
+
+@pytest.mark.asyncio
+async def test_account_save_strips_surrounding_whitespace_from_api_key(monkeypatch):
+    """带空白字符的 API Key 应在落库前规范化（Issue #502）。"""
+    from backend.api.v1 import config as config_module
+    from backend.core.ai_protocol import account_store
+
+    saved: dict[str, str] = {}
+
+    async def fake_get_account(account_id):
+        return None
+
+    async def fake_save_account(account):
+        saved["api_key"] = account.api_key
+        return account
+
+    monkeypatch.setattr(account_store, "get_account", fake_get_account)
+    monkeypatch.setattr(account_store, "save_account", fake_save_account)
+    monkeypatch.setattr(
+        config_module, "validate_provider_base_url", lambda *a, **k: (True, "")
+    )
+
+    response = await config_module.save_ai_account(
+        AccountSaveRequest(
+            name="Public Relay",
+            provider_id="custom",
+            api_base="https://example.com/v1",
+            api_key="  sk-relay-token\n",
+        ),
+        {"sub": "tester"},
+    )
+    assert response.status_code == 200
+    assert saved["api_key"] == "sk-relay-token"
+
+
+@pytest.mark.asyncio
+async def test_account_save_keeps_existing_key_when_masked(monkeypatch):
+    """api_key 为脱敏占位时应保留库中原值（Issue #502 回归保护）。"""
+    from backend.api.v1 import config as config_module
+    from backend.core.ai_protocol import account_store
+
+    saved: dict[str, str] = {}
+
+    async def fake_get_account(account_id):
+        return ProviderAccount(
+            id=account_id,
+            name="Old Relay",
+            provider_id="custom",
+            api_base="https://example.com/v1",
+            api_key="sk-old-token",
+        )
+
+    async def fake_save_account(account):
+        saved["api_key"] = account.api_key
+        return account
+
+    monkeypatch.setattr(account_store, "get_account", fake_get_account)
+    monkeypatch.setattr(account_store, "save_account", fake_save_account)
+    monkeypatch.setattr(
+        config_module, "validate_provider_base_url", lambda *a, **k: (True, "")
+    )
+
+    response = await config_module.save_ai_account(
+        AccountSaveRequest(
+            id="acc_relay",
+            name="Public Relay",
+            provider_id="custom",
+            api_base="https://example.com/v1",
+            api_key="****",
+        ),
+        {"sub": "tester"},
+    )
+    assert response.status_code == 200
+    assert saved["api_key"] == "sk-old-token"
+
+
+def test_build_candidate_from_account_strips_stored_api_key_whitespace():
+    """存量账号中带首尾空白的 key 应在构造 candidate 时规范化（Issue #502）。"""
+    account = ProviderAccount(
+        id="acc_legacy",
+        name="Legacy Whitespace",
+        provider_id="openai",
+        protocol=ProtocolFamily.OPENAI_COMPATIBLE.value,
+        api_key="  sk-legacy-token\n",
+        default_model="gpt-5.6-sol",
+    )
+    candidate = _build_candidate_from_account(account, "gpt-5.6-sol")
+    assert candidate is not None
+    assert candidate.credential == "sk-legacy-token"

--- a/tests/test_ai_account_probe.py
+++ b/tests/test_ai_account_probe.py
@@ -1,0 +1,81 @@
+"""AI 账号连接探测回归测试。"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ai_protocol import account_probe
+from backend.core.ai_protocol.errors import AIError
+from backend.core.ai_protocol.models import AIErrorCategory
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self.api_key = None
+
+    async def list_models(self, client, endpoint, api_key):
+        self.api_key = api_key
+        return [SimpleNamespace(model_id="test-model", context_window_tokens=None)]
+
+
+@pytest.mark.asyncio
+async def test_probe_account_strips_api_key_before_request(monkeypatch):
+    adapter = _RecordingAdapter()
+
+    monkeypatch.setattr(
+        account_probe,
+        "validate_provider_base_url",
+        lambda *args, **kwargs: (True, ""),
+    )
+    monkeypatch.setattr(account_probe, "get_adapter", lambda family: adapter)
+    monkeypatch.setattr(
+        account_probe,
+        "resolve_account_endpoint",
+        lambda *args, **kwargs: SimpleNamespace(),
+    )
+
+    result = await account_probe.probe_account(
+        provider_id="custom",
+        protocol="openai-compatible",
+        api_base="https://example.com/v1",
+        api_key="  sk-test-token\n",
+    )
+
+    assert result["success"] is True
+    assert adapter.api_key == "sk-test-token"
+
+
+class _AuthFailingAdapter:
+    async def list_models(self, client, endpoint, api_key):
+        raise AIError(AIErrorCategory.AUTH_INVALID, "upstream secret diagnostic")
+
+
+@pytest.mark.asyncio
+async def test_probe_account_auth_error_is_actionable_without_upstream_leak(monkeypatch):
+    monkeypatch.setattr(
+        account_probe,
+        "validate_provider_base_url",
+        lambda *args, **kwargs: (True, ""),
+    )
+    monkeypatch.setattr(
+        account_probe,
+        "get_adapter",
+        lambda family: _AuthFailingAdapter(),
+    )
+    monkeypatch.setattr(
+        account_probe,
+        "resolve_account_endpoint",
+        lambda *args, **kwargs: SimpleNamespace(),
+    )
+
+    result = await account_probe.probe_account(
+        provider_id="custom",
+        protocol="openai-compatible",
+        api_base="https://example.com/v1",
+        api_key="sk-test-token",
+    )
+
+    assert result["success"] is False
+    assert "API 鉴权失败" in result["message"]
+    assert "令牌权限/渠道" in result["message"]
+    assert "upstream secret diagnostic" not in result["message"]

--- a/tests/test_setup_service_ai_key_normalization.py
+++ b/tests/test_setup_service_ai_key_normalization.py
@@ -1,0 +1,59 @@
+"""Setup Wizard test_ai_api 的 API Key 规范化回归测试（Issue #502）。"""
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ai_protocol.errors import AIError
+from backend.core.ai_protocol.models import AIErrorCategory
+from backend.core.setup_service import setup_service
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self.api_key = None
+
+    async def list_models(self, client, endpoint, api_key):
+        self.api_key = api_key
+        return [SimpleNamespace(model_id="test-model", context_window_tokens=None)]
+
+
+class _AuthFailingAdapter:
+    async def list_models(self, client, endpoint, api_key):
+        raise AIError(AIErrorCategory.AUTH_INVALID, "upstream secret diagnostic")
+
+
+@pytest.mark.asyncio
+async def test_setup_test_ai_api_strips_api_key_before_request(monkeypatch):
+    adapter = _RecordingAdapter()
+    monkeypatch.setattr(
+        "backend.core.ai_protocol.registry.get_adapter", lambda family: adapter
+    )
+    monkeypatch.setattr(
+        "backend.core.ai_protocol.registry.resolve_endpoint",
+        lambda decl, api_base="": SimpleNamespace(),
+    )
+    result = await setup_service.test_ai_api(
+        "  sk-setup-token\n", "https://example.com/v1", model="test-model"
+    )
+    assert result["success"] is True
+    assert adapter.api_key == "sk-setup-token"
+
+
+@pytest.mark.asyncio
+async def test_setup_test_ai_api_auth_error_is_actionable_without_upstream_leak(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "backend.core.ai_protocol.registry.get_adapter",
+        lambda family: _AuthFailingAdapter(),
+    )
+    monkeypatch.setattr(
+        "backend.core.ai_protocol.registry.resolve_endpoint",
+        lambda decl, api_base="": SimpleNamespace(),
+    )
+    result = await setup_service.test_ai_api(
+        "sk-setup-token", "https://example.com/v1"
+    )
+    assert result["success"] is False
+    assert "API 鉴权失败" in result["message"]
+    assert "upstream secret diagnostic" not in result["message"]


### PR DESCRIPTION
## What changed

- Normalize copied API keys with `strip()` before account model discovery/authentication.
- Replace the misleading fixed `API Key 无效` response with an actionable authentication failure message that points users to token expiry, token permissions/channels, and API Base URL configuration.
- Add regression coverage for whitespace-trimmed keys and safe/non-leaking auth error messages.

## Why

Fixes #502. Third-party OpenAI-compatible/public relay users may copy API keys with trailing whitespace or a newline. The previous probe path sent those bytes unchanged, which can produce an upstream 401 even when the visible key is correct. Additionally, every upstream auth failure was collapsed into `API Key 无效`, hiding other common causes such as an expired token, unavailable channel/permission, or an incorrect compatible API endpoint.

## Root cause

`backend/core/ai_protocol/account_probe.py` passed the stored key directly to the protocol adapter and mapped every `auth_invalid` error to the same fixed text.

## Validation

Added `tests/test_ai_account_probe.py` covering:

- whitespace/newline removal before `list_models()`;
- actionable auth failure messaging;
- no propagation of upstream diagnostic text.

The current execution environment could not resolve `github.com` for a local clone, so the pytest suite was not executed locally in this session. CI should validate the new tests.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本 PR 修复了模型发现过程中的 API Key 规范化问题，优化了配置及设置服务的 Key 处理逻辑，并补充了完整的单元测试以保障功能稳定性。

**主要改动**
*   **Bug 修复**：修改 `backend/core/setup_service.py`、`backend/api/v1/config.py` 等文件，增加去除 API Key 首尾空白的逻辑，并优化了认证错误提示信息。
*   **测试增强**：新增 `tests/test_setup_service_ai_key_normalization.py` 与 `tests/test_ai_account_catalog.py`，补充了大量测试用例，覆盖账号目录与 Key 规范化场景。

**影响范围**
主要影响后端 API 配置、AI 协议角色配置及设置服务，提升了 API Key 处理的健壮性和模型发现的准确性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/api/v1/config.py"]
    N2["backend/core/ai_protocol/role_config.py"]
    N3["backend/core/setup_service.py"]
    N4["tests/test_ai_account_catalog.py"]
    N5["tests/test_setup_service_ai_key_normalization.py"]
    N6["backend/core/ai_protocol/account_probe.py"]
    N7["tests/test_ai_account_probe.py"]
    N1 --> N2
    N1 --> N3
    N4 --> N1
    N4 --> N2
    N7 --> N6
    N5 --> N3
```

<!-- sakura-ai-depgraph-end -->