### PR TITLE
test(ci): stop pinning GitHub Actions versions in workflow contract tests

### DIFF
--- a/tests/test_docker_channel_workflows.py
+++ b/tests/test_docker_channel_workflows.py
@@ -35,7 +35,7 @@ def test_reusable_publish_fails_closed_and_sets_build_identity():
     assert "platforms: linux/amd64,linux/arm64" in text
     # crane is required in the build job before channel tags are materialized;
     # the sync job has its own installation as well.
-    assert text.count("uses: imjasonh/setup-crane@v0.4") >= 2
+    assert text.count("uses: imjasonh/setup-crane@") >= 2
     assert 'existing_error=$(mktemp)' in text
     assert 'unable to verify immutable tag; refusing publication' in text
     assert 'existing immutable tag returned an invalid digest' in text

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -113,7 +113,7 @@ def test_updater_workflow_is_reusable_native_matrix_with_two_gates():
     assert "remained running" in helper
 
     upload = steps[upload_index]
-    assert upload["uses"] == "actions/upload-artifact@v4"
+    assert upload["uses"].startswith("actions/upload-artifact@")
     assert upload["with"]["retention-days"] == 1
     assert "matrix.arch" in upload["with"]["name"]
     assert "github.run_id" in upload["with"]["name"]
@@ -133,7 +133,7 @@ def test_publish_is_single_writer_and_uploads_only_two_binaries_and_checksum():
     download_steps = [
         step
         for step in publish["steps"]
-        if step.get("uses") == "actions/download-artifact@v5"
+        if step.get("uses", "").startswith("actions/download-artifact@")
     ]
     assert len(download_steps) == 2
     assert {step["with"]["path"] for step in download_steps} == {
@@ -260,7 +260,7 @@ def test_publish_update_manifest_waits_for_release_assets_and_stable_image():
         for step in manifest["steps"]
         if step.get("uses", "").startswith("actions/checkout@")
     )
-    assert checkout["uses"] == "actions/checkout@v7"
+    assert checkout["uses"].startswith("actions/checkout@")
     assert checkout["with"]["ref"] == (
         "refs/tags/v${{ needs.generate-release.outputs.version }}"
     )
@@ -324,8 +324,8 @@ def test_ci_keeps_main_job_and_adds_independent_updater_quality():
     setup_python = next(
         step for step in steps if step.get("uses", "").startswith("actions/setup-python@")
     )
-    assert checkout["uses"] == "actions/checkout@v7"
-    assert setup_python["uses"] == "actions/setup-python@v7"
+    assert checkout["uses"].startswith("actions/checkout@")
+    assert setup_python["uses"].startswith("actions/setup-python@")
     assert setup_python["with"]["python-version"] == "3.12"
 
     run_text = _job_run_text(updater)


### PR DESCRIPTION
## 根因

develop 连续 8 次 CI 失败（起点 a4c38ba1）：Dependabot 的 actions group bump 升级了 workflow 中的 action 版本，而发布工作流契约测试硬编码断言了旧版本：

| 断言 | 旧版本 | Dependabot 已升到 |
|---|---|---|
| `setup-crane` 计数 | v0.4 | v0.7 |
| `upload-artifact` | v4 | v7 |
| `download-artifact` | v5 | v8 |

## 修复

将 6 处精确版本断言改为前缀匹配（同文件既有 `startswith("actions/checkout@")` 先例写法）：

- tests/test_docker_channel_workflows.py：`setup-crane` 1 处
- tests/test_release_workflows.py：`upload-artifact` / `download-artifact` / `checkout` / `setup-python` 5 处（含 3 处当前已失败 + 2 处下次 bump 必挂的同类隐患）

这些测试守护的是结构不变量（crane 在 build 与 sync job 各安装一次、artifact 上传参数、下载路径），action 版本号由 Dependabot 管理，不应作为断言值。

## 验证

- `python -m pytest tests/test_release_workflows.py tests/test_docker_channel_workflows.py -q`：10 passed
- `python -m pytest -q`：2113 passed, 10 skipped
- `run_ruff.py --check`（两个文件）：All checks passed

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本次 PR 优化了 CI 工作流合约测试，移除了对 GitHub Actions 组件版本的固定锁定。

**主要改动列表**
*   **解除版本锁定**：修改 `tests/test_docker_channel_workflows.py` 和 `tests/test_release_workflows.py`。
*   **测试逻辑调整**：更新测试断言，使其不再校验 Actions 的具体版本号，从而允许版本动态更新。

**影响范围**
*   仅影响测试代码，不涉及生产逻辑。
*   有助于减少因 GitHub Actions 官方版本更新导致的测试失败，降低维护成本。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_docker_channel_workflows.py"]
    N2["tests/test_release_workflows.py"]
```

<!-- sakura-ai-depgraph-end -->